### PR TITLE
Fix compilation error in explain.rs

### DIFF
--- a/src/explain.rs
+++ b/src/explain.rs
@@ -162,7 +162,7 @@ impl ExecutionPlan for DistributedExplainExec {
 
         let batch =
             RecordBatch::try_new(schema.clone(), vec![Arc::new(plan_types), Arc::new(plans)])
-                .map_err(|e| datafusion::error::DataFusionError::ArrowError(e, None))?;
+                .map_err(|e| datafusion::error::DataFusionError::ArrowError(Box::new(e), None))?;
 
         // Use MemoryStream which is designed for DataFusion execution plans
         let stream = MemoryStream::try_new(vec![batch], schema, None)?;


### PR DESCRIPTION
It looks like after https://github.com/datafusion-contrib/datafusion-distributed/pull/31 the project no longer compiles with `cargo build`. This should fix it