### PR TITLE
Branch name in benchmarks

### DIFF
--- a/benchmarks/cdk/bin/datafusion-bench.ts
+++ b/benchmarks/cdk/bin/datafusion-bench.ts
@@ -132,8 +132,8 @@ class DataFusionRunner implements BenchmarkRunner {
 
 function getCurrentBranch(): string {
     try {
-        // Try to get current git branch
-        return execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8' }).trim();
+        // Try to get current git branch. For branches with a slash prefix, keep the last entry.
+        return execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8' }).trim().split("/").slice(-1)[0];
     } catch {
         // Fallback if git command fails
         return 'unknown';


### PR DESCRIPTION
Just some small tweaks to the git branch names in the benchmarks. 