### PR TITLE
remove feature flags around chrono::DateTime

### DIFF
--- a/src/metrics/proto.rs
+++ b/src/metrics/proto.rs
@@ -383,10 +383,7 @@ pub fn metric_proto_to_df(metric: MetricProto) -> Result<Arc<Metric>, DataFusion
         Some(MetricValueProto::StartTimestamp(start_ts)) => match start_ts.value {
             Some(value) => {
                 let timestamp = Timestamp::new();
-                #[cfg(feature = "integration")]
                 timestamp.set(DateTime::from_timestamp_nanos(value));
-                #[cfg(not(feature = "integration"))]
-                { /* DateTime not available without integration feature */ }
                 Ok(Arc::new(Metric::new_with_labels(
                     MetricValue::StartTimestamp(timestamp),
                     partition,
@@ -402,10 +399,7 @@ pub fn metric_proto_to_df(metric: MetricProto) -> Result<Arc<Metric>, DataFusion
         Some(MetricValueProto::EndTimestamp(end_ts)) => match end_ts.value {
             Some(value) => {
                 let timestamp = Timestamp::new();
-                #[cfg(feature = "integration")]
                 timestamp.set(DateTime::from_timestamp_nanos(value));
-                #[cfg(not(feature = "integration"))]
-                { /* DateTime not available without integration feature */ }
                 Ok(Arc::new(Metric::new_with_labels(
                     MetricValue::EndTimestamp(timestamp),
                     partition,


### PR DESCRIPTION
It was moved into the main deps in https://github.com/datafusion-contrib/datafusion-distributed/pull/143. This clears up some warnings about unused imports and variables