### PR TITLE
test: reproduce metrics loss on early stream termination

### DIFF
--- a/src/flight_service/do_get.rs
+++ b/src/flight_service/do_get.rs
@@ -201,6 +201,9 @@ impl Worker {
 
             let num_partitions_remaining = Arc::clone(&stage_data.num_partitions_remaining);
             let task_data_entries = Arc::clone(&self.task_data_entries);
+            // When the stream is dropped before fully consumed (e.g. LIMIT on the client side),
+            // metrics piggybacked on the last FlightData message are lost.
+            // See https://github.com/datafusion-contrib/datafusion-distributed/issues/187
             let stream = on_drop_stream(stream, move || {
                 if !fully_finished_cloned.load(Ordering::SeqCst) {
                     // If the stream was not fully consumed, but it was dropped (abandoned), we


### PR DESCRIPTION
Adds a test reproducing the issue described in [#187](https://github.com/datafusion-contrib/datafusion-distributed/issues/187).

Since the test fails by design, it is marked as `#[ignore]`.

The underlying issue is that metrics are attached to the last `FlightData` message of the last partition stream on the worker side (in `do_get.rs`). When a `LIMIT` is present, the client-side network boundary node (e.g. `NetworkShuffleExec`) drops the stream once it has enough rows, before the worker finishes all partitions. The final message carrying the metrics is never sent or never consumed, so metrics for that stage are lost.

The test runs a `GROUP BY ... LIMIT 1` query against the `flights_1m` dataset (1M rows). The large dataset ensures the worker is still producing data when the LIMIT causes the client to drop the stream.

Note: This don't actually solve the issue, just showcases that it is really an issue!