### PR TITLE
Fix proto generation script `out_dir` path

### DIFF
--- a/src/observability/generated/observability.rs
+++ b/src/observability/generated/observability.rs
@@ -13,10 +13,10 @@ pub mod observability_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct ObservabilityServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -55,14 +55,13 @@ pub mod observability_service_client {
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
-                http::Request<tonic::body::Body>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
+                    http::Request<tonic::body::Body>,
+                    Response = http::Response<
+                        <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
+                    >,
                 >,
-            >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::Body>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::Body>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             ObservabilityServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -101,21 +100,17 @@ pub mod observability_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PingRequest>,
         ) -> std::result::Result<tonic::Response<super::PingResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic_prost::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/observability.ObservabilityService/Ping",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/observability.ObservabilityService/Ping");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("observability.ObservabilityService", "Ping"));
+            req.extensions_mut().insert(GrpcMethod::new(
+                "observability.ObservabilityService",
+                "Ping",
+            ));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -127,7 +122,7 @@ pub mod observability_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with ObservabilityServiceServer.
@@ -159,10 +154,7 @@ pub mod observability_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -197,8 +189,7 @@ pub mod observability_service_server {
             self
         }
     }
-    impl<T, B> tonic::codegen::Service<http::Request<B>>
-    for ObservabilityServiceServer<T>
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for ObservabilityServiceServer<T>
     where
         T: ObservabilityService,
         B: Body + std::marker::Send + 'static,
@@ -218,14 +209,9 @@ pub mod observability_service_server {
                 "/observability.ObservabilityService/Ping" => {
                     #[allow(non_camel_case_types)]
                     struct PingSvc<T: ObservabilityService>(pub Arc<T>);
-                    impl<
-                        T: ObservabilityService,
-                    > tonic::server::UnaryService<super::PingRequest> for PingSvc<T> {
+                    impl<T: ObservabilityService> tonic::server::UnaryService<super::PingRequest> for PingSvc<T> {
                         type Response = super::PingResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PingRequest>,
@@ -259,25 +245,19 @@ pub mod observability_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(
-                            tonic::body::Body::default(),
-                        );
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(tonic::body::Body::default());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(
+                        http::header::CONTENT_TYPE,
+                        tonic::metadata::GRPC_CONTENT_TYPE,
+                    );
+                    Ok(response)
+                }),
             }
         }
     }


### PR DESCRIPTION
Fix for merged PR [Add functionality for worker-console communication #297
](https://github.com/datafusion-contrib/datafusion-distributed/pull/297) where generated protobuf code would end up in `src/observability/src/generated/` instead of `src/observability/generated/`.