### PR TITLE
Put custom_execution_plan.rs example behind the integration flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,3 +82,8 @@ hyper-util = "0.1.16"
 pretty_assertions = "1.4"
 reqwest = "0.12"
 zip = "6.0"
+
+[[example]]
+name = "custom_execution_plan"
+path = "examples/custom_execution_plan.rs"
+required-features = ["integration"]


### PR DESCRIPTION
Just a very small thing. Without hiding the example behind a flag, running a plan `cargo test` fails because the feature is not enabled by default.