### PR TITLE
Fix header extension propagation

### DIFF
--- a/src/distributed_ext.rs
+++ b/src/distributed_ext.rs
@@ -50,7 +50,7 @@ pub trait DistributedExt: Sized {
     /// // Now, the CustomExtension will be able to cross network boundaries. Upon making an Arrow
     /// // Flight request, it will be sent through gRPC metadata.
     /// let state = SessionStateBuilder::new()
-    ///     .with_distributed_option_extension(my_custom_extension).unwrap()
+    ///     .with_distributed_option_extension(my_custom_extension)
     ///     .build();
     ///
     /// async fn build_state(ctx: WorkerQueryContext) -> Result<SessionState, DataFusionError> {
@@ -62,16 +62,10 @@ pub trait DistributedExt: Sized {
     ///         .build())
     /// }
     /// ```
-    fn with_distributed_option_extension<T: ConfigExtension + Default>(
-        self,
-        t: T,
-    ) -> Result<Self, DataFusionError>;
+    fn with_distributed_option_extension<T: ConfigExtension + Default>(self, t: T) -> Self;
 
     /// Same as [DistributedExt::with_distributed_option_extension] but with an in-place mutation
-    fn set_distributed_option_extension<T: ConfigExtension + Default>(
-        &mut self,
-        t: T,
-    ) -> Result<(), DataFusionError>;
+    fn set_distributed_option_extension<T: ConfigExtension + Default>(&mut self, t: T);
 
     /// Adds the provided [ConfigExtension] to the distributed context. The [ConfigExtension] will
     /// be serialized using gRPC metadata and sent across tasks. Users are expected to call this
@@ -109,7 +103,7 @@ pub trait DistributedExt: Sized {
     /// // Now, the CustomExtension will be able to cross network boundaries. Upon making an Arrow
     /// // Flight request, it will be sent through gRPC metadata.
     /// let state = SessionStateBuilder::new()
-    ///     .with_distributed_option_extension(my_custom_extension).unwrap()
+    ///     .with_distributed_option_extension(my_custom_extension)
     ///     .build();
     ///
     /// async fn build_state(ctx: WorkerQueryContext) -> Result<SessionState, DataFusionError> {
@@ -452,10 +446,7 @@ pub trait DistributedExt: Sized {
 }
 
 impl DistributedExt for SessionConfig {
-    fn set_distributed_option_extension<T: ConfigExtension + Default>(
-        &mut self,
-        t: T,
-    ) -> Result<(), DataFusionError> {
+    fn set_distributed_option_extension<T: ConfigExtension + Default>(&mut self, t: T) {
         set_distributed_option_extension(self, t)
     }
 
@@ -532,8 +523,8 @@ impl DistributedExt for SessionConfig {
     delegate! {
         to self {
             #[call(set_distributed_option_extension)]
-            #[expr($?;Ok(self))]
-            fn with_distributed_option_extension<T: ConfigExtension + Default>(mut self, t: T) -> Result<Self, DataFusionError>;
+            #[expr($;self)]
+            fn with_distributed_option_extension<T: ConfigExtension + Default>(mut self, t: T) -> Self;
 
             #[call(set_distributed_option_extension_from_headers)]
             #[expr($?;Ok(self))]
@@ -581,10 +572,10 @@ impl DistributedExt for SessionConfig {
 impl DistributedExt for SessionStateBuilder {
     delegate! {
         to self.config().get_or_insert_default() {
-            fn set_distributed_option_extension<T: ConfigExtension + Default>(&mut self, t: T) -> Result<(), DataFusionError>;
+            fn set_distributed_option_extension<T: ConfigExtension + Default>(&mut self, t: T);
             #[call(set_distributed_option_extension)]
-            #[expr($?;Ok(self))]
-            fn with_distributed_option_extension<T: ConfigExtension + Default>(mut self, t: T) -> Result<Self, DataFusionError>;
+            #[expr($;self)]
+            fn with_distributed_option_extension<T: ConfigExtension + Default>(mut self, t: T) -> Self;
 
             fn set_distributed_option_extension_from_headers<T: ConfigExtension + Default>(&mut self, h: &HeaderMap) -> Result<(), DataFusionError>;
             #[call(set_distributed_option_extension_from_headers)]
@@ -642,10 +633,10 @@ impl DistributedExt for SessionStateBuilder {
 impl DistributedExt for SessionState {
     delegate! {
         to self.config_mut() {
-            fn set_distributed_option_extension<T: ConfigExtension + Default>(&mut self, t: T) -> Result<(), DataFusionError>;
+            fn set_distributed_option_extension<T: ConfigExtension + Default>(&mut self, t: T);
             #[call(set_distributed_option_extension)]
-            #[expr($?;Ok(self))]
-            fn with_distributed_option_extension<T: ConfigExtension + Default>(mut self, t: T) -> Result<Self, DataFusionError>;
+            #[expr($;self)]
+            fn with_distributed_option_extension<T: ConfigExtension + Default>(mut self, t: T) -> Self;
 
             fn set_distributed_option_extension_from_headers<T: ConfigExtension + Default>(&mut self, h: &HeaderMap) -> Result<(), DataFusionError>;
             #[call(set_distributed_option_extension_from_headers)]
@@ -703,10 +694,10 @@ impl DistributedExt for SessionState {
 impl DistributedExt for SessionContext {
     delegate! {
         to self.state_ref().write().config_mut() {
-            fn set_distributed_option_extension<T: ConfigExtension + Default>(&mut self, t: T) -> Result<(), DataFusionError>;
+            fn set_distributed_option_extension<T: ConfigExtension + Default>(&mut self, t: T);
             #[call(set_distributed_option_extension)]
-            #[expr($?;Ok(self))]
-            fn with_distributed_option_extension<T: ConfigExtension + Default>(self, t: T) -> Result<Self, DataFusionError>;
+            #[expr($;self)]
+            fn with_distributed_option_extension<T: ConfigExtension + Default>(self, t: T) -> Self;
 
             fn set_distributed_option_extension_from_headers<T: ConfigExtension + Default>(&mut self, h: &HeaderMap) -> Result<(), DataFusionError>;
             #[call(set_distributed_option_extension_from_headers)]

--- a/src/distributed_planner/task_estimator.rs
+++ b/src/distributed_planner/task_estimator.rs
@@ -179,10 +179,13 @@ pub(crate) fn set_distributed_task_estimator(
     } else {
         let mut estimators = CombinedTaskEstimator::default();
         estimators.user_provided.push(Arc::new(estimator));
-        set_distributed_option_extension(cfg, DistributedConfig {
-            __private_task_estimator: estimators,
-            ..Default::default()
-        }).expect("Calling set_distributed_option_extension with a default DistributedConfig should never fail");
+        set_distributed_option_extension(
+            cfg,
+            DistributedConfig {
+                __private_task_estimator: estimators,
+                ..Default::default()
+            },
+        )
     }
 }
 

--- a/src/flight_service/do_get.rs
+++ b/src/flight_service/do_get.rs
@@ -1,7 +1,5 @@
 use crate::common::map_last_stream;
-use crate::config_extension_ext::{
-    ContextGrpcMetadata, set_distributed_option_extension_from_headers,
-};
+use crate::config_extension_ext::set_distributed_option_extension_from_headers;
 use crate::flight_service::session_builder::WorkerQueryContext;
 use crate::flight_service::worker::Worker;
 use crate::metrics::TaskMetricsCollector;
@@ -123,7 +121,6 @@ impl Worker {
             set_distributed_option_extension_from_headers::<DistributedConfig>(cfg, &headers)
                 .map_err(|err| datafusion_error_to_tonic_status(&err))?;
         let send_metrics = d_cfg.collect_metrics;
-        cfg.set_extension(Arc::new(ContextGrpcMetadata(headers)));
         cfg.set_extension(Arc::new(DistributedTaskContext {
             task_index: doget.target_task_index as usize,
             task_count: doget.target_task_count as usize,

--- a/src/flight_service/worker_connection_pool.rs
+++ b/src/flight_service/worker_connection_pool.rs
@@ -1,10 +1,10 @@
-use crate::config_extension_ext::ContextGrpcMetadata;
+use crate::Stage;
+use crate::config_extension_ext::get_config_extension_propagation_headers;
 use crate::flight_service::do_get::DoGet;
 use crate::networking::get_distributed_channel_resolver;
 use crate::protobuf::{
     FlightAppMetadata, StageKey, datafusion_error_to_tonic_status, map_flight_to_datafusion_error,
 };
-use crate::{DistributedConfig, Stage};
 use arrow_flight::decode::FlightRecordBatchStream;
 use arrow_flight::error::FlightError;
 use arrow_flight::{FlightData, Ticket};
@@ -16,7 +16,7 @@ use datafusion::common::{DataFusionError, Result, internal_err};
 use datafusion::execution::TaskContext;
 use datafusion::execution::memory_pool::{MemoryConsumer, MemoryReservation};
 use futures::{Stream, TryStreamExt};
-use http::{Extensions, HeaderMap};
+use http::Extensions;
 use prost::Message;
 use std::fmt::{Debug, Formatter};
 use std::ops::Range;
@@ -102,13 +102,10 @@ impl WorkerConnection {
         ctx: &Arc<TaskContext>,
     ) -> Result<Self> {
         let channel_resolver = get_distributed_channel_resolver(ctx.as_ref());
-        let d_cfg = DistributedConfig::from_config_options(ctx.session_config().options())?;
 
-        let context_headers = ContextGrpcMetadata::headers_from_ctx(ctx);
-        // TODO: this propagation should be automatic https://github.com/datafusion-contrib/datafusion-distributed/issues/247
-        let context_headers = manually_propagate_distributed_config(context_headers, d_cfg);
+        let headers = get_config_extension_propagation_headers(ctx.session_config())?;
         let ticket = Request::from_parts(
-            MetadataMap::from_headers(context_headers),
+            MetadataMap::from_headers(headers),
             Extensions::default(),
             Ticket {
                 ticket: DoGet {
@@ -246,19 +243,6 @@ fn fanout(o_txs: &[UnboundedSender<WorkerMsg>], err: Status) {
     for o_tx in o_txs {
         let _ = o_tx.send(Err(err.clone()));
     }
-}
-
-/// Manual propagation of the [DistributedConfig] fields relevant for execution. Can be removed
-/// after https://github.com/datafusion-contrib/datafusion-distributed/issues/247 is fixed, as this will become automatic.
-pub(super) fn manually_propagate_distributed_config(
-    mut headers: HeaderMap,
-    d_cfg: &DistributedConfig,
-) -> HeaderMap {
-    headers.insert(
-        "distributed.collect_metrics",
-        d_cfg.collect_metrics.to_string().parse().unwrap(),
-    );
-    headers
 }
 
 impl Debug for WorkerConnectionPool {

--- a/src/networking/channel_resolver.rs
+++ b/src/networking/channel_resolver.rs
@@ -56,10 +56,13 @@ pub(crate) fn set_distributed_channel_resolver(
     if let Some(distributed_cfg) = opts.extensions.get_mut::<DistributedConfig>() {
         distributed_cfg.__private_channel_resolver = channel_resolver;
     } else {
-        set_distributed_option_extension(cfg, DistributedConfig {
-            __private_channel_resolver: channel_resolver,
-            ..Default::default()
-        }).expect("Calling set_distributed_option_extension with a default DistributedConfig should never fail");
+        set_distributed_option_extension(
+            cfg,
+            DistributedConfig {
+                __private_channel_resolver: channel_resolver,
+                ..Default::default()
+            },
+        )
     }
 }
 

--- a/src/networking/worker_resolver.rs
+++ b/src/networking/worker_resolver.rs
@@ -29,10 +29,13 @@ pub(crate) fn set_distributed_worker_resolver(
     if let Some(distributed_cfg) = opts.extensions.get_mut::<DistributedConfig>() {
         distributed_cfg.__private_worker_resolver = worker_resolver;
     } else {
-        set_distributed_option_extension(cfg, DistributedConfig {
-            __private_worker_resolver: worker_resolver,
-            ..Default::default()
-        }).expect("Calling set_distributed_option_extension with a default DistributedConfig should never fail");
+        set_distributed_option_extension(
+            cfg,
+            DistributedConfig {
+                __private_worker_resolver: worker_resolver,
+                ..Default::default()
+            },
+        )
     }
 }
 

--- a/tests/custom_config_extension.rs
+++ b/tests/custom_config_extension.rs
@@ -40,7 +40,7 @@ mod tests {
                 bar: 1,
                 baz: true,
                 throw_err: false,
-            })?
+            })
             .build()
             .into();
 
@@ -69,20 +69,13 @@ mod tests {
     }
 
     #[tokio::test]
-    // TODO: the solution to this test failure is to, rather than dumping the config extension
-    //  fields into headers immediately when calling `with_distributed_option_extension()`, to instead
-    //  register the ConfigExtension::PREFIX as something that we should lazily capture and send
-    //  in the headers of every network request. In order to do that, first this PR upstream
-    //  https://github.com/apache/datafusion/pull/18887 needs to be shipped. It will be available
-    //  in DataFusion 52.0.0.
-    #[ignore]
     async fn custom_config_extension_runtime_change() -> Result<(), Box<dyn std::error::Error>> {
         let (mut ctx, _guard) = start_localhost_context(3, build_state).await;
         ctx = SessionStateBuilder::from(ctx.state())
             .with_distributed_option_extension(CustomExtension {
                 throw_err: true,
                 ..Default::default()
-            })?
+            })
             .build()
             .into();
 


### PR DESCRIPTION
Closes https://github.com/datafusion-contrib/datafusion-distributed/issues/247

Now config extensions can be mutated and it will still be correctly sent to downstream workers through headers.

There is one test that replicated the issue that was previously ignored, but it now runs fine.

---

This PR contains a breaking change on the public API, where `with_distributed_option_extension()` no longer returns a `Result<Self>`. It just returns `Self` now.