### PR TITLE
Evolve `ChannelResolver` trait for requiring a `FlightServiceClient` instead of a `tonic::BoxSyncCloneChannel`

### DIFF
--- a/examples/in_memory_cluster.rs
+++ b/examples/in_memory_cluster.rs
@@ -1,4 +1,5 @@
 use arrow::util::pretty::pretty_format_batches;
+use arrow_flight::flight_service_client::FlightServiceClient;
 use arrow_flight::flight_service_server::FlightServiceServer;
 use async_trait::async_trait;
 use datafusion::common::DataFusionError;
@@ -75,7 +76,7 @@ const DUMMY_URL: &str = "http://localhost:50051";
 /// tokio duplex rather than a TCP connection.
 #[derive(Clone)]
 struct InMemoryChannelResolver {
-    channel: BoxCloneSyncChannel,
+    channel: FlightServiceClient<BoxCloneSyncChannel>,
 }
 
 impl InMemoryChannelResolver {
@@ -93,7 +94,7 @@ impl InMemoryChannelResolver {
             }));
 
         let this = Self {
-            channel: BoxCloneSyncChannel::new(channel),
+            channel: FlightServiceClient::new(BoxCloneSyncChannel::new(channel)),
         };
         let this_clone = this.clone();
 
@@ -127,10 +128,10 @@ impl ChannelResolver for InMemoryChannelResolver {
         Ok(vec![url::Url::parse(DUMMY_URL).unwrap()])
     }
 
-    async fn get_channel_for_url(
+    async fn get_flight_client_for_url(
         &self,
         _: &url::Url,
-    ) -> Result<BoxCloneSyncChannel, DataFusionError> {
+    ) -> Result<FlightServiceClient<BoxCloneSyncChannel>, DataFusionError> {
         Ok(self.channel.clone())
     }
 }

--- a/examples/localhost_run.rs
+++ b/examples/localhost_run.rs
@@ -1,4 +1,5 @@
 use arrow::util::pretty::pretty_format_batches;
+use arrow_flight::flight_service_client::FlightServiceClient;
 use async_trait::async_trait;
 use dashmap::{DashMap, Entry};
 use datafusion::common::DataFusionError;
@@ -83,7 +84,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 #[derive(Clone)]
 struct LocalhostChannelResolver {
     ports: Vec<u16>,
-    cached: DashMap<Url, BoxCloneSyncChannel>,
+    cached: DashMap<Url, FlightServiceClient<BoxCloneSyncChannel>>,
 }
 
 #[async_trait]
@@ -96,14 +97,17 @@ impl ChannelResolver for LocalhostChannelResolver {
             .collect())
     }
 
-    async fn get_channel_for_url(&self, url: &Url) -> Result<BoxCloneSyncChannel, DataFusionError> {
+    async fn get_flight_client_for_url(
+        &self,
+        url: &Url,
+    ) -> Result<FlightServiceClient<BoxCloneSyncChannel>, DataFusionError> {
         match self.cached.entry(url.clone()) {
             Entry::Occupied(v) => Ok(v.get().clone()),
             Entry::Vacant(v) => {
                 let channel = Channel::from_shared(url.to_string())
                     .unwrap()
                     .connect_lazy();
-                let channel = BoxCloneSyncChannel::new(channel);
+                let channel = FlightServiceClient::new(BoxCloneSyncChannel::new(channel));
                 v.insert(channel.clone());
                 Ok(channel)
             }

--- a/src/distributed_ext.rs
+++ b/src/distributed_ext.rs
@@ -180,6 +180,7 @@ pub trait DistributedExt: Sized {
     /// Example:
     ///
     /// ```
+    /// # use arrow_flight::flight_service_client::FlightServiceClient;
     /// # use async_trait::async_trait;
     /// # use datafusion::common::DataFusionError;
     /// # use datafusion::execution::{SessionState, SessionStateBuilder};
@@ -195,7 +196,7 @@ pub trait DistributedExt: Sized {
     ///         todo!()
     ///     }
     ///
-    ///     async fn get_channel_for_url(&self, url: &Url) -> Result<BoxCloneSyncChannel, DataFusionError> {
+    ///     async fn get_flight_client_for_url(&self, url: &Url) -> Result<FlightServiceClient<BoxCloneSyncChannel>, DataFusionError> {
     ///         todo!()
     ///     }
     /// }

--- a/src/execution_plans/network_coalesce.rs
+++ b/src/execution_plans/network_coalesce.rs
@@ -12,7 +12,6 @@ use crate::protobuf::{map_flight_to_datafusion_error, map_status_to_datafusion_e
 use arrow_flight::Ticket;
 use arrow_flight::decode::FlightRecordBatchStream;
 use arrow_flight::error::FlightError;
-use arrow_flight::flight_service_client::FlightServiceClient;
 use dashmap::DashMap;
 use datafusion::common::{exec_err, internal_datafusion_err, internal_err, plan_err};
 use datafusion::error::DataFusionError;
@@ -285,8 +284,8 @@ impl ExecutionPlan for NetworkCoalesceExec {
 
         let metrics_collection_capture = self_ready.metrics_collection.clone();
         let stream = async move {
-            let channel = channel_resolver.get_channel_for_url(&url).await?;
-            let stream = FlightServiceClient::new(channel)
+            let mut client = channel_resolver.get_flight_client_for_url(&url).await?;
+            let stream = client
                 .do_get(ticket)
                 .await
                 .map_err(map_status_to_datafusion_error)?

--- a/src/execution_plans/network_shuffle.rs
+++ b/src/execution_plans/network_shuffle.rs
@@ -12,7 +12,6 @@ use crate::protobuf::{map_flight_to_datafusion_error, map_status_to_datafusion_e
 use arrow_flight::Ticket;
 use arrow_flight::decode::FlightRecordBatchStream;
 use arrow_flight::error::FlightError;
-use arrow_flight::flight_service_client::FlightServiceClient;
 use dashmap::DashMap;
 use datafusion::common::{exec_err, internal_datafusion_err, internal_err, plan_err};
 use datafusion::error::DataFusionError;
@@ -337,8 +336,8 @@ impl ExecutionPlan for NetworkShuffleExec {
                     "NetworkShuffleExec: task is unassigned, cannot proceed"
                 ))?;
 
-                let channel = channel_resolver.get_channel_for_url(&url).await?;
-                let stream = FlightServiceClient::new(channel)
+                let mut client = channel_resolver.get_flight_client_for_url(&url).await?;
+                let stream = client
                     .do_get(ticket)
                     .await
                     .map_err(map_status_to_datafusion_error)?

--- a/src/flight_service/do_get.rs
+++ b/src/flight_service/do_get.rs
@@ -10,15 +10,15 @@ use crate::protobuf::{
     AppMetadata, DistributedCodec, FlightAppMetadata, MetricsCollection, StageKey, TaskMetrics,
     datafusion_error_to_tonic_status, stage_from_proto,
 };
-use arrow::array::RecordBatch;
-use arrow::datatypes::SchemaRef;
-use arrow::ipc::writer::{DictionaryTracker, IpcDataGenerator, IpcWriteOptions};
 use arrow_flight::FlightData;
 use arrow_flight::Ticket;
 use arrow_flight::encode::FlightDataEncoderBuilder;
 use arrow_flight::error::FlightError;
 use arrow_flight::flight_service_server::FlightService;
 use bytes::Bytes;
+use datafusion::arrow::array::RecordBatch;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::ipc::writer::{DictionaryTracker, IpcDataGenerator, IpcWriteOptions};
 use datafusion::common::exec_datafusion_err;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;

--- a/src/test_utils/in_memory_channel_resolver.rs
+++ b/src/test_utils/in_memory_channel_resolver.rs
@@ -2,6 +2,7 @@ use crate::{
     ArrowFlightEndpoint, BoxCloneSyncChannel, ChannelResolver, DistributedExt,
     DistributedSessionBuilderContext,
 };
+use arrow_flight::flight_service_client::FlightServiceClient;
 use arrow_flight::flight_service_server::FlightServiceServer;
 use async_trait::async_trait;
 use datafusion::common::DataFusionError;
@@ -15,7 +16,7 @@ const DUMMY_URL: &str = "http://localhost:50051";
 /// tokio duplex rather than a TCP connection.
 #[derive(Clone)]
 pub struct InMemoryChannelResolver {
-    channel: BoxCloneSyncChannel,
+    channel: FlightServiceClient<BoxCloneSyncChannel>,
 }
 
 impl Default for InMemoryChannelResolver {
@@ -39,7 +40,7 @@ impl InMemoryChannelResolver {
             }));
 
         let this = Self {
-            channel: BoxCloneSyncChannel::new(channel),
+            channel: FlightServiceClient::new(BoxCloneSyncChannel::new(channel)),
         };
         let this_clone = this.clone();
 
@@ -73,10 +74,10 @@ impl ChannelResolver for InMemoryChannelResolver {
         Ok(vec![url::Url::parse(DUMMY_URL).unwrap()])
     }
 
-    async fn get_channel_for_url(
+    async fn get_flight_client_for_url(
         &self,
         _: &url::Url,
-    ) -> Result<BoxCloneSyncChannel, DataFusionError> {
+    ) -> Result<FlightServiceClient<BoxCloneSyncChannel>, DataFusionError> {
         Ok(self.channel.clone())
     }
 }


### PR DESCRIPTION
All the relevant configuration parameters are set while building a `FlightServiceClient`:
- the timeouts
- the maximum decoding size
- the gRPC interceptors
- etc...

Previously, we were not allowing users to build their own `FlightServiceClient`, instead, we were requiring a raw tonic channel that leaves no room for configuration.

With this PR, users now provide their own `FlightServiceClient` rather than a raw channel, and therefore, they can now configure pretty much anything a gRPC client allows to configure.