### PR TITLE
util: ensure wait_for can only be used in a non-async runtime

### DIFF
--- a/src/proxy_service.rs
+++ b/src/proxy_service.rs
@@ -121,8 +121,9 @@ impl DDProxyHandler {
         stage_id: u64,
         addrs: Addrs,
     ) -> Result<Response<crate::flight::DoGetStream>, Status> {
-        let mut ctx =
-            get_ctx().map_err(|e| Status::internal(format!("Could not create context {e:?}")))?;
+        let mut ctx = get_ctx()
+            .await
+            .map_err(|e| Status::internal(format!("Could not create context {e:?}")))?;
 
         add_ctx_extentions(&mut ctx, &self.host, &query_id, stage_id, addrs, vec![])
             .map_err(|e| Status::internal(format!("Could not add context extensions {e:?}")))?;

--- a/src/query_planner.rs
+++ b/src/query_planner.rs
@@ -91,7 +91,9 @@ impl QueryPlanner {
     /// distributed plan, and distributed stages, but it does not yet contain
     /// worker addresses or tasks, as they are filled in later by `distribute_plan()`.
     pub async fn prepare(&self, sql: &str) -> Result<QueryPlan> {
-        let mut ctx = get_ctx().map_err(|e| anyhow!("Could not create context: {e}"))?;
+        let mut ctx = get_ctx()
+            .await
+            .map_err(|e| anyhow!("Could not create context: {e}"))?;
         if let Some(customizer) = &self.customizer {
             customizer
                 .customize(&mut ctx)
@@ -119,7 +121,9 @@ impl QueryPlanner {
     /// distributed plan, and distributed stages, but it does not yet contain
     /// worker addresses or tasks, as they are filled in later by `distribute_plan()`.
     pub async fn prepare_substrait(&self, substrait_plan: Plan) -> Result<QueryPlan> {
-        let mut ctx = get_ctx().map_err(|e| anyhow!("Could not create context: {e}"))?;
+        let mut ctx = get_ctx()
+            .await
+            .map_err(|e| anyhow!("Could not create context: {e}"))?;
         if let Some(customizer) = &self.customizer {
             customizer
                 .customize(&mut ctx)

--- a/src/worker_service.rs
+++ b/src/worker_service.rs
@@ -261,7 +261,7 @@ impl DDWorkerHandler {
         stage_addrs: Addrs,
         partition_group: Vec<u64>,
     ) -> Result<SessionContext> {
-        let mut ctx = get_ctx()?;
+        let mut ctx = get_ctx().await?;
         let host = Host {
             addr: self.addr.clone(),
             name: self.name.clone(),


### PR DESCRIPTION
Previously, `wait_for` would deadlock when used in an async runtime (ie. any async function calls `wait_for` directly or indirectly). Now, `wait_for` returns an error if called in an async runtime. There's no reason to call it in an async runtime / function because you can simply await the future. This change updates a few places where `wait_for` is called to be async functions and just wait on the future.

Why did the old `Spawner` deadlock? `Handle::current().block_on(f)` and the `std::sync::mpsc::channel` would both block an executor thread in tokio (this is a very bad practice generally). If there's no executer threads available, you can't run anything. Now, the closure just does `f.await` instead of `block_on`, which does not block an executor. The channel is now a `tokio::sync::mpsc::channel` as well with a buffer size of 1, so the async send will not block (I think a buffered std channel would have worked, but it's better to use tokio implementations generally). The receiver of the channel is in a sync runtime, so it does a blocking receive.

Testing
- unit tests now pass
- added a unit test for `wait_for` returning an error in an async runtime
- test for nested `wait_for` calls which now return an error

Closes https://github.com/datafusion-contrib/datafusion-distributed/issues/63