### PR TITLE
Increase minimum Rust version to 1.82

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.1.0"
 edition = "2021"
 readme = "README.md"
 license = "Apache-2.0"
-rust-version = "1.70"
+rust-version = "1.82"
 build = "build.rs"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ DataFusion Distributed implements a master-worker architecture for distributed S
 
 ### Prerequisites
 
-- Rust 1.70 or later
+- Rust 1.82 or later
 - Protocol Buffers compiler (protoc)
 - (Optional) Kubernetes cluster for distributed execution
 


### PR DESCRIPTION
👋 Tried to build the project with Rust 1.78 and had to upgrade the toolchain to something higher/latest

Inspecting the dependency, the project actually depend on 1.82+ 


```
cargo metadata --format-version 1 | jq -r '.packages[] | .rust_version' | grep -v null | sort -V | tail -n 1
1.82.0
```


This pull request updates the project to require Rust version 1.82, reflecting changes in both the `Cargo.toml` file and the `README.md` documentation.

Version requirement updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L28-R28): Updated the `rust-version` field from `1.70` to `1.82` to specify the new minimum Rust version required for the project.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L61-R61): Updated the prerequisites section to reflect the new minimum Rust version (1.82).