### PR TITLE
Wire-up distributed execution with tpch benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,7 +1137,10 @@ dependencies = [
 name = "datafusion-distributed-benchmarks"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "datafusion",
+ "datafusion-distributed",
+ "datafusion-proto",
  "env_logger",
  "log",
  "parquet",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -6,6 +6,7 @@ default-run = "dfbench"
 
 [dependencies]
 datafusion = { workspace = true }
+datafusion-distributed = { path = "..", features = ["integration"] }
 tokio = { version = "1.46.1", features = ["full"] }
 parquet = { version = "55.2.0" }
 structopt = { version = "0.3.26" }
@@ -13,7 +14,14 @@ log = "0.4.27"
 serde = "1.0.219"
 serde_json = "1.0.141"
 env_logger = "0.11.8"
+async-trait = "0.1.88"
+datafusion-proto = { version = "49.0.0", optional = true }
 
 [[bin]]
 name = "dfbench"
 path = "src/bin/dfbench.rs"
+
+[features]
+ci = [
+    "datafusion-proto"
+]


### PR DESCRIPTION
This builds on top of https://github.com/datafusion-contrib/datafusion-distributed/pull/73 adding distribution capabilities to the TPCH benchmarks, spawning just a single host and injecting all the appropriate things in the SessionContext so that TPCH queries run distributed.