### PR TITLE
Fix build without `integration` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: cargo build
+
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ rand = "0.8.5"
 object_store = "0.12.3"
 bytes = "1.10.1"
 pin-project = "1.1.10"
+tokio-stream = "0.1.17"
 
 # integration_tests deps
 insta = { version = "1.43.1", features = ["filters"], optional = true }
@@ -44,7 +45,6 @@ tpchgen = { git = "https://github.com/clflushopt/tpchgen-rs", rev = "e83365a5a91
 tpchgen-arrow = { git = "https://github.com/clflushopt/tpchgen-rs", rev = "e83365a5a9101906eb9f78c5607b83bc59849acf", optional = true }
 parquet = { version = "57.0.0", optional = true }
 arrow = { version = "57.0.0", optional = true }
-tokio-stream = { version = "0.1.17", optional = true }
 hyper-util = { version = "0.1.16", optional = true }
 pretty_assertions = { version = "1.4", optional = true }
 
@@ -55,7 +55,6 @@ integration = [
     "tpchgen-arrow",
     "parquet",
     "arrow",
-    "tokio-stream",
     "hyper-util",
     "pretty_assertions",
 ]

--- a/src/execution_plans/common.rs
+++ b/src/execution_plans/common.rs
@@ -1,4 +1,4 @@
-use arrow::array::RecordBatch;
+use datafusion::arrow::array::RecordBatch;
 use datafusion::common::runtime::SpawnedTask;
 use datafusion::common::{DataFusionError, plan_err};
 use datafusion::execution::memory_pool::{MemoryConsumer, MemoryPool};


### PR DESCRIPTION
This was broken some PRs ago, running `cargo build` on this project fails unless `integration` feature is passed, which should not be required.

This PR:
- fixes the compilation error
- adds a CI check so that this does not happen again