### PR TITLE
Change remote cluster benchmark instances to c5n.2xlarge

### DIFF
--- a/benchmarks/cdk/bin/cdk.ts
+++ b/benchmarks/cdk/bin/cdk.ts
@@ -8,7 +8,7 @@ import {SPARK_ENGINE} from "../lib/spark";
 const app = new cdk.App();
 
 const config = {
-    instanceType: 't3.2xlarge',
+    instanceType: 'c5n.2xlarge',  // Non-burstable, network-optimized
     instanceCount: 4,
     engines: [
         DATAFUSION_DISTRIBUTED_ENGINE,


### PR DESCRIPTION
The previous `t3.2xlarge` where "burstable" instances, that are optimized to be economic at the price of not being able to use all the CPUs for a sustained amount of time.

When running big benchmarks (TPC-H 100), the latency measurements show huge difference between runs, not only on DataFusion, but on Trino and Spark, which doesn't make a good reliable environment for benchmarks.

These new instance types are the bare minimum to run TPC-H 100 on Trino (very resource hungry) while maintaining good consistency between benchmark runs.