### PR TITLE
Add ballista benchmarks feature

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -8,10 +8,6 @@ default-run = "dfbench"
 datafusion = { workspace = true }
 datafusion-proto = { workspace = true }
 datafusion-distributed = { path = "..", features = ["integration"] }
-ballista = { version = "50" }
-ballista-executor = { version = "50" }
-ballista-scheduler = { version = "50" }
-ballista-core = "50"
 tokio = { version = "1.46.1", features = ["full"] }
 parquet = { version = "57.1.0" }
 structopt = { version = "0.3.26" }
@@ -34,6 +30,20 @@ aws-sdk-ec2 = "1"
 openssl = { version = "0.10", features = ["vendored"] }
 clap = "4.5"
 
+# ballista feature
+ballista = { version = "50", optional = true }
+ballista-executor = { version = "50", optional = true }
+ballista-scheduler = { version = "50", optional = true }
+ballista-core = { version = "50", optional = true }
+
+[features]
+ballista-benchmarks = [
+    "ballista",
+    "ballista-executor",
+    "ballista-scheduler",
+    "ballista-core"
+]
+
 [[bin]]
 name = "dfbench"
 path = "src/main.rs"
@@ -45,11 +55,14 @@ path = "cdk/bin/worker.rs"
 [[bin]]
 name = "ballista-http"
 path = "cdk/bin/ballista_http.rs"
+required-features = ["ballista-benchmarks"]
 
 [[bin]]
 name = "ballista-executor"
 path = "cdk/bin/ballista_executor.rs"
+required-features = ["ballista-benchmarks"]
 
 [[bin]]
 name = "ballista-scheduler"
 path = "cdk/bin/ballista_scheduler.rs"
+required-features = ["ballista-benchmarks"]

--- a/benchmarks/cdk/lib/ballista.ts
+++ b/benchmarks/cdk/lib/ballista.ts
@@ -17,21 +17,21 @@ let ballistaExecutorBinary: s3assets.Asset
 export const BALLISTA_ENGINE: QueryEngine = {
     beforeEc2Machines(ctx: BeforeEc2MachinesContext): void {
         console.log('Building Ballista server binary...');
-        execSync('cargo zigbuild -p datafusion-distributed-benchmarks --release --bin ballista-http --target x86_64-unknown-linux-gnu', {
+        execSync('cargo zigbuild -p datafusion-distributed-benchmarks --features ballista-benchmarks --release --bin ballista-http --target x86_64-unknown-linux-gnu', {
             cwd: ROOT,
             stdio: 'inherit',
         });
         console.log('Ballista server binary built successfully');
 
         console.log('Building Ballista scheduler...');
-        execSync('cargo zigbuild -p datafusion-distributed-benchmarks --release --bin ballista-scheduler --target x86_64-unknown-linux-gnu', {
+        execSync('cargo zigbuild -p datafusion-distributed-benchmarks --features ballista-benchmarks --release --bin ballista-scheduler --target x86_64-unknown-linux-gnu', {
             cwd: ROOT,
             stdio: 'inherit',
         });
         console.log('Ballista scheduler built successfully');
 
         console.log('Building Ballista executor...');
-        execSync('cargo zigbuild -p datafusion-distributed-benchmarks --release --bin ballista-executor --target x86_64-unknown-linux-gnu', {
+        execSync('cargo zigbuild -p datafusion-distributed-benchmarks --features ballista-benchmarks --release --bin ballista-executor --target x86_64-unknown-linux-gnu', {
             cwd: ROOT,
             stdio: 'inherit',
         });


### PR DESCRIPTION
Importing ballista if it's not needed, so hide it behind a flag.

Importing ballista is heavy, as it usually lags behind in DataFusion versions, forcing us to import a whole previous DataFusion version