### PR TITLE
Rename all arrow flight endpoint references to "Worker"

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ https://datafusion-contrib.github.io/datafusion-distributed
 There are some runnable examples showcasing how to provide a localhost implementation for Distributed DataFusion in
 [examples/](examples):
 
-- [localhost_worker.rs](examples/localhost_worker.rs): code that spawns an Arrow Flight Endpoint listening for physical
+- [localhost_worker.rs](examples/localhost_worker.rs): code that spawns a Worker listening for physical
   plans over the network.
-- [localhost_run.rs](examples/localhost_run.rs): code that distributes a query across the spawned Arrow Flight Endpoints
-  and executes it.
+- [localhost_run.rs](examples/localhost_run.rs): code that distributes a query across the spawned Workers and executes
+  it.
 
 The integration tests also provide an idea about how to use the library and what can be achieved with it:
 

--- a/benchmarks/src/run.rs
+++ b/benchmarks/src/run.rs
@@ -31,7 +31,7 @@ use datafusion::prelude::*;
 use datafusion_distributed::test_utils::localhost::LocalHostWorkerResolver;
 use datafusion_distributed::test_utils::{clickbench, tpcds, tpch};
 use datafusion_distributed::{
-    ArrowFlightEndpoint, DistributedExt, DistributedPhysicalOptimizerRule, NetworkBoundaryExt,
+    DistributedExt, DistributedPhysicalOptimizerRule, NetworkBoundaryExt, Worker,
 };
 use log::info;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -185,7 +185,7 @@ impl RunOpt {
                 let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
                 Ok::<_, Box<dyn Error + Send + Sync>>(
                     Server::builder()
-                        .add_service(ArrowFlightEndpoint::default().into_flight_server())
+                        .add_service(Worker::default().into_flight_server())
                         .serve_with_incoming(incoming)
                         .await?,
                 )

--- a/docs/source/user-guide/channel-resolver.md
+++ b/docs/source/user-guide/channel-resolver.md
@@ -13,7 +13,7 @@ points:
 
 - You will need to provide your own implementation in two places:
     - in the `SessionContext` that handles your queries.
-    - while instantiating the `ArrowFlightEndpoint` with the `from_session_builder()` constructor.
+    - while instantiating the `Worker` with the `from_session_builder()` constructor.
 - If you decide to build it from scratch, make sure that Arrow Flight clients are reused across
   request rather than always building new ones.
 - You can use this library's `DefaultChannelResolver` as a backbone for your own implementation.
@@ -44,10 +44,10 @@ async fn main() {
         .with_distributed_channel_resolver(channel_resolver.clone())
         .build();
 
-    let endpoint = ArrowFlightEndpoint::from_session_builder(|ctx: DistributedSessionBuilderContext| {
+    // ... and here for each query the Worker handles.
+    let endpoint = Worker::from_session_builder(move |ctx: WorkerQueryContext| {
         let channel_resolver = channel_resolver.clone();
         async move {
-            // ... and here for each query that ArrowFlightEndpoint handles.
             Ok(ctx.builder.with_distributed_channel_resolver(channel_resolver).build())
         }
     });

--- a/docs/source/user-guide/getting-started.md
+++ b/docs/source/user-guide/getting-started.md
@@ -40,15 +40,16 @@ impl ChannelResolver for LocalhostChannelResolver {
 
 > NOTE: This example is not production-ready and is meant to showcase the basic concepts of the library.
 
-This `WorkerResolver` implementation should resolve URLs of Distributed DataFusion Arrow Flight servers, and it's
-also the user of this library's responsibility to spawn a Tonic server that exposes the Arrow Flight service.
+This `WorkerResolver` implementation should resolve URLs of Distributed DataFusion workers, and it's
+also the user of this library's responsibility to spawn a Tonic server that exposes the worker as an Arrow Flight
+service using Tonic.
 
 A basic example of such a server is:
 
 ```rust
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let endpoint = ArrowFlightEndpoint::default();
+    let endpoint = Worker::default();
 
     Server::builder()
         .add_service(endpoint.into_flight_server())
@@ -66,7 +67,7 @@ The next two sections of this guide will walk you through tailoring the library'
 - [Build your own WorkerResolver](worker-resolver.md)
 - [Build your own ChannelResolver](channel-resolver.md)
 - [Build your own TaskEstimator](task-estimator.md)
-- [Build your own distributed DataFusion Arrow Flight endpoint](arrow-flight-endpoint.md)
+- [Build your own distributed DataFusion Worker](worker.md)
 
 Here are some other resources in the codebase:
 

--- a/docs/source/user-guide/index.md
+++ b/docs/source/user-guide/index.md
@@ -10,7 +10,7 @@ your own distributed DataFusion cluster.
 - [Concepts](concepts.md)
 - [Getting Started](getting-started.md)
 - [Building a WorkerResolver](worker-resolver.md)
-- [Building an Arrow Flight endpoint](arrow-flight-endpoint.md)
+- [Spawning a Worker](worker.md)
 - [Building a ChannelResolver](channel-resolver.md)
 - [Building a TaskEstimator](task-estimator.md)
 - [How a distributed plan is built](how-a-distributed-plan-is-built.md)

--- a/docs/source/user-guide/worker-resolver.md
+++ b/docs/source/user-guide/worker-resolver.md
@@ -30,13 +30,13 @@ async fn main() {
 }
 ```
 
-> NOTE: It's not necessary to pass this to the Arrow Flight endpoint session builder.
+> NOTE: It's not necessary to pass this to the Worker session builder.
 
 ## Static WorkerResolver
 
 This is the simplest thing you can do, although it will not fit some common use cases. An example of this can be
-seen
-in [localhost_worker.rs](https://github.com/datafusion-contrib/datafusion-distributed/blob/fad9fa222d65b7d2ddae92fbc20082b5c434e4ff/examples/localhost_run.rs)
+seen in the
+[localhost_worker.rs](https://github.com/datafusion-contrib/datafusion-distributed/blob/fad9fa222d65b7d2ddae92fbc20082b5c434e4ff/examples/localhost_run.rs)
 example:
 
 ```rust
@@ -65,8 +65,8 @@ provider for hosting your Distributed DataFusion workers.
 It's up to you to decide how the URLs should be resolved. One important implementation note is:
 
 - Retrieving the worker URLs needs to be synchronous (as planning is synchronous), and therefore, you'll likely
-  need to spawn a background tasks that periodically refreshes the list of available URLs.
+  need to spawn background tasks that periodically refresh the list of available URLs.
 
 A good example can be found
 in https://github.com/datafusion-contrib/datafusion-distributed/blob/main/benchmarks/cdk/bin/worker.rs,
-where a cluster of AWS EC2 machines are discovered identified by tags with the AWS Rust SDK.
+where a cluster of AWS EC2 machines is discovered identified by tags with the AWS Rust SDK.

--- a/docs/source/user-guide/worker.md
+++ b/docs/source/user-guide/worker.md
@@ -1,26 +1,26 @@
-# Building an Arrow Flight Endpoint
+# Spawn a Worker
 
-An `ArrowFlightEndpoint` is a gRPC server that implements the Arrow Flight protocol for distributed query execution.
+A `Worker` is a gRPC server that implements the Arrow Flight protocol for distributed query execution.
 Worker nodes run these endpoints to receive execution plans, execute them, and stream results back.
 
 ## Overview
 
-The `ArrowFlightEndpoint` is the core worker component in Distributed DataFusion. It:
+The `Worker` is the core worker component in Distributed DataFusion. It:
 
 - Receives serialized execution plans via Arrow Flight's `do_get` method
 - Deserializes plans using protobuf and user-provided codecs
 - Executes plans using the local DataFusion runtime
 - Streams results back as Arrow record batches through the gRPC Arrow Flight interface
 
-## Creating an ArrowFlightEndpoint
+## Launching the Arrow Flight server
 
-The `Default` implementation of the `ArrowFlightEndpoint` should satisfy most basic use cases
+The `Default` implementation of the `Worker` should satisfy most basic use cases
 
 ```rust
-use datafusion_distributed::{ArrowFlightEndpoint};
+use datafusion_distributed::Worker;
 
 async fn main() {
-    let endpoint = ArrowFlightEndpoint::default();
+    let endpoint = Worker::default();
 
     Server::builder()
         .add_service(endpoint.into_flight_server())
@@ -31,13 +31,13 @@ async fn main() {
 }
 ```
 
-If you are using DataFusion though, it's very likely that you have your own custom UDFs, execution nodes, config options
-etc...
+If you are using DataFusion, though, it's very likely that you have your own custom UDFs, execution nodes, config
+options, etc...
 
-You'll need to tell the `ArrowFlightEndpoint` how to build your DataFusion sessions:
+You'll need to tell the `Worker` how to build your DataFusion sessions:
 
 ```rust
-async fn build_state(ctx: DistributedSessionBuilderContext) -> Result<SessionState, DataFusionError> {
+async fn build_state(ctx: WorkerQueryContext) -> Result<SessionState, DataFusionError> {
     Ok(ctx
         .builder
         .with_scalar_functions(vec![your_custom_udf()])
@@ -45,7 +45,7 @@ async fn build_state(ctx: DistributedSessionBuilderContext) -> Result<SessionSta
 }
 
 async fn main() {
-    let endpoint = ArrowFlightEndpoint::from_session_builder(build_sate);
+    let endpoint = Worker::from_session_builder(build_sate);
 
     Server::builder()
         .add_service(endpoint.into_flight_server())
@@ -56,21 +56,21 @@ async fn main() {
 }
 ```
 
-### DistributedSessionBuilder
+### WorkerSessionBuilder
 
-The `DistributedSessionBuilder` is a closure or type that implements:
+The `WorkerSessionBuilder` is a closure or type that implements:
 
 ```rust
 #[async_trait]
-pub trait DistributedSessionBuilder {
+pub trait WorkerSessionBuilder {
     async fn build_session_state(
         &self,
-        ctx: DistributedSessionBuilderContext,
+        ctx: WorkerQueryContext,
     ) -> Result<SessionState, DataFusionError>;
 }
 ```
 
-It receives a `DistributedSessionBuilderContext` containing:
+It receives a `WorkerQueryContext` containing:
 
 - `SessionStateBuilder`: A pre-populated session state builder in which you can inject your custom stuff
 - `headers`: HTTP headers from the incoming request (useful for passing metadata)
@@ -81,11 +81,11 @@ Convert the endpoint to a gRPC service and serve it:
 
 ```rust
 use tonic::transport::Server;
-use datafusion_distributed::ArrowFlightEndpoint;
+use datafusion_distributed::Worker;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 async fn main() {
-    let endpoint = ArrowFlightEndpoint::default();
+    let endpoint = Worker::default();
 
     Server::builder()
         .add_service(endpoint.into_flight_server())

--- a/examples/localhost.md
+++ b/examples/localhost.md
@@ -16,7 +16,7 @@ git lfs checkout
 
 ### Spawning the workers
 
-In two different terminals spawn two ArrowFlightEndpoints
+In two different terminals spawn two workers
 
 ```shell
 cargo run --example localhost_worker -- 8080
@@ -26,7 +26,7 @@ cargo run --example localhost_worker -- 8080
 cargo run --example localhost_worker -- 8081
 ```
 
-The positional numeric argument is the port in which each Arrow Flight endpoint will listen to.
+The positional numeric argument is the port in which each worker will listen to.
 
 ### Issuing a distributed SQL query
 

--- a/examples/localhost_worker.rs
+++ b/examples/localhost_worker.rs
@@ -1,4 +1,4 @@
-use datafusion_distributed::ArrowFlightEndpoint;
+use datafusion_distributed::Worker;
 use std::error::Error;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use structopt::StructOpt;
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::from_args();
 
     Server::builder()
-        .add_service(ArrowFlightEndpoint::default().into_flight_server())
+        .add_service(Worker::default().into_flight_server())
         .serve(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), args.port))
         .await?;
 

--- a/src/execution_plans/network_coalesce.rs
+++ b/src/execution_plans/network_coalesce.rs
@@ -75,9 +75,9 @@ pub struct NetworkCoalesceExec {
     /// Metrics are populated in this map via [NetworkCoalesceExec::execute].
     ///
     /// An instance may receive metrics for 0 to N child tasks, where N is the number of tasks in
-    /// the stage it is reading from. This is because, by convention, the ArrowFlightEndpoint
-    /// sends metrics for a task to the last NetworkCoalesceExec to read from it, which may or may
-    /// not be this instance.
+    /// the stage it is reading from. This is because, by convention, the Worker sends metrics for
+    /// a task to the last NetworkCoalesceExec to read from it, which may or may not be this
+    /// instance.
     pub(crate) metrics_collection: Arc<DashMap<StageKey, Vec<MetricsSetProto>>>,
 }
 

--- a/src/execution_plans/network_shuffle.rs
+++ b/src/execution_plans/network_shuffle.rs
@@ -126,7 +126,7 @@ pub struct NetworkShuffleExec {
     /// Metrics are populated in this map via [NetworkShuffleExec::execute].
     ///
     /// An instance may receive metrics for 0 to N child tasks, where N is the number of tasks in
-    /// the stage it is reading from. This is because, by convention, the ArrowFlightEndpoint
+    /// the stage it is reading from. This is because, by convention, the Worker
     /// sends metrics for a task to the last NetworkShuffleExec to read from it, which may or may
     /// not be this instance.
     pub(crate) metrics_collection: Arc<DashMap<StageKey, Vec<MetricsSetProto>>>,

--- a/src/flight_service/mod.rs
+++ b/src/flight_service/mod.rs
@@ -1,10 +1,10 @@
 mod do_get;
-mod service;
 mod session_builder;
+mod worker;
 pub(crate) use do_get::DoGet;
 
-pub use service::ArrowFlightEndpoint;
 pub use session_builder::{
-    DefaultSessionBuilder, DistributedSessionBuilder, DistributedSessionBuilderContext,
-    MappedDistributedSessionBuilder, MappedDistributedSessionBuilderExt,
+    DefaultSessionBuilder, MappedWorkerSessionBuilder, MappedWorkerSessionBuilderExt,
+    WorkerQueryContext, WorkerSessionBuilder,
 };
+pub use worker::Worker;

--- a/src/flight_service/session_builder.rs
+++ b/src/flight_service/session_builder.rs
@@ -5,15 +5,14 @@ use http::HeaderMap;
 use std::sync::Arc;
 
 #[derive(Debug, Default)]
-pub struct DistributedSessionBuilderContext {
+pub struct WorkerQueryContext {
     pub builder: SessionStateBuilder,
     pub headers: HeaderMap,
 }
 
-/// Trait called by the Arrow Flight endpoint that handles distributed parts of a DataFusion
-/// plan for building a DataFusion's [SessionState].
+/// builds a DataFusion's [SessionState] in each query issued to a worker.
 #[async_trait]
-pub trait DistributedSessionBuilder {
+pub trait WorkerSessionBuilder {
     /// Builds a custom [SessionState] scoped to a single ArrowFlight gRPC call, allowing the
     /// users to provide a customized DataFusion session with things like custom extension codecs,
     /// custom physical optimization rules, UDFs, UDAFs, config extensions, etc...
@@ -27,7 +26,7 @@ pub trait DistributedSessionBuilder {
     /// # use datafusion::execution::{FunctionRegistry, SessionState, SessionStateBuilder, TaskContext};
     /// # use datafusion::physical_plan::ExecutionPlan;
     /// # use datafusion_proto::physical_plan::PhysicalExtensionCodec;
-    /// # use datafusion_distributed::{DistributedExt, DistributedSessionBuilder, DistributedSessionBuilderContext};
+    /// # use datafusion_distributed::{DistributedExt, WorkerSessionBuilder, WorkerQueryContext};
     ///
     /// #[derive(Debug)]
     /// struct CustomExecCodec;
@@ -46,8 +45,8 @@ pub trait DistributedSessionBuilder {
     /// struct CustomSessionBuilder;
     ///
     /// #[async_trait]
-    /// impl DistributedSessionBuilder for CustomSessionBuilder {
-    ///     async fn build_session_state(&self, ctx: DistributedSessionBuilderContext) -> Result<SessionState, DataFusionError> {
+    /// impl WorkerSessionBuilder for CustomSessionBuilder {
+    ///     async fn build_session_state(&self, ctx: WorkerQueryContext) -> Result<SessionState, DataFusionError> {
     ///         Ok(ctx
     ///             .builder
     ///             .with_distributed_user_codec(CustomExecCodec)
@@ -58,52 +57,52 @@ pub trait DistributedSessionBuilder {
     /// ```
     async fn build_session_state(
         &self,
-        ctx: DistributedSessionBuilderContext,
+        ctx: WorkerQueryContext,
     ) -> Result<SessionState, DataFusionError>;
 }
 
-/// Noop implementation of the [DistributedSessionBuilder]. Used by default if no [DistributedSessionBuilder] is provided
-/// while building the Arrow Flight endpoint.
+/// Noop implementation of the [WorkerSessionBuilder]. Used by default if no [WorkerSessionBuilder]
+/// is provided while building the Worker.
 #[derive(Debug, Clone)]
 pub struct DefaultSessionBuilder;
 
 #[async_trait]
-impl DistributedSessionBuilder for DefaultSessionBuilder {
+impl WorkerSessionBuilder for DefaultSessionBuilder {
     async fn build_session_state(
         &self,
-        ctx: DistributedSessionBuilderContext,
+        ctx: WorkerQueryContext,
     ) -> Result<SessionState, DataFusionError> {
         Ok(ctx.builder.build())
     }
 }
 
-/// Implementation of [DistributedSessionBuilder] for any async function that returns a [Result]
+/// Implementation of [WorkerSessionBuilder] for any async function that returns a [Result]
 #[async_trait]
-impl<F, Fut> DistributedSessionBuilder for F
+impl<F, Fut> WorkerSessionBuilder for F
 where
-    F: Fn(DistributedSessionBuilderContext) -> Fut + Send + Sync + 'static,
+    F: Fn(WorkerQueryContext) -> Fut + Send + Sync + 'static,
     Fut: std::future::Future<Output = Result<SessionState, DataFusionError>> + Send + 'static,
 {
     async fn build_session_state(
         &self,
-        ctx: DistributedSessionBuilderContext,
+        ctx: WorkerQueryContext,
     ) -> Result<SessionState, DataFusionError> {
         self(ctx).await
     }
 }
 
-pub trait MappedDistributedSessionBuilderExt {
-    /// Maps an existing [DistributedSessionBuilder] allowing to add further extensions
+pub trait MappedWorkerSessionBuilderExt {
+    /// Maps an existing [WorkerSessionBuilder] allowing to add further extensions
     /// to its already built [SessionStateBuilder].
     ///
-    /// Useful if there's already a [DistributedSessionBuilder] that needs to be extended
+    /// Useful if there's already a [WorkerSessionBuilder] that needs to be extended
     /// with further capabilities.
     ///
     /// Example:
     ///
     /// ```rust
     /// # use datafusion::execution::SessionStateBuilder;
-    /// # use datafusion_distributed::{DefaultSessionBuilder, MappedDistributedSessionBuilderExt};
+    /// # use datafusion_distributed::{DefaultSessionBuilder, MappedWorkerSessionBuilderExt};
     ///
     /// let session_builder = DefaultSessionBuilder
     ///     .map(|b: SessionStateBuilder| {
@@ -111,30 +110,30 @@ pub trait MappedDistributedSessionBuilderExt {
     ///         Ok(b.build())
     ///     });
     /// ```
-    fn map<F>(self, f: F) -> MappedDistributedSessionBuilder<Self, F>
+    fn map<F>(self, f: F) -> MappedWorkerSessionBuilder<Self, F>
     where
         Self: Sized,
         F: Fn(SessionStateBuilder) -> Result<SessionState, DataFusionError>;
 }
 
-impl<T: DistributedSessionBuilder> MappedDistributedSessionBuilderExt for T {
-    fn map<F>(self, f: F) -> MappedDistributedSessionBuilder<Self, F>
+impl<T: WorkerSessionBuilder> MappedWorkerSessionBuilderExt for T {
+    fn map<F>(self, f: F) -> MappedWorkerSessionBuilder<Self, F>
     where
         Self: Sized,
     {
-        MappedDistributedSessionBuilder {
+        MappedWorkerSessionBuilder {
             inner: self,
             f: Arc::new(f),
         }
     }
 }
 
-pub struct MappedDistributedSessionBuilder<T, F> {
+pub struct MappedWorkerSessionBuilder<T, F> {
     inner: T,
     f: Arc<F>,
 }
 
-impl<T: Clone, F> Clone for MappedDistributedSessionBuilder<T, F> {
+impl<T: Clone, F> Clone for MappedWorkerSessionBuilder<T, F> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -144,14 +143,14 @@ impl<T: Clone, F> Clone for MappedDistributedSessionBuilder<T, F> {
 }
 
 #[async_trait]
-impl<T, F> DistributedSessionBuilder for MappedDistributedSessionBuilder<T, F>
+impl<T, F> WorkerSessionBuilder for MappedWorkerSessionBuilder<T, F>
 where
-    T: DistributedSessionBuilder + Send + Sync + 'static,
+    T: WorkerSessionBuilder + Send + Sync + 'static,
     F: Fn(SessionStateBuilder) -> Result<SessionState, DataFusionError> + Send + Sync,
 {
     async fn build_session_state(
         &self,
-        ctx: DistributedSessionBuilderContext,
+        ctx: WorkerQueryContext,
     ) -> Result<SessionState, DataFusionError> {
         let state = self.inner.build_session_state(ctx).await?;
         let builder = SessionStateBuilder::new_from_existing(state);

--- a/src/flight_service/worker.rs
+++ b/src/flight_service/worker.rs
@@ -1,6 +1,6 @@
 use crate::DefaultSessionBuilder;
 use crate::common::ttl_map::{TTLMap, TTLMapConfig};
-use crate::flight_service::DistributedSessionBuilder;
+use crate::flight_service::WorkerSessionBuilder;
 use crate::flight_service::do_get::TaskData;
 use crate::protobuf::StageKey;
 use arrow_flight::flight_service_server::{FlightService, FlightServiceServer};
@@ -18,20 +18,20 @@ use tonic::{Request, Response, Status, Streaming};
 
 #[allow(clippy::type_complexity)]
 #[derive(Default)]
-pub(super) struct ArrowFlightEndpointHooks {
+pub(super) struct WorkerHooks {
     pub(super) on_plan:
         Vec<Arc<dyn Fn(Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> + Sync + Send>>,
 }
 
-pub struct ArrowFlightEndpoint {
+pub struct Worker {
     pub(super) runtime: Arc<RuntimeEnv>,
     pub(super) task_data_entries: Arc<TTLMap<StageKey, Arc<OnceCell<TaskData>>>>,
-    pub(super) session_builder: Arc<dyn DistributedSessionBuilder + Send + Sync>,
-    pub(super) hooks: ArrowFlightEndpointHooks,
+    pub(super) session_builder: Arc<dyn WorkerSessionBuilder + Send + Sync>,
+    pub(super) hooks: WorkerHooks,
     pub(super) max_message_size: Option<usize>,
 }
 
-impl Default for ArrowFlightEndpoint {
+impl Default for Worker {
     fn default() -> Self {
         let ttl_map = TTLMap::try_new(TTLMapConfig::default())
             .expect("Instantiating a TTLMap with default params should never fail");
@@ -39,17 +39,17 @@ impl Default for ArrowFlightEndpoint {
             runtime: Arc::new(RuntimeEnv::default()),
             task_data_entries: Arc::new(ttl_map),
             session_builder: Arc::new(DefaultSessionBuilder),
-            hooks: ArrowFlightEndpointHooks::default(),
+            hooks: WorkerHooks::default(),
             max_message_size: Some(usize::MAX),
         }
     }
 }
 
-impl ArrowFlightEndpoint {
-    /// Builds an [ArrowFlightEndpoint] with a custom [DistributedSessionBuilder]. Use this
+impl Worker {
+    /// Builds a [Worker] with a custom [WorkerSessionBuilder]. Use this
     /// method whenever you need to add custom stuff to the `SessionContext` that executes the query.
     pub fn from_session_builder(
-        session_builder: impl DistributedSessionBuilder + Send + Sync + 'static,
+        session_builder: impl WorkerSessionBuilder + Send + Sync + 'static,
     ) -> Self {
         Self {
             session_builder: Arc::new(session_builder),
@@ -84,7 +84,7 @@ impl ArrowFlightEndpoint {
         self
     }
 
-    /// Converts this endpoint into a [`FlightServiceServer`] with high default message size limits.
+    /// Converts this [Worker] into a [`FlightServiceServer`] with high default message size limits.
     ///
     /// This is a convenience method that wraps the endpoint in a [`FlightServiceServer`] and
     /// configures it with `max_decoding_message_size(usize::MAX)` and
@@ -95,11 +95,21 @@ impl ArrowFlightEndpoint {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
-    /// let endpoint = ArrowFlightEndpoint::try_new(session_builder)?;
-    /// let server = endpoint.into_flight_server();
-    /// // Can chain additional tonic methods if needed
-    /// // let server = server.some_other_tonic_method(...);
+    /// ```
+    /// # use datafusion_distributed::Worker;
+    /// # use tonic::transport::Server;
+    /// # use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    /// # async fn f() {
+    ///
+    /// let worker = Worker::default();
+    /// let server = worker.into_flight_server();
+    ///
+    /// Server::builder()
+    ///     .add_service(Worker::default().into_flight_server())
+    ///     .serve(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080))
+    ///     .await;
+    ///
+    /// # }
     /// ```
     pub fn into_flight_server(self) -> FlightServiceServer<Self> {
         FlightServiceServer::new(self)
@@ -109,7 +119,7 @@ impl ArrowFlightEndpoint {
 }
 
 #[async_trait]
-impl FlightService for ArrowFlightEndpoint {
+impl FlightService for Worker {
     type HandshakeStream = BoxStream<'static, Result<HandshakeResponse, Status>>;
 
     async fn handshake(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,8 @@ pub use execution_plans::{
     DistributedExec, NetworkCoalesceExec, NetworkShuffleExec, PartitionIsolatorExec,
 };
 pub use flight_service::{
-    ArrowFlightEndpoint, DefaultSessionBuilder, DistributedSessionBuilder,
-    DistributedSessionBuilderContext, MappedDistributedSessionBuilder,
-    MappedDistributedSessionBuilderExt,
+    DefaultSessionBuilder, MappedWorkerSessionBuilder, MappedWorkerSessionBuilderExt, Worker,
+    WorkerQueryContext, WorkerSessionBuilder,
 };
 pub use metrics::rewrite_distributed_plan_with_metrics;
 pub use networking::{

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -16,16 +16,10 @@ use uuid::Uuid;
 /// It implements [`ExecutionPlan`] and can be executed to produce a
 /// stream of record batches.
 ///
-/// An ExecutionTask is a finer grained unit of work compared to an ExecutionStage.
-/// One ExecutionStage will create one or more ExecutionTasks
-///
-/// When an [`StageExec`] is execute()'d if will execute its plan and return a stream
-/// of record batches.
-///
 /// If the stage has input stages, then it those input stages will be executed on remote resources
 /// and will be provided the remainder of the stage tree.
 ///
-/// For example if our stage tree looks like this:
+/// For example, if our stage tree looks like this:
 ///
 /// ```text
 ///                       ┌─────────┐
@@ -44,13 +38,13 @@ use uuid::Uuid;
 ///
 /// ```
 ///
-/// Then executing Stage 1 will run its plan locally.  Stage 1 has two inputs, Stage 2 and Stage 3.  We
-/// know these will execute on remote resources.   As such the plan for Stage 1 must contain an
-/// [`NetworkShuffleExec`] node that will read the results of Stage 2 and Stage 3 and coalese the
+/// Then executing Stage 1 will run its plan locally. Stage 1 has two inputs, Stage 2 and Stage 3. We
+/// know these will execute on remote resources. As such, the plan for Stage 1 must contain a
+/// [`NetworkShuffleExec`] node that will read the results of Stage 2 and Stage 3 and coalesce the
 /// results.
 ///
 /// When Stage 1's [`NetworkShuffleExec`] node is executed, it makes an ArrowFlightRequest to the
-/// host assigned in the Stage.  It provides the following Stage tree serialilzed in the body of the
+/// host assigned in the Stage. It provides the following Stage tree serialized in the body of the
 /// Arrow Flight Ticket:
 ///
 /// ```text
@@ -65,7 +59,7 @@ use uuid::Uuid;
 ///
 /// ```
 ///
-/// The receiving ArrowFlightEndpoint will then execute Stage 2 and will repeat this process.
+/// The receiving Worker will then execute Stage 2 and will repeat this process.
 ///
 /// When Stage 4 is executed, it has no input tasks, so it is assumed that the plan included in that
 /// Stage can complete on its own; it's likely holding a leaf node in the overall physical plan and
@@ -178,7 +172,7 @@ use datafusion_proto::protobuf::PhysicalPlanNode;
 use prost::Message;
 /// Be able to display a nice tree for stages.
 ///
-/// The challenge to doing this at the moment is that `TreeRenderVistor`
+/// The challenge to doing this at the moment is that `TreeRenderVisitor`
 /// in [`datafusion::physical_plan::display`] is not public, and that it also
 /// is specific to a `ExecutionPlan` trait object, which we don't have.
 ///
@@ -334,7 +328,7 @@ const COLOR_SCHEME: &str = "spectral6";
 /// Graphviz dot format.
 /// You can view them on https://vis-js.com
 ///
-/// Or it is often useful to expertiment with plan output using
+/// Or it is often useful to experiment with plan output using
 /// https://datafusion-fiddle.vercel.app/
 pub fn display_plan_graphviz(plan: Arc<dyn ExecutionPlan>) -> Result<String> {
     let mut f = String::new();

--- a/tests/custom_config_extension.rs
+++ b/tests/custom_config_extension.rs
@@ -15,7 +15,7 @@ mod tests {
     };
     use datafusion_distributed::test_utils::localhost::start_localhost_context;
     use datafusion_distributed::test_utils::parquet::register_parquet_tables;
-    use datafusion_distributed::{DistributedExt, DistributedSessionBuilderContext};
+    use datafusion_distributed::{DistributedExt, WorkerQueryContext};
     use datafusion_proto::physical_plan::PhysicalExtensionCodec;
     use futures::TryStreamExt;
     use prost::Message;
@@ -23,9 +23,7 @@ mod tests {
     use std::fmt::Formatter;
     use std::sync::Arc;
 
-    async fn build_state(
-        ctx: DistributedSessionBuilderContext,
-    ) -> Result<SessionState, DataFusionError> {
+    async fn build_state(ctx: WorkerQueryContext) -> Result<SessionState, DataFusionError> {
         Ok(ctx
             .builder
             .with_distributed_option_extension_from_headers::<CustomExtension>(&ctx.headers)?

--- a/tests/custom_extension_codec.rs
+++ b/tests/custom_extension_codec.rs
@@ -12,9 +12,7 @@ mod tests {
     };
     use datafusion_distributed::test_utils::localhost::start_localhost_context;
     use datafusion_distributed::test_utils::parquet::register_parquet_tables;
-    use datafusion_distributed::{
-        DistributedExt, DistributedSessionBuilderContext, assert_snapshot,
-    };
+    use datafusion_distributed::{DistributedExt, WorkerQueryContext, assert_snapshot};
     use datafusion_proto::physical_plan::PhysicalExtensionCodec;
     use datafusion_proto::protobuf::proto_error;
     use futures::TryStreamExt;
@@ -25,9 +23,7 @@ mod tests {
 
     #[tokio::test]
     async fn custom_extension_codec() -> Result<(), Box<dyn std::error::Error>> {
-        async fn build_state(
-            ctx: DistributedSessionBuilderContext,
-        ) -> Result<SessionState, DataFusionError> {
+        async fn build_state(ctx: WorkerQueryContext) -> Result<SessionState, DataFusionError> {
             Ok(ctx
                 .builder
                 .with_distributed_user_codec(CustomPassThroughExecCodec)

--- a/tests/error_propagation.rs
+++ b/tests/error_propagation.rs
@@ -12,7 +12,7 @@ mod tests {
     };
     use datafusion_distributed::test_utils::localhost::start_localhost_context;
     use datafusion_distributed::test_utils::parquet::register_parquet_tables;
-    use datafusion_distributed::{DistributedExt, DistributedSessionBuilderContext};
+    use datafusion_distributed::{DistributedExt, WorkerQueryContext};
     use datafusion_proto::physical_plan::PhysicalExtensionCodec;
     use datafusion_proto::protobuf::proto_error;
     use futures::{TryStreamExt, stream};
@@ -24,9 +24,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_error_propagation() -> Result<(), Box<dyn Error>> {
-        async fn build_state(
-            ctx: DistributedSessionBuilderContext,
-        ) -> Result<SessionState, DataFusionError> {
+        async fn build_state(ctx: WorkerQueryContext) -> Result<SessionState, DataFusionError> {
             Ok(ctx
                 .builder
                 .with_distributed_user_codec(ErrorThrowingExecCodec)

--- a/tests/introspection.rs
+++ b/tests/introspection.rs
@@ -4,22 +4,19 @@ mod tests {
     use datafusion::physical_plan::execute_stream;
     use datafusion_distributed::test_utils::localhost::start_localhost_context;
     use datafusion_distributed::test_utils::parquet::register_parquet_tables;
-    use datafusion_distributed::{
-        DistributedSessionBuilderContext, assert_snapshot, display_plan_ascii,
-    };
+    use datafusion_distributed::{WorkerQueryContext, assert_snapshot, display_plan_ascii};
     use futures::TryStreamExt;
     use std::error::Error;
 
     #[tokio::test]
     async fn distributed_show_columns() -> Result<(), Box<dyn Error>> {
-        let (ctx, _guard) =
-            start_localhost_context(3, |mut ctx: DistributedSessionBuilderContext| async {
-                let cfg = ctx.builder.config().get_or_insert_default();
-                let opts = cfg.options_mut();
-                opts.catalog.information_schema = true;
-                Ok(ctx.builder.build())
-            })
-            .await;
+        let (ctx, _guard) = start_localhost_context(3, |mut ctx: WorkerQueryContext| async {
+            let cfg = ctx.builder.config().get_or_insert_default();
+            let opts = cfg.options_mut();
+            opts.catalog.information_schema = true;
+            Ok(ctx.builder.build())
+        })
+        .await;
         register_parquet_tables(&ctx).await?;
 
         let df = ctx.sql(r#"SHOW COLUMNS from weather"#).await?;

--- a/tests/udfs.rs
+++ b/tests/udfs.rs
@@ -16,8 +16,8 @@ mod tests {
     use datafusion::physical_plan::{ExecutionPlan, execute_stream};
     use datafusion_distributed::test_utils::localhost::start_localhost_context;
     use datafusion_distributed::{
-        DistributedExt, DistributedPhysicalOptimizerRule, DistributedSessionBuilderContext,
-        assert_snapshot, display_plan_ascii,
+        DistributedExt, DistributedPhysicalOptimizerRule, WorkerQueryContext, assert_snapshot,
+        display_plan_ascii,
     };
     use futures::TryStreamExt;
     use std::any::Any;
@@ -26,9 +26,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_udf_in_partitioning_field() -> Result<(), Box<dyn Error>> {
-        async fn build_state(
-            ctx: DistributedSessionBuilderContext,
-        ) -> Result<SessionState, DataFusionError> {
+        async fn build_state(ctx: WorkerQueryContext) -> Result<SessionState, DataFusionError> {
             Ok(ctx
                 .builder
                 .with_scalar_functions(vec![udf()])


### PR DESCRIPTION
While writing the documentation, I realized we are naming the same thing in two different ways: "Worker" and "ArrowFlightEndpoint".

This PR changes all the reference in the code an in the docs to use the "Worker" word to reference the server listening on a port that handles chunks of plans