### PR TITLE
Fix compile and clippy warnings

### DIFF
--- a/src/planning.rs
+++ b/src/planning.rs
@@ -460,7 +460,7 @@ pub async fn distribute_stages(
 
         // all stages to workers
         let (task_datas, final_addrs) =
-            assign_to_workers(query_id, &stages, workers.values().collect(), codec)?;
+            assign_to_workers(query_id, stages, workers.values().collect(), codec)?;
 
         // we retry this a few times to ensure that the workers are ready
         // and can accept the stages

--- a/src/query_planner.rs
+++ b/src/query_planner.rs
@@ -10,7 +10,6 @@ use datafusion::{
 
 use datafusion_proto::physical_plan::{DefaultPhysicalExtensionCodec, PhysicalExtensionCodec};
 use datafusion_substrait::{logical_plan::consumer::from_substrait_plan, substrait::proto::Plan};
-use insta::assert_snapshot;
 use tokio_stream::StreamExt;
 
 use crate::{
@@ -288,10 +287,12 @@ impl QueryPlanner {
     }
 }
 
-pub mod tests {
+#[cfg(test)]
+mod tests {
     use super::*;
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion::physical_plan::displayable;
+    use insta::assert_snapshot;
     use std::io::BufReader;
     use std::{fs::File, path::Path};
 

--- a/src/worker_service.rs
+++ b/src/worker_service.rs
@@ -99,6 +99,7 @@ struct DDWorkerHandler {
     done: Arc<Mutex<bool>>,
 
     /// Optional customizer for our context and proto serde
+    #[allow(dead_code)]
     pub customizer: Option<Arc<dyn Customizer>>,
 
     codec: Arc<dyn PhysicalExtensionCodec>,
@@ -165,8 +166,7 @@ impl DDWorkerHandler {
             customizer
                 .clone()
                 .map(|c| c as Arc<dyn PhysicalExtensionCodec>)
-                .or(Some(Arc::new(DefaultPhysicalExtensionCodec {})))
-                .unwrap(),
+                .unwrap_or(Arc::new(DefaultPhysicalExtensionCodec {})),
         ));
 
         Self {
@@ -502,6 +502,7 @@ impl DDWorkerHandler {
 
         Ok(Box::pin(out_stream))
     }
+    #[allow(clippy::result_large_err)]
     fn do_action_get_host(&self) -> Result<Response<crate::flight::DoActionStream>, Status> {
         let addr = self.addr.clone();
         let name = self.name.clone();


### PR DESCRIPTION
To avoid `compile` and `clippy` warnings, I need to changes these;

1. Remove unnecessary reference `&` from `stages`
2. Add `#[cfg(test)]` to import test-only stuffs
3. Add `#[allow(dead_code)]` for `customizer`
4. Make `Status`  stack `Box<Status.` heap.
5. Add ` #[allow(clippy::result_large_err)]` where we do not want t(or cannot) o make `Status` `Box<Status>`