### PR TITLE
move chrono out of optional deps so project can compile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+chrono = { version = "0.4.42" }
 datafusion = { workspace = true }
 datafusion-proto = { workspace = true }
 arrow-flight = "55.2.0"
@@ -38,7 +39,6 @@ parquet = { version = "55.2.0", optional = true }
 arrow = { version = "55.2.0", optional = true }
 tokio-stream = { version = "0.1.17", optional = true }
 hyper-util = { version = "0.1.16", optional = true }
-chrono = { version = "0.4.42", optional = true }
 
 [features]
 integration = [
@@ -49,7 +49,6 @@ integration = [
     "arrow",
     "tokio-stream",
     "hyper-util",
-    "chrono"
 ]
 
 tpch = ["integration"]


### PR DESCRIPTION
Because `lib.rs` includes the module metrics, the project did not compile without the integration test feature.   Moving `chrono` to a regular dependency fixes the problem.

@jayshrivastava, or did I miss something?