### PR TITLE
fix: Incorrect weather parquet path in examples

### DIFF
--- a/examples/localhost_run.rs
+++ b/examples/localhost_run.rs
@@ -53,12 +53,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     )
     .await?;
 
-    ctx.register_parquet(
-        "weather",
-        "testdata/weather",
-        ParquetReadOptions::default(),
-    )
-    .await?;
+    ctx.register_parquet("weather", "testdata/weather", ParquetReadOptions::default())
+        .await?;
 
     let df = ctx.sql(&args.query).await?;
     if args.explain {


### PR DESCRIPTION
<img width="1849" height="197" alt="image" src="https://github.com/user-attachments/assets/1b86da67-fcda-459e-b921-c42448252041" />

