### PR TITLE
add `network_latency_*` metrics for network* nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,6 +2044,7 @@ dependencies = [
  "prost",
  "rand 0.9.2",
  "reqwest",
+ "sketches-ddsketch",
  "structopt",
  "test-case",
  "tokio",
@@ -5462,6 +5463,12 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ pin-project = "1.1.10"
 tokio-stream = "0.1.17"
 tokio-util = "0.7"
 moka = { version = "0.12", features = ["sync", "future"] }
+sketches-ddsketch = "0.3.0"
 
 # integration_tests deps
 insta = { version = "1.46.0", features = ["filters"], optional = true }

--- a/src/metrics/latency_tracker.rs
+++ b/src/metrics/latency_tracker.rs
@@ -1,0 +1,134 @@
+use sketches_ddsketch::{Config, DDSketch};
+use std::time::Duration;
+
+/// Tracks latency stats using running aggregates and a DDSketch for quantiles.
+#[derive(Clone)]
+pub struct LatencyTracker {
+    // first sample
+    first_nanos: Option<u64>,
+    // DDSketch provides relative-error quantiles with bounded size.
+    sketch: DDSketch,
+}
+
+impl Default for LatencyTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LatencyTracker {
+    /// Creates a new empty tracker.
+    pub fn new() -> Self {
+        Self {
+            first_nanos: None,
+            sketch: DDSketch::new(Config::defaults()),
+        }
+    }
+
+    /// Adds a latency sample to the tracker.
+    pub fn track(&mut self, duration: Duration) {
+        let nanos = duration.as_nanos() as u64;
+
+        if self.sketch.count() == 0 {
+            self.first_nanos = Some(nanos);
+        }
+
+        self.sketch.add(nanos as f64);
+    }
+
+    /// Returns the number of samples recorded.
+    pub fn count(&self) -> u64 {
+        self.sketch.count() as u64
+    }
+
+    /// Returns the first recorded latency, if any.
+    pub fn first(&self) -> Option<Duration> {
+        self.first_nanos.map(Duration::from_nanos)
+    }
+
+    /// Returns the minimum latency seen, if any.
+    pub fn min(&self) -> Option<Duration> {
+        let value = self.sketch.min()?;
+        if value.is_finite() && value >= 0.0 {
+            Some(Duration::from_nanos(value.round() as u64))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the maximum latency seen, if any.
+    pub fn max(&self) -> Option<Duration> {
+        let value = self.sketch.max()?;
+        if value.is_finite() && value >= 0.0 {
+            Some(Duration::from_nanos(value.round() as u64))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the average latency, if any.
+    pub fn avg(&self) -> Option<Duration> {
+        let sum = self.sketch.sum()?;
+        let count = self.count();
+        if count == 0 {
+            return None;
+        }
+        let avg = sum / count as f64;
+        if avg.is_finite() && avg >= 0.0 {
+            Some(Duration::from_nanos(avg.round() as u64))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the estimated latency at the given quantile (0.0..=1.0).
+    pub fn quantile(&self, q: f64) -> Option<Duration> {
+        if self.count() == 0 {
+            return None;
+        }
+        let q = q.clamp(0.0, 1.0);
+        let value = self.sketch.quantile(q).ok().flatten()?;
+        if value.is_finite() && value >= 0.0 {
+            Some(Duration::from_nanos(value.round() as u64))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_tracker_returns_none() {
+        let tracker = LatencyTracker::new();
+        assert_eq!(tracker.count(), 0);
+        assert!(tracker.first().is_none());
+        assert!(tracker.min().is_none());
+        assert!(tracker.max().is_none());
+        assert!(tracker.avg().is_none());
+        assert!(tracker.quantile(0.90).is_none());
+        assert!(tracker.quantile(0.99).is_none());
+    }
+
+    #[test]
+    fn basic_stats_and_quantiles() {
+        let mut tracker = LatencyTracker::new();
+        for nanos in [10u64, 20, 30, 40, 50] {
+            tracker.track(Duration::from_nanos(nanos));
+        }
+
+        assert_eq!(tracker.count(), 5);
+        assert_eq!(tracker.first(), Some(Duration::from_nanos(10)));
+        assert_eq!(tracker.min(), Some(Duration::from_nanos(10)));
+        assert_eq!(tracker.max(), Some(Duration::from_nanos(50)));
+        assert_eq!(tracker.avg(), Some(Duration::from_nanos(30)));
+        let p90 = tracker.quantile(0.90).unwrap().as_nanos() as i64;
+        let p99 = tracker.quantile(0.99).unwrap().as_nanos() as i64;
+        // DDSketch provides approximate quantiles with bounded relative error,
+        // so we use a wider range to account for this.
+        assert!((40..=60).contains(&p90));
+        assert!((40..=60).contains(&p99));
+    }
+}

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod latency_tracker;
 pub(crate) mod proto;
 mod task_metrics_collector;
 mod task_metrics_rewriter;

--- a/tests/metrics_collection.rs
+++ b/tests/metrics_collection.rs
@@ -154,6 +154,8 @@ mod tests {
         assert!(value > 100);
         let value = node_metrics::<NetworkCoalesceExec>(&d_physical, "elapsed_compute", 1);
         assert!(value > 100);
+        let value = node_metrics::<NetworkCoalesceExec>(&d_physical, "network_latency_avg", 1);
+        assert!(value > 0);
 
         let value = node_metrics::<NetworkShuffleExec>(&d_physical, "bytes_transferred", 1);
         assert!(value > 100);
@@ -161,6 +163,8 @@ mod tests {
         assert!(value > 100);
         let value = node_metrics::<NetworkShuffleExec>(&d_physical, "elapsed_compute", 1);
         assert!(value > 100);
+        let value = node_metrics::<NetworkShuffleExec>(&d_physical, "network_latency_avg", 1);
+        assert!(value > 0);
 
         Ok(())
     }


### PR DESCRIPTION
This change adds `"network_latency_first", "network_latency_min", "network_latency_max", "network_latency_avg", "network_latency_p99"` metrics that measures the time between creating a message on
a worker to the client recieving it. This is measured for all messages received by a task (in all partitions).

I considered tracking it for all partitions (using labels for the partition id), however, `Time` metrics are aggregated
by summation, not average, so this would not work. We would need a custom metric for an avg time aggregator and these
are unsupported.

Example plan:
```
───── DistributedExec ── Tasks: t0:[p0]
│ CoalescePartitionsExec, metrics=[output_rows_0=2, elapsed_compute_0=11.08µs, output_bytes_0=256.0 KB, output_batches_0=2]
│   HashJoinExec: mode=CollectLeft, join_type=Left, on=[(RainTomorrow@1, RainTomorrow@1)], projection=[MinTemp@0, MaxTemp@2], metrics=[output_rows_0=2, elapsed_compute_0=139.00µs, output_
bytes_0=256.0 KB, output_batches_0=2, build_input_batches_0=2, build_input_rows_0=2, input_batches_0=3, input_rows_0=2, build_mem_used_0=731, build_time_0=73.75µs, join_time_0=58.71µs, av
g_fanout_0=100% (2/2), probe_hit_rate_0=100% (2/2)]
│     CoalescePartitionsExec, metrics=[output_rows_0=2, elapsed_compute_0=6.88µs, output_bytes_0=640.0 B, output_batches_0=2]
│       [Stage 2] => NetworkCoalesceExec: output_partitions=6, input_tasks=2, metrics=[elapsed_compute_0=476.88µs, bytes_transferred_0=23.73 K, max_mem_used_0=1.54 K, network_latency_avg_
0=1.66ms, network_latency_first_0=1.81ms, network_latency_max_0=1.81ms, network_latency_min_0=1.50ms, network_latency_p99_0=1.70ms]
│     ProjectionExec: expr=[avg(weather.MaxTemp)@1 as MaxTemp, RainTomorrow@0 as RainTomorrow], metrics=[output_rows_0=2, elapsed_compute_0=2.42µs, output_bytes_0=32.1 KB, output_batches_
0=2, expr_0_eval_time_0=293ns, expr_1_eval_time_0=169ns]
│       AggregateExec: mode=FinalPartitioned, gby=[RainTomorrow@0 as RainTomorrow], aggr=[avg(weather.MaxTemp)], metrics=[output_rows_0=2, elapsed_compute_0=103.08µs, output_bytes_0=32.1
KB, output_batches_0=2, spill_count_0=0, spilled_bytes_0=0.0 B, spilled_rows_0=0, peak_mem_used_0=50.54 K, aggregate_arguments_time_0=6.29µs, aggregation_time_0=7.75µs, emitting_time_0=6.
63µs, time_calculating_group_ids_0=11.08µs]
│         [Stage 3] => NetworkShuffleExec: output_partitions=3, input_tasks=3, metrics=[elapsed_compute_0=1.01ms, bytes_transferred_0=23.26 K, max_mem_used_0=4.74 K, network_latency_avg_0
=14.65ms, network_latency_first_0=14.61ms, network_latency_max_0=16.69ms, network_latency_min_0=13.04ms, network_latency_p99_0=14.59ms]
└──────────────────────────────────────────────────
  ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p0..p2]
  │ ProjectionExec: expr=[avg(weather.MinTemp)@1 as MinTemp, RainTomorrow@0 as RainTomorrow], metrics=[output_rows_0=1, output_rows_1=1, elapsed_compute_0=1.33µs, elapsed_compute_1=1.38µs
, output_bytes_0=16.0 KB, output_bytes_1=16.0 KB, output_batches_0=1, output_batches_1=1, expr_0_eval_time_0=85ns, expr_0_eval_time_1=169ns, expr_1_eval_time_0=44ns, expr_1_eval_time_1=85
ns]
  │   AggregateExec: mode=FinalPartitioned, gby=[RainTomorrow@0 as RainTomorrow], aggr=[avg(weather.MinTemp)], metrics=[output_rows_0=1, output_rows_1=1, elapsed_compute_0=78.09µs, elapse
d_compute_1=78.17µs, output_bytes_0=16.0 KB, output_bytes_1=16.0 KB, output_batches_0=1, output_batches_1=1, spill_count_0=0, spill_count_1=0, spilled_bytes_0=0.0 B, spilled_bytes_1=0.0 B
, spilled_rows_0=0, spilled_rows_1=0, peak_mem_used_0=50.45 K, peak_mem_used_1=50.45 K, aggregate_arguments_time_0=4.38µs, aggregate_arguments_time_1=3.88µs, aggregation_time_0=7.29µs, ag
gregation_time_1=4.63µs, emitting_time_0=3.71µs, emitting_time_1=9.34µs, time_calculating_group_ids_0=7.50µs, time_calculating_group_ids_1=5.71µs]
  │     [Stage 1] => NetworkShuffleExec: output_partitions=3, input_tasks=3, metrics=[elapsed_compute_0=755.83µs, elapsed_compute_1=735.25µs, bytes_transferred_0=16.51 K, bytes_transferre
d_1=10.64 K, max_mem_used_0=3.10 K, max_mem_used_1=3.47 K, network_latency_avg_0=3.05ms, network_latency_avg_1=3.21ms, network_latency_first_0=3.41ms, network_latency_first_1=3.44ms, netw
ork_latency_max_0=3.41ms, network_latency_max_1=3.44ms, network_latency_min_0=2.67ms, network_latency_min_1=2.75ms, network_latency_p99_0=3.30ms, network_latency_p99_1=3.36ms]
  └──────────────────────────────────────────────────
    ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p0..p5] t2:[p0..p5]
    │ RepartitionExec: partitioning=Hash([RainTomorrow@0], 6), input_partitions=1, metrics=[]
    │   AggregateExec: mode=Partial, gby=[RainTomorrow@1 as RainTomorrow], aggr=[avg(weather.MinTemp)], metrics=[]
    │     FilterExec: RainToday@1 = Yes, projection=[MinTemp@0, RainTomorrow@2], metrics=[]
    │       PartitionIsolatorExec: t0:[p0,__,__] t1:[__,p0,__] t2:[__,__,p0], metrics=[]
    │         DataSourceExec: file_groups={3 groups: [[Users/jayant.shrivastava/code/datafusion-distributed/testdata/weather/result-000000.parquet], [Users/jayant.shrivastava/code/datafus
ion-distributed/testdata/weather/result-000001.parquet], [Users/jayant.shrivastava/code/datafusion-distributed/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, RainToday, R
ainTomorrow], file_type=parquet, predicate=RainToday@19 = Yes, pruning_predicate=RainToday_null_count@2 != row_count@3 AND RainToday_min@0 <= Yes AND Yes <= RainToday_max@1, required_guar
antees=[RainToday in (Yes)], metrics=[]
    └──────────────────────────────────────────────────
 ┌───── Stage 3 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2]
  │ RepartitionExec: partitioning=Hash([RainTomorrow@0], 3), input_partitions=1, metrics=[output_rows_0=2, output_rows_1=2, output_rows_2=2, elapsed_compute_0=18.50µs, elapsed_compute_1=1
7.50µs, elapsed_compute_2=21.54µs, output_bytes_0=512.0 KB, output_bytes_1=512.0 KB, output_bytes_2=512.0 KB, output_batches_0=2, output_batches_1=2, output_batches_2=2, spill_count_0=0,
spill_count_1=0, spill_count_2=0, spilled_bytes_0=0.0 B, spilled_bytes_1=0.0 B, spilled_bytes_2=0.0 B, spilled_rows_0=0, spilled_rows_1=0, spilled_rows_2=0, fetch_time_0=4.98ms, fetch_tim
e_1=7.02ms, fetch_time_2=5.60ms, repartition_time_0=12.17µs, repartition_time_1=19.62µs, repartition_time_2=19.79µs, send_time_0=4.04µs, send_time_1=5.46µs, send_time_2=6.17µs]
  │   AggregateExec: mode=Partial, gby=[RainTomorrow@1 as RainTomorrow], aggr=[avg(weather.MaxTemp)], metrics=[output_rows_0=2, output_rows_1=2, output_rows_2=2, elapsed_compute_0=57.46µs
, elapsed_compute_1=82.13µs, elapsed_compute_2=75.79µs, output_bytes_0=16.1 KB, output_bytes_1=16.1 KB, output_bytes_2=16.1 KB, output_batches_0=1, output_batches_1=1, output_batches_2=1,
 spill_count_0=0, spill_count_1=0, spill_count_2=0, spilled_bytes_0=0.0 B, spilled_bytes_1=0.0 B, spilled_bytes_2=0.0 B, spilled_rows_0=0, spilled_rows_1=0, spilled_rows_2=0, skipped_aggr
egation_rows_0=0, skipped_aggregation_rows_1=0, skipped_aggregation_rows_2=0, peak_mem_used_0=18.55 K, peak_mem_used_1=18.70 K, peak_mem_used_2=18.67 K, aggregate_arguments_time_0=1.38µs,
 aggregate_arguments_time_1=4.54µs, aggregate_arguments_time_2=3.50µs, aggregation_time_0=6.67µs, aggregation_time_1=9.00µs, aggregation_time_2=8.71µs, emitting_time_0=4.42µs, emitting_ti
me_1=5.79µs, emitting_time_2=5.88µs, time_calculating_group_ids_0=20.38µs, time_calculating_group_ids_1=28.04µs, time_calculating_group_ids_2=27.71µs, reduction_factor_0=2.2% (2/89), redu
ction_factor_1=1.9% (2/107), reduction_factor_2=1.9% (2/104)]
  │     FilterExec: RainToday@1 = No, projection=[MaxTemp@0, RainTomorrow@2], metrics=[output_rows_0=89, output_rows_1=107, output_rows_2=104, elapsed_compute_0=52.08µs, elapsed_compute_1
=44.50µs, elapsed_compute_2=44.67µs, output_bytes_0=192.0 KB, output_bytes_1=192.0 KB, output_bytes_2=192.0 KB, output_batches_0=1, output_batches_1=1, output_batches_2=1, selectivity_0=7
3% (89/122), selectivity_1=88% (107/122), selectivity_2=85% (104/122)]
  │       PartitionIsolatorExec: t0:[p0,__,__] t1:[__,p0,__] t2:[__,__,p0], metrics=[]
  │         DataSourceExec: file_groups={3 groups: [[Users/jayant.shrivastava/code/datafusion-distributed/testdata/weather/result-000000.parquet], [Users/jayant.shrivastava/code/datafusio
n-distributed/testdata/weather/result-000001.parquet], [Users/jayant.shrivastava/code/datafusion-distributed/testdata/weather/result-000002.parquet]]}, projection=[MaxTemp, RainToday, Rai
nTomorrow], file_type=parquet, predicate=RainToday@19 = No, pruning_predicate=RainToday_null_count@2 != row_count@3 AND RainToday_min@0 <= No AND No <= RainToday_max@1, required_guarantee
s=[RainToday in (No)], metrics=[output_rows_0=122, output_rows_1=122, output_rows_2=122, elapsed_compute_0=1ns, elapsed_compute_1=1ns, elapsed_compute_2=1ns, output_bytes_0=6.5 KB, output
_bytes_1=6.5 KB, output_bytes_2=6.5 KB, output_batches_0=1, output_batches_1=1, output_batches_2=1, files_ranges_pruned_statistics_0=1 total → 1 matched, files_ranges_pruned_statistics_1=
1 total → 1 matched, files_ranges_pruned_statistics_2=1 total → 1 matched, row_groups_pruned_statistics_0=1 total → 1 matched, row_groups_pruned_statistics_1=1 total → 1 matched, row_grou
ps_pruned_statistics_2=1 total → 1 matched, row_groups_pruned_bloom_filter_0=1 total → 1 matched, row_groups_pruned_bloom_filter_1=1 total → 1 matched, row_groups_pruned_bloom_filter_2=1
total → 1 matched, page_index_rows_pruned_0=122 total → 122 matched, page_index_rows_pruned_1=122 total → 122 matched, page_index_rows_pruned_2=122 total → 122 matched, batches_split_0=0,
 batches_split_1=0, batches_split_2=0, bytes_scanned_0=13.53 K, bytes_scanned_1=13.40 K, bytes_scanned_2=13.44 K, file_open_errors_0=0, file_open_errors_1=0, file_open_errors_2=0, file_sc
an_errors_0=0, file_scan_errors_1=0, file_scan_errors_2=0, num_predicate_creation_errors_0=0, num_predicate_creation_errors_1=0, num_predicate_creation_errors_2=0, predicate_cache_inner_r
ecords_0=0, predicate_cache_inner_records_1=0, predicate_cache_inner_records_2=0, predicate_cache_records_0=0, predicate_cache_records_1=0, predicate_cache_records_2=0, predicate_evaluati
on_errors_0=0, predicate_evaluation_errors_1=0, predicate_evaluation_errors_2=0, pushdown_rows_matched_0=0, pushdown_rows_matched_1=0, pushdown_rows_matched_2=0, pushdown_rows_pruned_0=0,
 pushdown_rows_pruned_1=0, pushdown_rows_pruned_2=0, bloom_filter_eval_time_0=31.00µs, bloom_filter_eval_time_1=29.88µs, bloom_filter_eval_time_2=30.75µs, metadata_load_time_0=3.82ms, met
adata_load_time_1=4.71ms, metadata_load_time_2=3.88ms, page_index_eval_time_0=54.00µs, page_index_eval_time_1=45.21µs, page_index_eval_time_2=46.71µs, row_pushdown_eval_time_0=2ns, row_pu
shdown_eval_time_1=2ns, row_pushdown_eval_time_2=2ns, statistics_eval_time_0=41.00µs, statistics_eval_time_1=33.71µs, statistics_eval_time_2=34.54µs, time_elapsed_opening_0=4.22ms, time_e
lapsed_opening_1=5.13ms, time_elapsed_opening_2=4.19ms, time_elapsed_processing_0=1.57ms, time_elapsed_processing_1=1.53ms, time_elapsed_processing_2=1.44ms, time_elapsed_scanning_total_0
=636.83µs, time_elapsed_scanning_total_1=1.77ms, time_elapsed_scanning_total_2=1.29ms, time_elapsed_scanning_until_data_0=533.79µs, time_elapsed_scanning_until_data_1=1.68ms, time_elapsed
_scanning_until_data_2=1.19ms, scan_efficiency_ratio_0=29% (13.53 K/46.08 K), scan_efficiency_ratio_1=29% (13.40 K/45.46 K), scan_efficiency_ratio_2=29% (13.44 K/45.82 K)]
  └──────────────────────────────────────────────────
```