### PR TITLE
fix bench data generation and docs

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -2,10 +2,13 @@
 
 ### Generating Benchmarking data
 
-Generate TPCH data into the `data/` dir
+Generate datasets into `benchmarks/data/`.
 
 ```shell
+# TPC-H (default: SCALE_FACTOR=1, PARTITIONS=16 - override by setting these environment variables)
 ./gen-tpch.sh
+
+# TPC-DS (only SCALE_FACTOR=1 is supported)
 ./gen-tpcds.sh
 ```
 
@@ -14,23 +17,25 @@ Generate TPCH data into the `data/` dir
 After generating the data with the command above, the benchmarks can be run with:
 
 ```shell
-WORKERS=0 ./benchmarks/run.sh --threads 2 --path benchmarks/data/tpch_sf1
+WORKERS=0 ./benchmarks/run.sh --threads 2 --dataset tpch_sf1
 ```
 
-- `--threads`: This is the physical threads that the Tokio runtime will use for executing the binary.
-  It's recommended to set `--threads` to something small, like `2`, for throttling each individual
-  process running queries, and simulate how adding throttled workers can speed up the queries.
-- `--path`: It can point to any folder containing benchmark datasets.
+- `--threads`: This is the physical threads that the Tokio runtime will use for executing the
+  binary. It's recommended to set `--threads` to something small, like `2`, for throttling each
+  individual process running queries, and simulate how adding throttled workers can speed up the
+  queries.
+- `--dataset`: Dataset directory name under `benchmarks/data/` (e.g. `tpch_sf1`, `tpcds_sf1`).
 
 ### Running Benchmarks benchmarks in distributed mode
 
 The same script is used for running distributed benchmarks:
 
 ```shell
-WORKERS=8 ./benchmarks/run.sh --threads 2 --path ./benchmarks/data/tpch_sf1 --files-per-task 2
+WORKERS=8 ./benchmarks/run.sh --threads 2 --dataset tpch_sf1 --files-per-task 2
 ```
 
 - `WORKERS`: Env variable that sets the amount of localhost workers used in the query.
-- `--threads`: Sets the Tokio runtime threads for each individual worker and for the benchmarking binary.
-- `--path`: It can point to any folder containing benchmark datasets.
+- `--threads`: Sets the Tokio runtime threads for each individual worker and for the benchmarking
+  binary.
+- `--dataset`: Dataset directory name under `benchmarks/data/`.
 - `--files-per-task`: How many files each distributed task will handle.

--- a/benchmarks/gen-tpcds.sh
+++ b/benchmarks/gen-tpcds.sh
@@ -10,7 +10,7 @@ echo "Generating TPC-DS dataset with SCALE_FACTOR=${SCALE_FACTOR} and PARTITIONS
 # https://stackoverflow.com/questions/59895/how-do-i-get-the-directory-where-a-bash-script-is-located-from-within-the-script
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 DATA_DIR=${DATA_DIR:-$SCRIPT_DIR/data}
-CARGO_COMMAND=${CARGO_COMMAND:-"cargo run --release"}
+CARGO_COMMAND=${CARGO_COMMAND:-"cargo run -p datafusion-distributed-benchmarks --release"}
 TPCDS_DIR="${DATA_DIR}/tpcds_sf${SCALE_FACTOR}"
 
 echo "Creating tpcds dataset at Scale Factor ${SCALE_FACTOR} in ${TPCDS_DIR}..."


### PR DESCRIPTION
**Problem 1:**
The rpcds benchmark would only let you generate data if you were in the "./benchmarks" dir. Changed so that you can do it from anywhere

before:
<img width="748" height="420" alt="Screenshot 2026-01-28 at 6 49 44 AM" src="https://github.com/user-attachments/assets/144c3c98-3082-4d59-bdc2-918a6aee9803" />

after:
<img width="755" height="233" alt="Screenshot 2026-01-28 at 6 51 03 AM" src="https://github.com/user-attachments/assets/6619b59c-1d5a-46d8-8ac6-459e83b88b13" />

**Problem 2:**
gen-tpch.sh was fialing to convert to parquet because the csv reader expected less columns than there actually was. This was because it did not properly take into account its empty trailing field.

before:
<img width="759" height="622" alt="Screenshot 2026-01-28 at 6 57 03 AM" src="https://github.com/user-attachments/assets/6ed0f3ea-b5eb-45b5-9985-06b58387b929" />

after:
<img width="755" height="514" alt="Screenshot 2026-01-28 at 6 55 32 AM" src="https://github.com/user-attachments/assets/8ff09fb4-8352-47eb-8a9a-b76f8a685548" />

**Problem 3:**
Docs were out of date and added some more info