### PR TITLE
fix bug in graphviz for determining output partitions

### DIFF
--- a/src/execution_plans/stage.rs
+++ b/src/execution_plans/stage.rs
@@ -570,26 +570,7 @@ pub fn display_plan(
         if let Some(parent) = maybe_parent {
             let output_partitions = plan.output_partitioning().partition_count();
 
-            let partitions = if !distributed {
-                #[deny(clippy::if_same_then_else)]
-                output_partitions
-            } else if plan
-                .as_any()
-                .downcast_ref::<ArrowFlightReadExec>()
-                .is_some()
-                || plan
-                    .as_any()
-                    .downcast_ref::<PartitionIsolatorExec>()
-                    .is_some()
-            {
-                output_partitions
-            } else if let Some(child) = plan.children().first() {
-                child.output_partitioning().partition_count()
-            } else {
-                output_partitions
-            };
-
-            for i in 0..partitions {
+            for i in 0..output_partitions {
                 let mut style = "";
                 if plan
                     .as_any()


### PR DESCRIPTION
Prior to this PR, Hash joins with a Coalesce Partition node were rendering incorrectly
<img width="616" height="375" alt="image" src="https://github.com/user-attachments/assets/24a91700-9984-46d8-ac91-66f1ad7e4769" />

Now it renders correctly like:

<img width="627" height="382" alt="image" src="https://github.com/user-attachments/assets/7d597547-4e77-4190-aa91-c395d003e664" />
