### PR TITLE
Faster CDK deploys

### DIFF
--- a/benchmarks/cdk/lib/cdk-stack.ts
+++ b/benchmarks/cdk/lib/cdk-stack.ts
@@ -93,8 +93,10 @@ export class CdkStack extends Stack {
       const userData = ec2.UserData.forLinux();
 
       userData.addCommands(
-        // Make binary executable
-        'chmod +x /usr/local/bin/worker',
+        // Install Rust tooling.
+        'yum install gcc',
+        "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh",
+        'cargo install --locked tokio-console',
 
         // Create systemd service
         `cat > /etc/systemd/system/worker.service << 'EOF'


### PR DESCRIPTION
Just some small tweaks to reduce the time it takes for a CDK deploy in the remote benchmarks.

Additionally, this no longer restarts the machines, so no need to reconnect to them in every deploy