### PR TITLE
Do not require default datafusion features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["benchmarks"]
 
 [workspace.dependencies]
-datafusion = { version = "49.0.0" }
+datafusion = { version = "49.0.0", default-features = false }
 datafusion-proto = { version = "49.0.0" }
 
 [package]


### PR DESCRIPTION
We do not use any of the default `datafusion` features, so do not require them. This has two benefits:
- faster compile times, as we are compiling less things
- we do not force consumers of this library to bring in all default datafusion features, as they might not want to