### PR TITLE
Return input task count in NetworkBoundary

### DIFF
--- a/src/distributed_planner/network_boundary.rs
+++ b/src/distributed_planner/network_boundary.rs
@@ -35,6 +35,9 @@ pub trait NetworkBoundary: ExecutionPlan {
         input_tasks: usize,
     ) -> datafusion::common::Result<Arc<dyn NetworkBoundary>>;
 
+    /// Returns the input tasks assigned to this [NetworkBoundary].
+    fn input_task_count(&self) -> usize;
+
     /// Called when a [Stage] is correctly formed. The [NetworkBoundary] can use this
     /// information to perform any internal transformations necessary for distributed execution.
     ///

--- a/src/execution_plans/network_coalesce.rs
+++ b/src/execution_plans/network_coalesce.rs
@@ -176,6 +176,13 @@ impl NetworkBoundary for NetworkCoalesceExec {
             }
         }))
     }
+
+    fn input_task_count(&self) -> usize {
+        match self {
+            Self::Pending(v) => v.input_tasks,
+            Self::Ready(v) => v.input_stage.tasks.len(),
+        }
+    }
 }
 
 impl DisplayAs for NetworkCoalesceExec {

--- a/src/execution_plans/network_shuffle.rs
+++ b/src/execution_plans/network_shuffle.rs
@@ -203,6 +203,13 @@ impl NetworkBoundary for NetworkShuffleExec {
         }))
     }
 
+    fn input_task_count(&self) -> usize {
+        match self {
+            Self::Pending(v) => v.input_tasks,
+            Self::Ready(v) => v.input_stage.tasks.len(),
+        }
+    }
+
     fn with_input_stage(
         &self,
         input_stage: Stage,


### PR DESCRIPTION
Will playing with the current API, I'm finding it useful to be able to traverse a distributed plan and see, for each `NetworkBoundary`, how many tasks it receives as an input.

The main use case for this right now is for letting people decide how many tasks will be spawned in a network boundary as a function as the input tasks of another network boundary, for example:

```
               ┌────────────────────┐             
               │NetworkCoalesceExec │             
               │  max(10, 5) tasks  │             
               └────────────────────┘             
                          │                       
           ┌──────────────┴────────────┐          
           ▼                           ▼          
┌────────────────────┐      ┌────────────────────┐
│ NetworkShuffleExec │      │NetworkCoalesceExec │
│      10 tasks      │      │      5 tasks       │
└────────────────────┘      └────────────────────┘
```

If I want to be able to do that in the upper network boundary, I need to be able to access how many input tasks the lower network boundaries are spawning