### PR TITLE
Introduce with_distributed_execution 

### DIFF
--- a/examples/in_memory_cluster.rs
+++ b/examples/in_memory_cluster.rs
@@ -7,12 +7,11 @@ use datafusion::physical_plan::displayable;
 use datafusion::prelude::{ParquetReadOptions, SessionContext};
 use datafusion_distributed::{
     ArrowFlightEndpoint, BoxCloneSyncChannel, ChannelResolver, DistributedExt,
-    DistributedPhysicalOptimizerRule, DistributedSessionBuilderContext, create_flight_client,
+    DistributedSessionBuilderContext, create_flight_client,
 };
 use futures::TryStreamExt;
 use hyper_util::rt::TokioIo;
 use std::error::Error;
-use std::sync::Arc;
 use structopt::StructOpt;
 use tonic::transport::{Endpoint, Server};
 
@@ -41,8 +40,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let state = SessionStateBuilder::new()
         .with_default_features()
-        .with_distributed_channel_resolver(InMemoryChannelResolver::new())
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_execution(InMemoryChannelResolver::new())
         .with_distributed_network_coalesce_tasks(args.network_shuffle_tasks)
         .with_distributed_network_shuffle_tasks(args.network_coalesce_tasks)
         .build();
@@ -107,7 +105,7 @@ impl InMemoryChannelResolver {
                 async move {
                     let builder = SessionStateBuilder::new()
                         .with_default_features()
-                        .with_distributed_channel_resolver(this)
+                        .with_distributed_execution(this)
                         .with_runtime_env(ctx.runtime_env.clone());
                     Ok(builder.build())
                 }

--- a/examples/localhost_run.rs
+++ b/examples/localhost_run.rs
@@ -6,12 +6,9 @@ use datafusion::common::DataFusionError;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::physical_plan::displayable;
 use datafusion::prelude::{ParquetReadOptions, SessionContext};
-use datafusion_distributed::{
-    BoxCloneSyncChannel, ChannelResolver, DistributedExt, DistributedPhysicalOptimizerRule,
-};
+use datafusion_distributed::{BoxCloneSyncChannel, ChannelResolver, DistributedExt};
 use futures::TryStreamExt;
 use std::error::Error;
-use std::sync::Arc;
 use structopt::StructOpt;
 use tonic::transport::Channel;
 use url::Url;
@@ -47,8 +44,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let state = SessionStateBuilder::new()
         .with_default_features()
-        .with_distributed_channel_resolver(localhost_resolver)
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_execution(localhost_resolver)
         .with_distributed_network_coalesce_tasks(args.network_coalesce_tasks)
         .with_distributed_network_shuffle_tasks(args.network_shuffle_tasks)
         .build();

--- a/examples/localhost_worker.rs
+++ b/examples/localhost_worker.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         async move {
             Ok(SessionStateBuilder::new()
                 .with_runtime_env(ctx.runtime_env)
-                .with_distributed_channel_resolver(local_host_resolver)
+                .with_distributed_execution(local_host_resolver)
                 .with_default_features()
                 .build())
         }

--- a/src/metrics/task_metrics_collector.rs
+++ b/src/metrics/task_metrics_collector.rs
@@ -128,7 +128,6 @@ mod tests {
     use futures::StreamExt;
 
     use crate::DistributedExt;
-    use crate::DistributedPhysicalOptimizerRule;
     use crate::execution_plans::DistributedExec;
     use crate::metrics::proto::metrics_set_proto_to_df;
     use crate::test_utils::in_memory_channel_resolver::InMemoryChannelResolver;
@@ -152,8 +151,7 @@ mod tests {
         let state = SessionStateBuilder::new()
             .with_default_features()
             .with_config(config)
-            .with_distributed_channel_resolver(InMemoryChannelResolver::new())
-            .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+            .with_distributed_execution(InMemoryChannelResolver::new())
             .with_distributed_network_coalesce_tasks(2)
             .with_distributed_network_shuffle_tasks(2)
             .build();

--- a/src/metrics/task_metrics_rewriter.rs
+++ b/src/metrics/task_metrics_rewriter.rs
@@ -218,7 +218,6 @@ mod tests {
     use uuid::Uuid;
 
     use crate::DistributedExt;
-    use crate::DistributedPhysicalOptimizerRule;
     use crate::metrics::task_metrics_rewriter::MetricsWrapperExec;
     use datafusion::physical_plan::empty::EmptyExec;
     use datafusion::physical_plan::metrics::MetricsSet;
@@ -245,8 +244,7 @@ mod tests {
 
         if distributed {
             builder = builder
-                .with_distributed_channel_resolver(InMemoryChannelResolver::new())
-                .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+                .with_distributed_execution(InMemoryChannelResolver::new())
                 .with_distributed_network_coalesce_tasks(2)
                 .with_distributed_network_shuffle_tasks(2)
         }

--- a/src/test_utils/in_memory_channel_resolver.rs
+++ b/src/test_utils/in_memory_channel_resolver.rs
@@ -49,7 +49,7 @@ impl InMemoryChannelResolver {
                 async move {
                     let builder = SessionStateBuilder::new()
                         .with_default_features()
-                        .with_distributed_channel_resolver(this)
+                        .with_distributed_execution(this)
                         .with_runtime_env(ctx.runtime_env.clone());
                     Ok(builder.build())
                 }

--- a/src/test_utils/localhost.rs
+++ b/src/test_utils/localhost.rs
@@ -53,9 +53,7 @@ where
     let channel_resolver = LocalHostChannelResolver::new(ports.clone());
     let session_builder = session_builder.map(move |builder: SessionStateBuilder| {
         let channel_resolver = channel_resolver.clone();
-        Ok(builder
-            .with_distributed_channel_resolver(channel_resolver)
-            .build())
+        Ok(builder.with_distributed_execution(channel_resolver).build())
     });
     let mut join_set = JoinSet::new();
     for listener in listeners {

--- a/tests/custom_config_extension.rs
+++ b/tests/custom_config_extension.rs
@@ -40,11 +40,14 @@ mod tests {
         }
 
         let (mut ctx, _guard) = start_localhost_context(3, build_state).await;
-        ctx.set_distributed_option_extension(CustomExtension {
-            foo: "foo".to_string(),
-            bar: 1,
-            baz: true,
-        })?;
+        ctx = SessionStateBuilder::from(ctx.state())
+            .with_distributed_option_extension(CustomExtension {
+                foo: "foo".to_string(),
+                bar: 1,
+                baz: true,
+            })?
+            .build()
+            .into();
 
         let mut plan: Arc<dyn ExecutionPlan> = Arc::new(CustomConfigExtensionRequiredExec::new());
 

--- a/tests/tpch_validation_test.rs
+++ b/tests/tpch_validation_test.rs
@@ -7,13 +7,12 @@ mod tests {
     use datafusion_distributed::test_utils::localhost::start_localhost_context;
     use datafusion_distributed::test_utils::tpch;
     use datafusion_distributed::{
-        DistributedExt, DistributedPhysicalOptimizerRule, DistributedSessionBuilderContext,
-        assert_snapshot, display_plan_ascii, explain_analyze,
+        DistributedExt, DistributedSessionBuilderContext, assert_snapshot, display_plan_ascii,
+        explain_analyze,
     };
     use futures::TryStreamExt;
     use std::error::Error;
     use std::fs;
-    use std::sync::Arc;
     use tokio::sync::OnceCell;
 
     const PARTITIONS: usize = 6;
@@ -2200,7 +2199,6 @@ mod tests {
         Ok(SessionStateBuilder::new()
             .with_runtime_env(ctx.runtime_env)
             .with_default_features()
-            .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
             .with_distributed_network_coalesce_tasks(COALESCE_TASKS)
             .with_distributed_network_shuffle_tasks(SHUFFLE_TASKS)
             .build())


### PR DESCRIPTION
This PR refactors the public API people use for enriching a DataFusion `SessionState` with distributed capabilities.

Before, all the `with_distributed_*` and `set_distributed_*` methods were applicable to a lot of DataFusion structs:
- `SessionContext`
- `SessionConfig`
- `SessionState`
- `SessionStateBuilder`

But there's an ergonomic issue with that:

Users have no other option but to use `SessionStateBuilder` for adding configuring distributed capabilities, because that's the only possible place in DataFusion to add a `PhysicalOptimizerRule` implementation (`builder.with_physical_optimizer_rule()`).

This means that no matter how many ergonomic improvements we bring to other structs, people need to configure things through `SessionStateBuilder`.

This PR allows configuring distributed DataFusion with a new `with_distributed_execution()` that will automatically:
- set the `ChannelResolver` implementation
- inject a `DistributedConfig` struct in the `ConfigOptions`
- Add a `DistributedPhysicalOptimizerRule` as an optimization rule

As these are all things that users need to do proactively one way or another, we now just expose it in one method:

```rust
let state = SessionStateBuilder::new()
    .with_distributed_execution(CustomChannelResolver)
    .build();
```

---

This is a preparation PR for a bigger one: 
- https://github.com/datafusion-contrib/datafusion-distributed/pull/216