### PR TITLE
Fix in-memory example

### DIFF
--- a/examples/in_memory.md
+++ b/examples/in_memory.md
@@ -13,6 +13,7 @@ This example queries a couple of test parquet we have for integration tests, and
 so pulling the first is necessary.
 
 ```shell
+git intall checkout
 git lfs checkout
 ```
 

--- a/examples/in_memory_cluster.rs
+++ b/examples/in_memory_cluster.rs
@@ -49,12 +49,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     )
     .await?;
 
-    ctx.register_parquet(
-        "weather",
-        "testdata/weather.parquet",
-        ParquetReadOptions::default(),
-    )
-    .await?;
+    ctx.register_parquet("weather", "testdata/weather", ParquetReadOptions::default())
+        .await?;
 
     let df = ctx.sql(&args.query).await?;
     if args.explain {

--- a/examples/localhost.md
+++ b/examples/localhost.md
@@ -10,6 +10,7 @@ This example queries a couple of test parquet we have for integration tests, and
 so pulling the first is necessary.
 
 ```shell
+git lfs install
 git lfs checkout
 ```
 


### PR DESCRIPTION
Since we moved to partitioned parquet files, this broke. This was fixed before in the localhost example in https://github.com/datafusion-contrib/datafusion-distributed/pull/165, but not here.