### PR TITLE
metrics: add plan_bytes_sent to network* nodes

### DIFF
--- a/src/flight_service/worker_connection_pool.rs
+++ b/src/flight_service/worker_connection_pool.rs
@@ -148,6 +148,11 @@ impl WorkerConnection {
         let elapsed_compute_clone = elapsed_compute.clone();
         MetricBuilder::new(metrics).build(MetricValue::ElapsedCompute(elapsed_compute.clone()));
 
+        // Track the size of the serialized plan sent over the wire.
+        let plan_bytes = MetricBuilder::new(metrics).global_counter("plan_bytes_sent");
+        let plan_proto = input_stage.plan.encoded()?;
+        plan_bytes.add(plan_proto.len());
+
         // Building the actual request that will be sent to the worker.
         let mut headers = get_config_extension_propagation_headers(ctx.session_config())?;
         headers.extend(get_passthrough_headers(ctx.session_config()));
@@ -156,7 +161,7 @@ impl WorkerConnection {
             Extensions::default(),
             Ticket {
                 ticket: DoGet {
-                    plan_proto: Bytes::clone(input_stage.plan.encoded()?),
+                    plan_proto: Bytes::clone(plan_proto),
                     target_partition_start: target_partition_range.start as u64,
                     target_partition_end: target_partition_range.end as u64,
                     stage_key: Some(StageKey::new(

--- a/tests/metrics_collection.rs
+++ b/tests/metrics_collection.rs
@@ -166,6 +166,19 @@ mod tests {
         let value = node_metrics::<NetworkShuffleExec>(&d_physical, "network_latency_avg", 1);
         assert!(value > 0);
 
+        // Verify the plan_bytes_sent metric is present on network boundaries.
+        // This tracks the size of the serialized plan sent over the wire.
+        let value = node_metrics::<NetworkCoalesceExec>(&d_physical, "plan_bytes_sent", 1);
+        assert!(
+            value > 0,
+            "plan_bytes_sent should be > 0 for NetworkCoalesceExec"
+        );
+        let value = node_metrics::<NetworkShuffleExec>(&d_physical, "plan_bytes_sent", 1);
+        assert!(
+            value > 0,
+            "plan_bytes_sent should be > 0 for NetworkShuffleExec"
+        );
+
         Ok(())
     }
 


### PR DESCRIPTION
Track the size of the serialized execution plan sent over the wire in network boundary nodes (NetworkShuffleExec, NetworkCoalesceExec, NetworkBroadcastExec). This helps investigate whether large plan sizes contribute to high compute time in network shuffle operations.

Informs #184