### PR TITLE
Split DistributedPhysicalOptimizerRule into multiple, more scoped ones.

### DIFF
--- a/benchmarks/cdk/bin/worker.rs
+++ b/benchmarks/cdk/bin/worker.rs
@@ -10,8 +10,8 @@ use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::physical_plan::execute_stream;
 use datafusion::prelude::SessionContext;
 use datafusion_distributed::{
-    ChannelResolver, DistributedExt, DistributedMetricsFormat, DistributedPhysicalOptimizerRule,
-    Worker, WorkerResolver, display_plan_ascii, get_distributed_channel_resolver,
+    ChannelResolver, DistributedExt, DistributedMetricsFormat, SessionStateBuilderExt, Worker,
+    WorkerResolver, display_plan_ascii, get_distributed_channel_resolver,
     get_distributed_worker_resolver, rewrite_distributed_plan_with_metrics,
 };
 use futures::{StreamExt, TryFutureExt};
@@ -94,7 +94,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .with_default_features()
         .with_runtime_env(Arc::clone(&runtime_env))
         .with_distributed_worker_resolver(Ec2WorkerResolver::new())
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_physical_optimizer_rules()
         .with_distributed_broadcast_joins(cmd.broadcast_joins)?
         .build();
     let ctx = SessionContext::from(state);

--- a/benchmarks/src/run.rs
+++ b/benchmarks/src/run.rs
@@ -30,13 +30,10 @@ use datafusion::prelude::*;
 use datafusion_distributed::test_utils::benchmarks_common;
 use datafusion_distributed::test_utils::localhost::LocalHostWorkerResolver;
 use datafusion_distributed::test_utils::{clickbench, tpcds, tpch};
-use datafusion_distributed::{
-    DistributedExt, DistributedPhysicalOptimizerRule, NetworkBoundaryExt, Worker,
-};
+use datafusion_distributed::{DistributedExt, NetworkBoundaryExt, SessionStateBuilderExt, Worker};
 use std::error::Error;
 use std::fs;
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::time::Duration;
 use structopt::StructOpt;
 use tokio::net::TcpListener;
@@ -179,7 +176,7 @@ impl RunOpt {
             .with_default_features()
             .with_config(self.config()?)
             .with_distributed_worker_resolver(LocalHostWorkerResolver::new(self.workers.clone()))
-            .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+            .with_distributed_physical_optimizer_rules()
             .with_distributed_files_per_task(
                 self.files_per_task.unwrap_or(get_available_parallelism()),
             )?

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -36,7 +36,7 @@ use datafusion_cli::{
 use datafusion_distributed::test_utils::in_memory_channel_resolver::{
     InMemoryChannelResolver, InMemoryWorkerResolver,
 };
-use datafusion_distributed::{DistributedExt, DistributedPhysicalOptimizerRule};
+use datafusion_distributed::{DistributedExt, SessionStateBuilderExt};
 use std::env;
 use std::path::Path;
 use std::process::ExitCode;
@@ -148,7 +148,7 @@ async fn main_inner() -> Result<()> {
         .with_default_features()
         .with_config(session_config)
         .with_runtime_env(runtime_env)
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_physical_optimizer_rules()
         .with_distributed_worker_resolver(InMemoryWorkerResolver::new(16))
         .with_distributed_channel_resolver(InMemoryChannelResolver::default())
         .build();

--- a/console/examples/console_run.rs
+++ b/console/examples/console_run.rs
@@ -4,7 +4,7 @@ use datafusion::common::DataFusionError;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::prelude::{ParquetReadOptions, SessionContext};
 use datafusion_distributed::{
-    DistributedExt, DistributedPhysicalOptimizerRule, WorkerResolver, display_plan_ascii,
+    DistributedExt, SessionStateBuilderExt, WorkerResolver, display_plan_ascii,
 };
 use futures::TryStreamExt;
 use std::error::Error;
@@ -39,7 +39,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let state = SessionStateBuilder::new()
         .with_default_features()
         .with_distributed_worker_resolver(localhost_resolver)
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_physical_optimizer_rules()
         .with_distributed_files_per_task(1)?
         .build();
 

--- a/console/examples/tpcds_runner.rs
+++ b/console/examples/tpcds_runner.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use datafusion::common::DataFusionError;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::prelude::SessionContext;
-use datafusion_distributed::{DistributedExt, DistributedPhysicalOptimizerRule, WorkerResolver};
+use datafusion_distributed::{DistributedExt, SessionStateBuilderExt, WorkerResolver};
 use std::error::Error;
 use std::path::Path;
 use std::sync::Arc;
@@ -74,7 +74,7 @@ async fn run_queries(
     let state = SessionStateBuilder::new()
         .with_default_features()
         .with_distributed_worker_resolver(localhost_resolver)
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_physical_optimizer_rules()
         .build();
 
     let ctx = SessionContext::from(state);

--- a/docs/source/user-guide/channel-resolver.md
+++ b/docs/source/user-guide/channel-resolver.md
@@ -43,7 +43,7 @@ async fn main() {
     let state = SessionStateBuilder::new()
         // these two are mandatory.
         .with_distributed_worker_resolver(todo!())
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_physical_optimizer_rules()
         // the CustomChannelResolver needs to be passed here once...
         .with_distributed_channel_resolver(channel_resolver.clone())
         .build();

--- a/docs/source/user-guide/concepts.md
+++ b/docs/source/user-guide/concepts.md
@@ -24,14 +24,6 @@ You'll see these concepts mentioned extensively across the documentation and the
 
 Some other more tangible concepts are the structs and traits exposed publicly, the most important are:
 
-## [DistributedPhysicalOptimizerRule](https://github.com/datafusion-contrib/datafusion-distributed/blob/main/src/distributed_planner/distributed_physical_optimizer_rule.rs)
-
-A physical optimizer rule that transforms single-node DataFusion query plans into distributed query plans. It reads
-a fully formed physical plan and injects the appropriate nodes to execute the query in a distributed fashion.
-
-It builds the distributed plan from bottom to top, injecting network boundaries at appropriate locations based on
-the nodes present in the original plan.
-
 ## [Worker](https://github.com/datafusion-contrib/datafusion-distributed/blob/main/src/flight_service/worker.rs)
 
 Arrow Flight server implementation that integrates with the Tonic ecosystem and listens to serialized plans that get
@@ -70,3 +62,12 @@ data. If you are on the task with index 2, you might want to return the last 1/3
 
 Optional extension trait that allows to customize how connections are established to workers. Given one of the
 URLs returned by the `WorkerResolver`, it builds an Arrow Flight client ready for serving queries.
+
+## [NetworkBoundaryPlaceholder](https://github.com/datafusion-contrib/datafusion-distributed/blob/main/src/distributed_planner/network_boundary_placeholder.rs)
+
+A custom ExecutionPlan implementation that acts as a placeholder for the distributed planner to place network boundaries
+that spawn the specified amount of tasks.
+
+Users can create their own physical optimizer rules and place them before this project's ApplyNetworkBoundaries rule
+in order to customize their distributed plan.
+

--- a/docs/source/user-guide/getting-started.md
+++ b/docs/source/user-guide/getting-started.md
@@ -49,7 +49,7 @@ impl WorkerResolver for LocalhostWorkerResolver {
 }
 ```
 
-Register both the `WorkerResolver` implementation and the `DistributedPhysicalOptimizerRule` in DataFusion's
+Register both the `WorkerResolver` implementation and the distributed physical optimization rules in DataFusion's
 `SessionStateBuilder` to enable distributed query planning:
 
 ```rs
@@ -59,7 +59,7 @@ let localhost_worker_resolver = LocalhostWorkerResolver {
 
 let state = SessionStateBuilder::new()
     .with_distributed_worker_resolver(localhost_worker_resolver)
-    .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+    .with_distributed_physical_optimizer_rules()
     .build();
 
 let ctx = SessionContext::from(state);

--- a/docs/source/user-guide/worker-resolver.md
+++ b/docs/source/user-guide/worker-resolver.md
@@ -24,7 +24,7 @@ impl WorkerResolver for CustomWorkerResolver {
 async fn main() {
     let state = SessionStateBuilder::new()
         .with_distributed_worker_resolver(CustomWorkerResolver)
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_physical_optimizer_rules()
         .build();
 }
 ```

--- a/examples/custom_execution_plan.rs
+++ b/examples/custom_execution_plan.rs
@@ -39,8 +39,8 @@ use datafusion_distributed::test_utils::in_memory_channel_resolver::{
     InMemoryChannelResolver, InMemoryWorkerResolver,
 };
 use datafusion_distributed::{
-    DistributedExt, DistributedPhysicalOptimizerRule, DistributedTaskContext, TaskEstimation,
-    TaskEstimator, WorkerQueryContext, display_plan_ascii,
+    DistributedExt, DistributedTaskContext, SessionStateBuilderExt, TaskEstimation, TaskEstimator,
+    WorkerQueryContext, display_plan_ascii,
 };
 use datafusion_proto::physical_plan::PhysicalExtensionCodec;
 use datafusion_proto::protobuf;
@@ -382,7 +382,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_config(config)
         .with_distributed_worker_resolver(worker_resolver)
         .with_distributed_channel_resolver(channel_resolver)
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_physical_optimizer_rules()
         .with_distributed_user_codec(NumbersExecCodec)
         .with_distributed_task_estimator(NumbersTaskEstimator)
         .build();

--- a/examples/in_memory_cluster.rs
+++ b/examples/in_memory_cluster.rs
@@ -5,13 +5,12 @@ use datafusion::common::DataFusionError;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::prelude::{ParquetReadOptions, SessionContext};
 use datafusion_distributed::{
-    BoxCloneSyncChannel, ChannelResolver, DistributedExt, DistributedPhysicalOptimizerRule, Worker,
+    BoxCloneSyncChannel, ChannelResolver, DistributedExt, SessionStateBuilderExt, Worker,
     WorkerQueryContext, WorkerResolver, create_flight_client, display_plan_ascii,
 };
 use futures::TryStreamExt;
 use hyper_util::rt::TokioIo;
 use std::error::Error;
-use std::sync::Arc;
 use structopt::StructOpt;
 use tonic::transport::{Endpoint, Server};
 
@@ -38,7 +37,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .with_default_features()
         .with_distributed_worker_resolver(InMemoryWorkerResolver)
         .with_distributed_channel_resolver(InMemoryChannelResolver::new())
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_physical_optimizer_rules()
         .with_distributed_files_per_task(1)?
         .build();
 

--- a/examples/localhost_run.rs
+++ b/examples/localhost_run.rs
@@ -4,11 +4,10 @@ use datafusion::common::DataFusionError;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::prelude::{ParquetReadOptions, SessionContext};
 use datafusion_distributed::{
-    DistributedExt, DistributedPhysicalOptimizerRule, WorkerResolver, display_plan_ascii,
+    DistributedExt, SessionStateBuilderExt, WorkerResolver, display_plan_ascii,
 };
 use futures::TryStreamExt;
 use std::error::Error;
-use std::sync::Arc;
 use structopt::StructOpt;
 use url::Url;
 
@@ -39,7 +38,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let state = SessionStateBuilder::new()
         .with_default_features()
         .with_distributed_worker_resolver(localhost_resolver)
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_physical_optimizer_rules()
         .with_distributed_files_per_task(1)?
         .build();
 

--- a/src/distributed_ext.rs
+++ b/src/distributed_ext.rs
@@ -198,7 +198,7 @@ pub trait DistributedExt: Sized {
     /// # use datafusion::prelude::SessionConfig;
     /// # use url::Url;
     /// # use std::sync::Arc;
-    /// # use datafusion_distributed::{BoxCloneSyncChannel, WorkerResolver, DistributedExt, DistributedPhysicalOptimizerRule, WorkerQueryContext};
+    /// # use datafusion_distributed::{BoxCloneSyncChannel, WorkerResolver, DistributedExt, SessionStateBuilderExt, WorkerQueryContext};
     ///
     /// struct CustomWorkerResolver;
     ///
@@ -212,9 +212,8 @@ pub trait DistributedExt: Sized {
     /// // This tweaks the SessionState so that it can plan for distributed queries and execute them.
     /// let state = SessionStateBuilder::new()
     ///     .with_distributed_worker_resolver(CustomWorkerResolver)
-    ///     // the DistributedPhysicalOptimizerRule also needs to be passed so that query plans
-    ///     // get distributed.
-    ///     .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+    ///     // Adds the necessary rules so that the query gets distributed.
+    ///     .with_distributed_physical_optimizer_rules()
     ///     .build();
     /// ```
     fn with_distributed_worker_resolver<T: WorkerResolver + Send + Sync + 'static>(
@@ -243,7 +242,7 @@ pub trait DistributedExt: Sized {
     /// # use datafusion::prelude::SessionConfig;
     /// # use url::Url;
     /// # use std::sync::Arc;
-    /// # use datafusion_distributed::{BoxCloneSyncChannel, ChannelResolver, DistributedExt, DistributedPhysicalOptimizerRule, WorkerQueryContext};
+    /// # use datafusion_distributed::{BoxCloneSyncChannel, ChannelResolver, DistributedExt, WorkerQueryContext, SessionStateBuilderExt};
     ///
     /// struct CustomChannelResolver;
     ///
@@ -258,9 +257,8 @@ pub trait DistributedExt: Sized {
     /// // This tweaks the SessionState so that it can plan for distributed queries and execute them.
     /// let state = SessionStateBuilder::new()
     ///     .with_distributed_channel_resolver(CustomChannelResolver)
-    ///     // the DistributedPhysicalOptimizerRule also needs to be passed so that query plans
-    ///     // get distributed.
-    ///     .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+    ///     // Adds the necessary rules so that the query gets distributed.
+    ///     .with_distributed_physical_optimizer_rules()
     ///     .build();
     ///
     /// // This function can be provided to a Worker so that, upon receiving a distributed

--- a/src/distributed_planner/distributed_config.rs
+++ b/src/distributed_planner/distributed_config.rs
@@ -118,8 +118,8 @@ impl ConfigExtension for DistributedConfig {
 // FIXME: Ideally, both ChannelResolverExtension and TaskEstimators would be passed as
 //  extensions in SessionConfig's AnyMap instead of the ConfigOptions. However, we need
 //  to pass this as ConfigOptions as we need these two fields to be present during
-//  planning in the DistributedPhysicalOptimizerRule, and the signature of the optimize()
-//  method there accepts a ConfigOptions instead of a SessionConfig.
+//  distributed planning, and the signature of the optimize()  method there accepts a
+//  ConfigOptions instead of a SessionConfig.
 //  The following PR addresses this: https://github.com/apache/datafusion/pull/18168
 //  but it still has not been accepted or merged.
 //  Because of this, all the boilerplate trait implementations below are needed.

--- a/src/distributed_planner/distributed_context.rs
+++ b/src/distributed_planner/distributed_context.rs
@@ -1,18 +1,24 @@
 use crate::common::require_one_child;
-use crate::distributed_planner::rules::AnnotatedPlan;
 use datafusion::common::{Result, not_impl_err, plan_err};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use std::any::Any;
 use std::fmt::Formatter;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
+/// [ExecutionPlan] implementation that sits immediately above another plan, and is there just to
+/// add contextual information for distributed planning.
+///
+/// All [PhysicalOptimizerRule]s are expected to accept a [DistributedContext] as a head node, and
+/// return a [DistributedContext] after the [PhysicalOptimizerRule::optimize] pass.
+///
+/// Users implementing custom [PhysicalOptimizerRule]s for Distributed DataFusion should always
+/// call [DistributedContext::ensure] at the beginning of their rule.
 #[derive(Debug)]
 pub struct DistributedContext {
     pub(crate) original_single_node_plan: Arc<dyn ExecutionPlan>,
     pub(crate) plan: Arc<dyn ExecutionPlan>,
-    pub(crate) annotated_plan: Mutex<Option<AnnotatedPlan>>,
 }
 
 impl DistributedContext {
@@ -20,10 +26,40 @@ impl DistributedContext {
         Self {
             original_single_node_plan: Arc::clone(&plan),
             plan,
-            annotated_plan: Mutex::new(None),
         }
     }
 
+    /// Ensures that the [PhysicalOptimizerRule] is running under a [DistributedContext].
+    ///
+    /// This function is expected to be called at the beginning of each [PhysicalOptimizerRule]:
+    ///
+    /// ```rust
+    /// # use datafusion::physical_optimizer::PhysicalOptimizerRule;
+    /// # use datafusion::physical_plan::ExecutionPlan;
+    /// # use datafusion::config::ConfigOptions;
+    /// # use datafusion::common::Result;
+    /// # use datafusion_distributed::DistributedContext;
+    /// # use std::sync::Arc;
+    ///
+    /// #[derive(Debug)]
+    /// pub struct MyRule;
+    ///
+    /// impl PhysicalOptimizerRule for MyRule {
+    ///     fn optimize(&self, plan: Arc<dyn ExecutionPlan>, config: &ConfigOptions) -> Result<Arc<dyn ExecutionPlan>> {
+    ///         DistributedContext::ensure(self, &plan)?;
+    ///         // Add your logic here
+    ///         Ok(plan)
+    ///     }
+    ///  
+    ///     fn name(&self) -> &str {
+    ///         "MyRule"
+    ///     }
+    ///
+    ///     fn schema_check(&self) -> bool {
+    ///         true
+    ///     }
+    /// }
+    /// ```
     pub fn ensure<'a>(
         rule: &dyn PhysicalOptimizerRule,
         plan: &'a Arc<dyn ExecutionPlan>,
@@ -77,7 +113,6 @@ impl ExecutionPlan for DistributedContext {
         Ok(Arc::new(Self {
             original_single_node_plan: Arc::clone(&self.original_single_node_plan),
             plan: require_one_child(children)?,
-            annotated_plan: Mutex::new(self.annotated_plan.lock().unwrap().take()),
         }))
     }
 

--- a/src/distributed_planner/distributed_context.rs
+++ b/src/distributed_planner/distributed_context.rs
@@ -1,0 +1,87 @@
+use crate::common::require_one_child;
+use crate::distributed_planner::rules::AnnotatedPlan;
+use datafusion::common::{Result, not_impl_err, plan_err};
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use std::any::Any;
+use std::fmt::Formatter;
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug)]
+pub struct DistributedContext {
+    pub(crate) original_single_node_plan: Arc<dyn ExecutionPlan>,
+    pub(crate) plan: Arc<dyn ExecutionPlan>,
+    pub(crate) annotated_plan: Mutex<Option<AnnotatedPlan>>,
+}
+
+impl DistributedContext {
+    pub(crate) fn new(plan: Arc<dyn ExecutionPlan>) -> Self {
+        Self {
+            original_single_node_plan: Arc::clone(&plan),
+            plan,
+            annotated_plan: Mutex::new(None),
+        }
+    }
+
+    pub fn ensure<'a>(
+        rule: &dyn PhysicalOptimizerRule,
+        plan: &'a Arc<dyn ExecutionPlan>,
+    ) -> Result<&'a Self> {
+        let Some(this) = plan.as_any().downcast_ref::<Self>() else {
+            return plan_err!(
+                "Rule {} received a plan {}, but {} was expected.",
+                rule.name(),
+                plan.name(),
+                Self::static_name()
+            );
+        };
+        if this.plan.as_any().is::<Self>() {
+            let name = Self::static_name();
+            return plan_err!(
+                "Rule {} received a {name}, but it had another nexted {name} in it. There is an error in one of the PhysicalOptimizerRules that is double-nesting {name}.",
+                rule.name()
+            );
+        }
+        Ok(this)
+    }
+}
+
+impl DisplayAs for DistributedContext {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "DistributedContext")
+    }
+}
+
+impl ExecutionPlan for DistributedContext {
+    fn name(&self) -> &str {
+        "DistributedContext"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        self.plan.properties()
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.plan]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(Self {
+            original_single_node_plan: Arc::clone(&self.original_single_node_plan),
+            plan: require_one_child(children)?,
+            annotated_plan: Mutex::new(self.annotated_plan.lock().unwrap().take()),
+        }))
+    }
+
+    fn execute(&self, _: usize, _: Arc<TaskContext>) -> Result<SendableRecordBatchStream> {
+        not_impl_err!("DistributedContext does not support execution!")
+    }
+}

--- a/src/distributed_planner/mod.rs
+++ b/src/distributed_planner/mod.rs
@@ -1,14 +1,16 @@
-mod batch_coalescing_below_network_boundaries;
 mod distributed_config;
-mod distributed_physical_optimizer_rule;
-mod insert_broadcast;
+mod distributed_context;
 mod network_boundary;
-mod plan_annotator;
+mod rules;
+mod session_state_builder_ext;
 mod task_estimator;
 
-pub(crate) use batch_coalescing_below_network_boundaries::batch_coalescing_below_network_boundaries;
 pub use distributed_config::DistributedConfig;
-pub use distributed_physical_optimizer_rule::DistributedPhysicalOptimizerRule;
 pub use network_boundary::{NetworkBoundary, NetworkBoundaryExt};
+pub use rules::{
+    AddCoalesceOnTop, AnnotatePlan, ApplyNetworkBoundaries, BatchCoalesceBelowBoundaries,
+    EndDistributedContext, InsertBroadcast, StartDistributedContext,
+};
+pub use session_state_builder_ext::SessionStateBuilderExt;
 pub(crate) use task_estimator::set_distributed_task_estimator;
 pub use task_estimator::{TaskCountAnnotation, TaskEstimation, TaskEstimator};

--- a/src/distributed_planner/mod.rs
+++ b/src/distributed_planner/mod.rs
@@ -1,15 +1,18 @@
 mod distributed_config;
 mod distributed_context;
 mod network_boundary;
+mod network_boundary_placeholder;
 mod rules;
 mod session_state_builder_ext;
 mod task_estimator;
 
 pub use distributed_config::DistributedConfig;
+pub use distributed_context::DistributedContext;
 pub use network_boundary::{NetworkBoundary, NetworkBoundaryExt};
+pub use network_boundary_placeholder::{NetworkBoundaryKind, NetworkBoundaryPlaceholder};
 pub use rules::{
-    AddCoalesceOnTop, AnnotatePlan, ApplyNetworkBoundaries, BatchCoalesceBelowBoundaries,
-    EndDistributedContext, InsertBroadcast, StartDistributedContext,
+    AddCoalesceOnTop, ApplyNetworkBoundaries, BatchCoalesceBelowBoundaries, EndDistributedContext,
+    InjectNetworkBoundaryPlaceholders, InsertBroadcast, StartDistributedContext,
 };
 pub use session_state_builder_ext::SessionStateBuilderExt;
 pub(crate) use task_estimator::set_distributed_task_estimator;

--- a/src/distributed_planner/network_boundary_placeholder.rs
+++ b/src/distributed_planner/network_boundary_placeholder.rs
@@ -1,0 +1,87 @@
+use crate::common::require_one_child;
+use datafusion::common::{Result, not_impl_err};
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use std::any::Any;
+use std::fmt::Formatter;
+use std::sync::Arc;
+
+/// [ExecutionPlan] implementation that acts as a simple placeholder for the distributed planner
+/// to know when a `NetworkBoundary` should be injected.
+///
+/// This structure is part of the public API, and it's what allows users of this library to decide
+/// where should the network boundaries be placed, and what task count should be used for the
+/// stage below.
+///
+/// Note that there are restrictions around where can the [NetworkBoundaryPlaceholder]s be placed,
+/// for example:
+/// - A [NetworkBoundaryKind::Broadcast] needs to be placed right above a `BroadcastExec` node.
+/// - A [NetworkBoundaryKind::Shuffle] needs to be placed right about a `RepartitionExec` node.
+///
+/// Failure to do so will result in planning errors.
+#[derive(Debug)]
+pub struct NetworkBoundaryPlaceholder {
+    /// The kind of network boundary that should be injected.
+    pub kind: NetworkBoundaryKind,
+    /// The task count for the input stage of this network boundary.
+    ///
+    /// Note that the task count for this network boundary is decided by the other network boundary
+    /// immediately above, and not this one.
+    pub input_task_count: usize,
+    /// The input [ExecutionPlan] that will run remotely on the stage below.
+    pub input: Arc<dyn ExecutionPlan>,
+}
+
+/// The type of network boundary that should be injected:
+/// - [NetworkBoundaryKind::Shuffle] -> `NetworkShuffleExec`
+/// - [NetworkBoundaryKind::Coalesce] -> `NetworkCoalesceExec`
+/// - [NetworkBoundaryKind::Broadcast] -> `NetworkBroadcastExec`
+#[derive(Debug, Clone)]
+pub enum NetworkBoundaryKind {
+    Shuffle,
+    Coalesce,
+    Broadcast,
+}
+
+impl DisplayAs for NetworkBoundaryPlaceholder {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "NetworkBoundaryPlaceholder: kind={:?}, input_tasks={}",
+            self.kind, self.input_task_count
+        )
+    }
+}
+
+impl ExecutionPlan for NetworkBoundaryPlaceholder {
+    fn name(&self) -> &str {
+        "NetworkBoundaryPlaceholder"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        self.input.properties()
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(Self {
+            kind: self.kind.clone(),
+            input_task_count: self.input_task_count,
+            input: require_one_child(children)?,
+        }))
+    }
+
+    fn execute(&self, _: usize, _: Arc<TaskContext>) -> Result<SendableRecordBatchStream> {
+        not_impl_err!("NetworkBoundaryPlaceholder does not support execution.")
+    }
+}

--- a/src/distributed_planner/rules/mod.rs
+++ b/src/distributed_planner/rules/mod.rs
@@ -1,0 +1,17 @@
+mod rule_1_start_distributed_context;
+mod rule_2_add_coalesce_on_top;
+mod rule_3_insert_broadcast;
+mod rule_4_annotate_plan;
+mod rule_5_apply_network_boundaries;
+mod rule_6_batch_coalesce_below_boundaries;
+mod rule_7_end_distributed_context;
+
+pub use rule_1_start_distributed_context::StartDistributedContext;
+pub use rule_2_add_coalesce_on_top::AddCoalesceOnTop;
+pub use rule_3_insert_broadcast::InsertBroadcast;
+pub use rule_4_annotate_plan::AnnotatePlan;
+pub use rule_5_apply_network_boundaries::ApplyNetworkBoundaries;
+pub use rule_6_batch_coalesce_below_boundaries::BatchCoalesceBelowBoundaries;
+pub use rule_7_end_distributed_context::EndDistributedContext;
+
+pub(crate) use rule_4_annotate_plan::AnnotatedPlan;

--- a/src/distributed_planner/rules/mod.rs
+++ b/src/distributed_planner/rules/mod.rs
@@ -1,7 +1,7 @@
 mod rule_1_start_distributed_context;
 mod rule_2_add_coalesce_on_top;
 mod rule_3_insert_broadcast;
-mod rule_4_annotate_plan;
+mod rule_4_inject_network_boundary_placeholders;
 mod rule_5_apply_network_boundaries;
 mod rule_6_batch_coalesce_below_boundaries;
 mod rule_7_end_distributed_context;
@@ -9,9 +9,7 @@ mod rule_7_end_distributed_context;
 pub use rule_1_start_distributed_context::StartDistributedContext;
 pub use rule_2_add_coalesce_on_top::AddCoalesceOnTop;
 pub use rule_3_insert_broadcast::InsertBroadcast;
-pub use rule_4_annotate_plan::AnnotatePlan;
+pub use rule_4_inject_network_boundary_placeholders::InjectNetworkBoundaryPlaceholders;
 pub use rule_5_apply_network_boundaries::ApplyNetworkBoundaries;
 pub use rule_6_batch_coalesce_below_boundaries::BatchCoalesceBelowBoundaries;
 pub use rule_7_end_distributed_context::EndDistributedContext;
-
-pub(crate) use rule_4_annotate_plan::AnnotatedPlan;

--- a/src/distributed_planner/rules/rule_1_start_distributed_context.rs
+++ b/src/distributed_planner/rules/rule_1_start_distributed_context.rs
@@ -1,0 +1,30 @@
+use crate::distributed_planner::distributed_context::DistributedContext;
+use datafusion::common::Result;
+use datafusion::config::ConfigOptions;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::ExecutionPlan;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct StartDistributedContext;
+
+impl PhysicalOptimizerRule for StartDistributedContext {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if plan.as_any().is::<DistributedContext>() {
+            return Ok(plan);
+        }
+        Ok(Arc::new(DistributedContext::new(plan)))
+    }
+
+    fn name(&self) -> &str {
+        "StartDistributedContext"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}

--- a/src/distributed_planner/rules/rule_2_add_coalesce_on_top.rs
+++ b/src/distributed_planner/rules/rule_2_add_coalesce_on_top.rs
@@ -1,0 +1,34 @@
+use crate::distributed_planner::distributed_context::DistributedContext;
+use datafusion::common::Result;
+use datafusion::config::ConfigOptions;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct AddCoalesceOnTop;
+
+impl PhysicalOptimizerRule for AddCoalesceOnTop {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let d_ctx = DistributedContext::ensure(self, &plan)?;
+
+        if d_ctx.plan.output_partitioning().partition_count() > 1 {
+            let child = Arc::clone(&d_ctx.plan);
+            return plan.with_new_children(vec![Arc::new(CoalescePartitionsExec::new(child))]);
+        }
+        Ok(plan)
+    }
+
+    fn name(&self) -> &str {
+        "AddCoalesceOnTop"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}

--- a/src/distributed_planner/rules/rule_3_insert_broadcast.rs
+++ b/src/distributed_planner/rules/rule_3_insert_broadcast.rs
@@ -1,18 +1,15 @@
-use std::sync::Arc;
-
+use crate::distributed_planner::distributed_context::DistributedContext;
+use crate::{BroadcastExec, DistributedConfig};
 use datafusion::common::JoinType;
 use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::config::ConfigOptions;
-use datafusion::error::DataFusionError;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::joins::{HashJoinExec, PartitionMode};
+use std::sync::Arc;
 
-use crate::BroadcastExec;
-
-use super::DistributedConfig;
-
-/// This is a top-down traversal of a [ExecutionPlan] that inserts [BroadcastExec] opeerators where
+/// This is a top-down traversal of a [ExecutionPlan] that inserts [BroadcastExec] operators where
 /// appropriate.
 ///
 /// # What is it doing?
@@ -108,82 +105,95 @@ use super::DistributedConfig;
 /// Worker 1 would emit: (2, Alice), (3, Bob)
 /// Worker 2 would emit: (1, John), (3, Bob)
 /// Thus when unioning results: (2, Alice), (3, Bob), (1, John), (3, Bob)
-/// ```
-///
-/// ```
-pub(super) fn insert_broadcast_execs(
-    plan: Arc<dyn ExecutionPlan>,
-    cfg: &ConfigOptions,
-) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-    let d_cfg = DistributedConfig::from_config_options(cfg)?;
-    if !d_cfg.broadcast_joins {
-        return Ok(plan);
+#[derive(Debug)]
+pub struct InsertBroadcast;
+
+impl PhysicalOptimizerRule for InsertBroadcast {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        cfg: &ConfigOptions,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        DistributedContext::ensure(self, &plan)?;
+
+        let d_cfg = DistributedConfig::from_config_options(cfg)?;
+        if !d_cfg.broadcast_joins {
+            return Ok(plan);
+        }
+
+        plan.transform_down(|node| {
+            let Some(hash_join) = node.as_any().downcast_ref::<HashJoinExec>() else {
+                return Ok(Transformed::no(node));
+            };
+            if hash_join.partition_mode() != &PartitionMode::CollectLeft {
+                return Ok(Transformed::no(node));
+            }
+
+            // Only broadcast when output is driven by the probe side.
+            // Joins that can emit build-side rows (left/left-semi/left-anti/left-mark/full) would
+            // duplicate output if the build is broadcast, thus are excluded.
+            let join_type = hash_join.join_type();
+            if !matches!(
+                join_type,
+                JoinType::Inner
+                    | JoinType::Right
+                    | JoinType::RightSemi
+                    | JoinType::RightAnti
+                    | JoinType::RightMark
+            ) {
+                return Ok(Transformed::no(node));
+            }
+
+            let children = node.children();
+            let Some(build_child) = children.first() else {
+                return Ok(Transformed::no(node));
+            };
+
+            // If build child is CoalescePartitionsExec get its input
+            // Otherwise, use the build child directly (DataSourceExec)
+            let broadcast_input = if let Some(coalesce) = build_child
+                .as_any()
+                .downcast_ref::<CoalescePartitionsExec>()
+            {
+                Arc::clone(coalesce.input())
+            } else {
+                Arc::clone(build_child)
+            };
+
+            // Insert BroadcastExec. consumer_task_count=1 is a placeholder and
+            // will be corrected during optimizer rule.
+            let broadcast = Arc::new(BroadcastExec::new(
+                broadcast_input,
+                1, // placeholder
+            ));
+
+            // Always wrap with CoalescePartitionsExec
+            let new_build_child: Arc<dyn ExecutionPlan> =
+                Arc::new(CoalescePartitionsExec::new(broadcast));
+
+            let mut new_children: Vec<Arc<dyn ExecutionPlan>> =
+                children.into_iter().cloned().collect();
+            new_children[0] = new_build_child;
+            Ok(Transformed::yes(node.with_new_children(new_children)?))
+        })
+        .map(|transformed| transformed.data)
     }
 
-    plan.transform_down(|node| {
-        let Some(hash_join) = node.as_any().downcast_ref::<HashJoinExec>() else {
-            return Ok(Transformed::no(node));
-        };
-        if hash_join.partition_mode() != &PartitionMode::CollectLeft {
-            return Ok(Transformed::no(node));
-        }
+    fn name(&self) -> &str {
+        "InsertBroadcast"
+    }
 
-        // Only broadcast when output is driven by the probe side.
-        // Joins that can emit build-side rows (left/left-semi/left-anti/left-mark/full) would
-        // duplicate output if the build is broadcast, thus are excluded.
-        let join_type = hash_join.join_type();
-        if !matches!(
-            join_type,
-            JoinType::Inner
-                | JoinType::Right
-                | JoinType::RightSemi
-                | JoinType::RightAnti
-                | JoinType::RightMark
-        ) {
-            return Ok(Transformed::no(node));
-        }
-
-        let children = node.children();
-        let Some(build_child) = children.first() else {
-            return Ok(Transformed::no(node));
-        };
-
-        // If build child is CoalescePartitionsExec get its input
-        // Otherwise, use the build child directly (DataSourceExec)
-        let broadcast_input = if let Some(coalesce) = build_child
-            .as_any()
-            .downcast_ref::<CoalescePartitionsExec>()
-        {
-            Arc::clone(coalesce.input())
-        } else {
-            Arc::clone(build_child)
-        };
-
-        // Insert BroadcastExec. consumer_task_count=1 is a placeholder and
-        // will be corrected during optimizer rule.
-        let broadcast = Arc::new(BroadcastExec::new(
-            broadcast_input,
-            1, // placeholder
-        ));
-
-        // Always wrap with CoalescePartitionsExec
-        let new_build_child: Arc<dyn ExecutionPlan> =
-            Arc::new(CoalescePartitionsExec::new(broadcast));
-
-        let mut new_children: Vec<Arc<dyn ExecutionPlan>> = children.into_iter().cloned().collect();
-        new_children[0] = new_build_child;
-        Ok(Transformed::yes(node.with_new_children(new_children)?))
-    })
-    .map(|transformed| transformed.data)
+    fn schema_check(&self) -> bool {
+        true
+    }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::assert_snapshot;
     use crate::test_utils::plans::{
         TestPlanOptions, base_session_builder, context_with_query, sql_to_physical_plan,
     };
+    use crate::{StartDistributedContext, assert_snapshot};
     use datafusion::physical_plan::displayable;
 
     #[tokio::test]
@@ -282,9 +292,16 @@ mod tests {
         );
         let (ctx, query) = context_with_query(builder, query).await;
         let df = ctx.sql(&query).await.unwrap();
-        let plan = df.create_physical_plan().await.unwrap();
-        let plan = insert_broadcast_execs(plan, ctx.state_ref().read().config_options().as_ref())
-            .expect("failed to insert broadcasts");
-        format!("{}", displayable(plan.as_ref()).indent(true))
+        let mut plan = df.create_physical_plan().await.unwrap();
+        let state_ref = ctx.state_ref();
+        let state = state_ref.read();
+        let cfg = state.config_options().as_ref();
+
+        plan = StartDistributedContext.optimize(plan, cfg).unwrap();
+        plan = InsertBroadcast.optimize(plan, cfg).unwrap();
+
+        let d_ctx = plan.as_any().downcast_ref::<DistributedContext>().unwrap();
+
+        format!("{}", displayable(d_ctx.plan.as_ref()).indent(true))
     }
 }

--- a/src/distributed_planner/rules/rule_4_annotate_plan.rs
+++ b/src/distributed_planner/rules/rule_4_annotate_plan.rs
@@ -1,9 +1,11 @@
 use crate::TaskCountAnnotation::{Desired, Maximum};
+use crate::distributed_planner::distributed_context::DistributedContext;
 use crate::execution_plans::ChildrenIsolatorUnionExec;
 use crate::{BroadcastExec, DistributedConfig, TaskCountAnnotation, TaskEstimator};
-use datafusion::common::{DataFusionError, plan_datafusion_err};
+use datafusion::common::{DataFusionError, Result, plan_datafusion_err};
 use datafusion::config::ConfigOptions;
 use datafusion::physical_expr::Partitioning;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::execution_plan::CardinalityEffect;
@@ -13,6 +15,35 @@ use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMerge
 use datafusion::physical_plan::union::UnionExec;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct AnnotatePlan;
+
+impl PhysicalOptimizerRule for AnnotatePlan {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let d_ctx = DistributedContext::ensure(self, &plan)?;
+
+        d_ctx.annotated_plan.lock().unwrap().replace(annotate_plan(
+            Arc::clone(&d_ctx.plan),
+            None,
+            config,
+            true,
+        )?);
+        Ok(plan)
+    }
+
+    fn name(&self) -> &str {
+        "AnnotatePlan"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}
 
 /// Annotation attached to a single [ExecutionPlan] that determines the kind of network boundary
 /// needed just below itself.
@@ -42,7 +73,7 @@ impl PlanOrNetworkBoundary {
 
 /// Wraps an [ExecutionPlan] and annotates it with information about how many distributed tasks
 /// it should run on, and whether it needs a network boundary below or not.
-pub(super) struct AnnotatedPlan {
+pub(crate) struct AnnotatedPlan {
     /// The annotated [ExecutionPlan].
     pub(super) plan_or_nb: PlanOrNetworkBoundary,
     /// The annotated children of this [ExecutionPlan]. This will always hold the same nodes as
@@ -158,14 +189,7 @@ impl Debug for AnnotatedPlan {
 /// ```
 ///
 /// ```
-pub(super) fn annotate_plan(
-    plan: Arc<dyn ExecutionPlan>,
-    cfg: &ConfigOptions,
-) -> Result<AnnotatedPlan, DataFusionError> {
-    _annotate_plan(plan, None, cfg, true)
-}
-
-fn _annotate_plan(
+fn annotate_plan(
     plan: Arc<dyn ExecutionPlan>,
     parent: Option<&Arc<dyn ExecutionPlan>>,
     cfg: &ConfigOptions,
@@ -182,8 +206,8 @@ fn _annotate_plan(
     let annotated_children = plan
         .children()
         .iter()
-        .map(|child| _annotate_plan(Arc::clone(child), Some(&plan), cfg, false))
-        .collect::<Result<Vec<_>, _>>()?;
+        .map(|child| annotate_plan(Arc::clone(child), Some(&plan), cfg, false))
+        .collect::<std::result::Result<Vec<_>, _>>()?;
 
     if plan.children().is_empty() {
         // This is a leaf node, maybe a DataSourceExec, or maybe something else custom from the
@@ -265,7 +289,7 @@ fn _annotate_plan(
         // If the parent is trying to coalesce all partitions into one, we need to introduce
         // a network coalesce right below it (or in other words, above the current node)
         && (parent.as_any().is::<CoalescePartitionsExec>()
-            || parent.as_any().is::<SortPreservingMergeExec>())
+        || parent.as_any().is::<SortPreservingMergeExec>())
     {
         // A BroadcastExec underneath a coalesce parent means the build side will cross stages.
         if plan.as_any().is::<BroadcastExec>() {
@@ -290,7 +314,7 @@ fn _annotate_plan(
         annotation: &mut AnnotatedPlan,
         task_count: &TaskCountAnnotation,
         d_cfg: &DistributedConfig,
-    ) -> Result<(), DataFusionError> {
+    ) -> std::result::Result<(), DataFusionError> {
         annotation.task_count = task_count.clone();
         let plan = match &annotation.plan_or_nb {
             // If it's a normal plan, continue with the propagation.
@@ -403,14 +427,17 @@ fn _annotate_plan(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::distributed_planner::insert_broadcast::insert_broadcast_execs;
     use crate::test_utils::plans::{
         BuildSideOneTaskEstimator, TestPlanOptions, base_session_builder, context_with_query,
         sql_to_physical_plan,
     };
-    use crate::{DistributedExt, TaskEstimation, TaskEstimator, assert_snapshot};
+    use crate::{
+        DistributedExt, EndDistributedContext, InsertBroadcast, StartDistributedContext,
+        TaskEstimation, TaskEstimator, assert_snapshot,
+    };
     use datafusion::config::ConfigOptions;
     use datafusion::execution::SessionStateBuilder;
+    use datafusion::physical_optimizer::PhysicalOptimizerRule;
     use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
     use datafusion::physical_plan::filter::FilterExec;
     /* schema for the "weather" table
@@ -979,12 +1006,15 @@ mod tests {
         let (ctx, query) = context_with_query(builder, query).await;
         let df = ctx.sql(&query).await.unwrap();
         let mut plan = df.create_physical_plan().await.unwrap();
+        let state_ref = ctx.state_ref();
+        let state = state_ref.read();
+        let cfg = state.config_options().as_ref();
 
-        plan = insert_broadcast_execs(plan, ctx.state_ref().read().config_options().as_ref())
-            .expect("failed to insert broadcasts");
+        plan = StartDistributedContext.optimize(plan, cfg).unwrap();
+        plan = InsertBroadcast.optimize(plan, cfg).unwrap();
+        plan = EndDistributedContext.optimize(plan, cfg).unwrap();
+        let annotated = annotate_plan(Arc::clone(&plan), None, cfg, true).unwrap();
 
-        let annotated = annotate_plan(plan, ctx.state_ref().read().config_options().as_ref())
-            .expect("failed to annotate plan");
         format!("{annotated:?}")
     }
 }

--- a/src/distributed_planner/rules/rule_4_inject_network_boundary_placeholders.rs
+++ b/src/distributed_planner/rules/rule_4_inject_network_boundary_placeholders.rs
@@ -1,8 +1,13 @@
+use crate::NetworkBoundaryKind::{Broadcast, Coalesce, Shuffle};
 use crate::TaskCountAnnotation::{Desired, Maximum};
 use crate::distributed_planner::distributed_context::DistributedContext;
+use crate::distributed_planner::network_boundary_placeholder::NetworkBoundaryKind;
 use crate::execution_plans::ChildrenIsolatorUnionExec;
-use crate::{BroadcastExec, DistributedConfig, TaskCountAnnotation, TaskEstimator};
-use datafusion::common::{DataFusionError, Result, plan_datafusion_err};
+use crate::{
+    BroadcastExec, DistributedConfig, NetworkBoundaryPlaceholder, TaskCountAnnotation,
+    TaskEstimator,
+};
+use datafusion::common::{DataFusionError, Result, plan_datafusion_err, plan_err};
 use datafusion::config::ConfigOptions;
 use datafusion::physical_expr::Partitioning;
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
@@ -16,10 +21,14 @@ use datafusion::physical_plan::union::UnionExec;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
+/// Injects the appropriate [NetworkBoundaryPlaceholder]s in the plan. These placeholders tell the
+/// next step where to put the actual network boundaries.
+///
+/// Additionally, it replaces [UnionExec]s with [ChildrenIsolatorUnionExec]s.
 #[derive(Debug)]
-pub struct AnnotatePlan;
+pub struct InjectNetworkBoundaryPlaceholders;
 
-impl PhysicalOptimizerRule for AnnotatePlan {
+impl PhysicalOptimizerRule for InjectNetworkBoundaryPlaceholders {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
@@ -27,17 +36,37 @@ impl PhysicalOptimizerRule for AnnotatePlan {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let d_ctx = DistributedContext::ensure(self, &plan)?;
 
-        d_ctx.annotated_plan.lock().unwrap().replace(annotate_plan(
-            Arc::clone(&d_ctx.plan),
-            None,
-            config,
-            true,
-        )?);
-        Ok(plan)
+        let annotated = annotate_plan(Arc::clone(&d_ctx.plan), None, config, true)?;
+
+        fn inject_network_boundary_placeholders(
+            mut annotation: AnnotatedPlan,
+        ) -> Result<Arc<dyn ExecutionPlan>> {
+            match annotation.plan_or_nb {
+                PlanOrNetworkBoundary::Plan(plan) => {
+                    let mut children = Vec::with_capacity(annotation.children.len());
+                    for child in annotation.children {
+                        children.push(inject_network_boundary_placeholders(child)?);
+                    }
+                    plan.with_new_children(children)
+                }
+                PlanOrNetworkBoundary::NetworkBoundary(kind) => {
+                    let Some(child) = annotation.children.pop() else {
+                        return plan_err!("Expected NetworkBoundary annotation to have one child");
+                    };
+                    Ok(Arc::new(NetworkBoundaryPlaceholder {
+                        kind,
+                        input_task_count: child.task_count.as_usize(),
+                        input: inject_network_boundary_placeholders(child)?,
+                    }))
+                }
+            }
+        }
+
+        plan.with_new_children(vec![inject_network_boundary_placeholders(annotated)?])
     }
 
     fn name(&self) -> &str {
-        "AnnotatePlan"
+        "InjectNetworkBoundaryPlaceholders"
     }
 
     fn schema_check(&self) -> bool {
@@ -47,42 +76,38 @@ impl PhysicalOptimizerRule for AnnotatePlan {
 
 /// Annotation attached to a single [ExecutionPlan] that determines the kind of network boundary
 /// needed just below itself.
-pub(super) enum PlanOrNetworkBoundary {
+enum PlanOrNetworkBoundary {
     Plan(Arc<dyn ExecutionPlan>),
-    Shuffle,
-    Coalesce,
-    Broadcast,
+    NetworkBoundary(NetworkBoundaryKind),
 }
 
 impl Debug for PlanOrNetworkBoundary {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Plan(plan) => write!(f, "{}", plan.name()),
-            Self::Shuffle => write!(f, "[NetworkBoundary] Shuffle"),
-            Self::Coalesce => write!(f, "[NetworkBoundary] Coalesce"),
-            Self::Broadcast => write!(f, "[NetworkBoundary] Broadcast"),
+            Self::NetworkBoundary(kind) => write!(f, "[NetworkBoundary] {kind:?}"),
         }
     }
 }
 
 impl PlanOrNetworkBoundary {
     fn is_network_boundary(&self) -> bool {
-        matches!(self, Self::Shuffle | Self::Coalesce | Self::Broadcast)
+        matches!(self, Self::NetworkBoundary(_))
     }
 }
 
 /// Wraps an [ExecutionPlan] and annotates it with information about how many distributed tasks
 /// it should run on, and whether it needs a network boundary below or not.
-pub(crate) struct AnnotatedPlan {
+struct AnnotatedPlan {
     /// The annotated [ExecutionPlan].
-    pub(super) plan_or_nb: PlanOrNetworkBoundary,
+    plan_or_nb: PlanOrNetworkBoundary,
     /// The annotated children of this [ExecutionPlan]. This will always hold the same nodes as
     /// `self.plan.children()` but annotated.
-    pub(super) children: Vec<AnnotatedPlan>,
+    children: Vec<AnnotatedPlan>,
 
     // annotation fields
     /// How many distributed tasks this plan should run on.
-    pub(super) task_count: TaskCountAnnotation,
+    task_count: TaskCountAnnotation,
 }
 
 impl Debug for AnnotatedPlan {
@@ -187,8 +212,6 @@ impl Debug for AnnotatedPlan {
 /// │      DataSource      │ network_boundary: None
 /// └──────────────────────┘                                                                                                                                                                                        └──────────────────────┘
 /// ```
-///
-/// ```
 fn annotate_plan(
     plan: Arc<dyn ExecutionPlan>,
     parent: Option<&Arc<dyn ExecutionPlan>>,
@@ -246,7 +269,7 @@ fn annotate_plan(
         && node.mode == PartitionMode::CollectLeft
         && !broadcast_joins
     {
-        // Only distriubte CollectLeft HashJoins after we broadcast more intelligently or when it
+        // Only distribute CollectLeft HashJoins after we broadcast more intelligently or when it
         // is explicitly enabled.
         task_count = Maximum(1);
     } else {
@@ -277,7 +300,7 @@ fn annotate_plan(
     if let Some(r_exec) = plan.as_any().downcast_ref::<RepartitionExec>() {
         if matches!(r_exec.partitioning(), Partitioning::Hash(_, _)) {
             annotation = AnnotatedPlan {
-                plan_or_nb: PlanOrNetworkBoundary::Shuffle,
+                plan_or_nb: PlanOrNetworkBoundary::NetworkBoundary(Shuffle),
                 children: vec![annotation],
                 task_count,
             };
@@ -294,13 +317,13 @@ fn annotate_plan(
         // A BroadcastExec underneath a coalesce parent means the build side will cross stages.
         if plan.as_any().is::<BroadcastExec>() {
             annotation = AnnotatedPlan {
-                plan_or_nb: PlanOrNetworkBoundary::Broadcast,
+                plan_or_nb: PlanOrNetworkBoundary::NetworkBoundary(Broadcast),
                 children: vec![annotation],
                 task_count,
             };
         } else {
             annotation = AnnotatedPlan {
-                plan_or_nb: PlanOrNetworkBoundary::Coalesce,
+                plan_or_nb: PlanOrNetworkBoundary::NetworkBoundary(Coalesce),
                 children: vec![annotation],
                 task_count,
             };
@@ -320,7 +343,7 @@ fn annotate_plan(
             // If it's a normal plan, continue with the propagation.
             PlanOrNetworkBoundary::Plan(plan) => plan,
             // Broadcast is a stage split only propagate a Maximum cap into the build stage.
-            PlanOrNetworkBoundary::Broadcast => {
+            PlanOrNetworkBoundary::NetworkBoundary(Broadcast) => {
                 if let Maximum(max) = task_count {
                     for child in annotation.children.iter_mut() {
                         let child_task_count = child.task_count.clone().limit(*max);
@@ -333,8 +356,8 @@ fn annotate_plan(
             //
             // Nothing to propagate here, all the nodes below the network boundary were already
             // assigned a task count, we do not want to overwrite it.
-            PlanOrNetworkBoundary::Shuffle => return Ok(()),
-            PlanOrNetworkBoundary::Coalesce => return Ok(()),
+            PlanOrNetworkBoundary::NetworkBoundary(Shuffle) => return Ok(()),
+            PlanOrNetworkBoundary::NetworkBoundary(Coalesce) => return Ok(()),
         };
 
         if d_cfg.children_isolator_unions && plan.as_any().is::<UnionExec>() {
@@ -374,7 +397,10 @@ fn annotate_plan(
         // If the current plan that needs a NetworkBoundary boundary below is either a
         // CoalescePartitionsExec or a SortPreservingMergeExec, then we are sure that all the stage
         // that they are going to be part of needs to run in exactly one task.
-        if matches!(annotation.plan_or_nb, PlanOrNetworkBoundary::Coalesce) {
+        if matches!(
+            annotation.plan_or_nb,
+            PlanOrNetworkBoundary::NetworkBoundary(Coalesce)
+        ) {
             annotation.task_count = Maximum(1);
             return Ok(annotation);
         }

--- a/src/distributed_planner/rules/rule_5_apply_network_boundaries.rs
+++ b/src/distributed_planner/rules/rule_5_apply_network_boundaries.rs
@@ -1,75 +1,51 @@
 use crate::common::require_one_child;
-use crate::distributed_planner::batch_coalescing_below_network_boundaries;
-use crate::distributed_planner::plan_annotator::{
-    AnnotatedPlan, PlanOrNetworkBoundary, annotate_plan,
+use crate::distributed_planner::distributed_context::DistributedContext;
+use crate::distributed_planner::rules::rule_4_annotate_plan::{
+    AnnotatedPlan, PlanOrNetworkBoundary,
 };
 use crate::{
     DistributedConfig, DistributedExec, NetworkBroadcastExec, NetworkCoalesceExec,
     NetworkShuffleExec, TaskEstimator,
 };
+use datafusion::common::DataFusionError;
 use datafusion::config::ConfigOptions;
-use datafusion::error::DataFusionError;
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
-use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
-use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
-use std::fmt::Debug;
+use datafusion::physical_plan::ExecutionPlan;
 use std::ops::AddAssign;
 use std::sync::Arc;
 use uuid::Uuid;
 
-use super::insert_broadcast::insert_broadcast_execs;
+#[derive(Debug)]
+pub struct ApplyNetworkBoundaries;
 
-/// Physical optimizer rule that inspects the plan, places the appropriate network
-/// boundaries, and breaks it down into stages that can be executed in a distributed manner.
-///
-/// The rule has three steps:
-///
-/// 1. Annotate the plan with [annotate_plan]: adds some annotations to each node about how
-///    many distributed tasks should be used in the stage containing them, and whether they
-///    need a network boundary below or not.
-///    For more information about this step, read [annotate_plan] docs.
-///
-/// 2. Based on the [AnnotatedPlan] returned by [annotate_plan], place all the appropriate
-///    network boundaries ([NetworkShuffleExec] and [NetworkCoalesceExec]) with the task count
-///    assignation that the annotations required. After this, the plan is already a distributed
-///    executable plan.
-///
-/// 3. Place the [CoalesceBatchesExec] in the appropriate places (just below network boundaries),
-///    so that we send fewer and bigger record batches over the wire instead of a lot of small ones.
-#[derive(Debug, Default)]
-pub struct DistributedPhysicalOptimizerRule;
-
-impl PhysicalOptimizerRule for DistributedPhysicalOptimizerRule {
+impl PhysicalOptimizerRule for ApplyNetworkBoundaries {
     fn optimize(
         &self,
-        original: Arc<dyn ExecutionPlan>,
-        cfg: &ConfigOptions,
+        plan: Arc<dyn ExecutionPlan>,
+        config: &ConfigOptions,
     ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
-        if original.as_any().is::<DistributedExec>() {
-            return Ok(original);
-        }
+        let d_ctx = DistributedContext::ensure(self, &plan)?;
 
-        let mut plan = Arc::clone(&original);
-        if original.output_partitioning().partition_count() > 1 {
-            plan = Arc::new(CoalescePartitionsExec::new(plan))
-        }
-
-        plan = insert_broadcast_execs(plan, cfg)?;
-
-        let annotated = annotate_plan(plan, cfg)?;
+        let Some(annotated) = d_ctx.annotated_plan.lock().unwrap().take() else {
+            return Ok(plan);
+        };
 
         let mut stage_id = 1;
-        let distributed = distribute_plan(annotated, cfg, Uuid::new_v4(), &mut stage_id)?;
-        if stage_id == 1 {
-            return Ok(original);
-        }
-        let distributed = batch_coalescing_below_network_boundaries(distributed, cfg)?;
+        let query_id = Uuid::new_v4();
+        let distributed = apply_network_boundaries(annotated, config, query_id, &mut stage_id)?;
 
-        Ok(Arc::new(DistributedExec::new(distributed)))
+        let child = if stage_id == 1 {
+            // The plan did not get distributed, so rolling back to the original plan.
+            Arc::clone(&d_ctx.original_single_node_plan)
+        } else {
+            // The plan did get distributed.
+            Arc::new(DistributedExec::new(distributed))
+        };
+        plan.with_new_children(vec![child])
     }
 
     fn name(&self) -> &str {
-        "DistributedPhysicalOptimizer"
+        "ApplyNetworkBoundaries"
     }
 
     fn schema_check(&self) -> bool {
@@ -84,7 +60,7 @@ impl PhysicalOptimizerRule for DistributedPhysicalOptimizerRule {
 ///   which they are going to run. This is configurable by the user via the [TaskEstimator] trait.
 /// - The appropriate network boundaries are placed in the plan depending on how it was annotated,
 ///   so new nodes like [NetworkBroadcastExec], [NetworkCoalesceExec] and [NetworkShuffleExec] will be present.
-fn distribute_plan(
+fn apply_network_boundaries(
     annotated_plan: AnnotatedPlan,
     cfg: &ConfigOptions,
     query_id: Uuid,
@@ -96,7 +72,7 @@ fn distribute_plan(
     let max_child_task_count = children.iter().map(|v| v.task_count.as_usize()).max();
     let new_children = children
         .into_iter()
-        .map(|child| distribute_plan(child, cfg, query_id, stage_id))
+        .map(|child| apply_network_boundaries(child, cfg, query_id, stage_id))
         .collect::<Result<Vec<_>, _>>()?;
     match annotated_plan.plan_or_nb {
         // This is a leaf node. It needs to be scaled up in order to account for it running in
@@ -174,12 +150,9 @@ mod tests {
         BuildSideOneTaskEstimator, TestPlanOptions, base_session_builder, context_with_query,
         sql_to_physical_plan,
     };
-    use crate::{
-        DistributedExt, DistributedPhysicalOptimizerRule, assert_snapshot, display_plan_ascii,
-    };
+    use crate::{DistributedExt, SessionStateBuilderExt, assert_snapshot, display_plan_ascii};
     use datafusion::execution::SessionStateBuilder;
     use datafusion::physical_plan::displayable;
-    use std::sync::Arc;
     /* schema for the "weather" table
 
      MinTemp [type=DOUBLE] [repetitiontype=OPTIONAL]
@@ -949,8 +922,7 @@ mod tests {
             options.broadcast_enabled,
         );
         if use_optimizer {
-            builder =
-                builder.with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule));
+            builder.set_distributed_physical_optimizer_rules()
         }
         let builder = configure(builder);
         let (ctx, query) = context_with_query(builder, query).await;

--- a/src/distributed_planner/rules/rule_5_apply_network_boundaries.rs
+++ b/src/distributed_planner/rules/rule_5_apply_network_boundaries.rs
@@ -1,13 +1,11 @@
 use crate::common::require_one_child;
 use crate::distributed_planner::distributed_context::DistributedContext;
-use crate::distributed_planner::rules::rule_4_annotate_plan::{
-    AnnotatedPlan, PlanOrNetworkBoundary,
-};
+use crate::execution_plans::ChildrenIsolatorUnionExec;
 use crate::{
-    DistributedConfig, DistributedExec, NetworkBroadcastExec, NetworkCoalesceExec,
-    NetworkShuffleExec, TaskEstimator,
+    DistributedConfig, DistributedExec, NetworkBoundaryKind, NetworkBoundaryPlaceholder,
+    NetworkBroadcastExec, NetworkCoalesceExec, NetworkShuffleExec, TaskEstimator,
 };
-use datafusion::common::DataFusionError;
+use datafusion::common::Result;
 use datafusion::config::ConfigOptions;
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::ExecutionPlan;
@@ -15,6 +13,16 @@ use std::ops::AddAssign;
 use std::sync::Arc;
 use uuid::Uuid;
 
+/// Takes a plan with [NetworkBoundaryPlaceholder]s in it, and transforms them into actual
+/// network boundaries:
+/// - [NetworkBoundaryKind::Coalesce] -> [NetworkCoalesceExec]
+/// - [NetworkBoundaryKind::Shuffle] -> [NetworkShuffleExec]
+/// - [NetworkBoundaryKind::Broadcast] -> [NetworkBroadcastExec]
+///
+/// The previous [PhysicalOptimizerRule] to this one (`InjectNetworkBoundaryPlaceholders`) is in
+/// charge of placing the [NetworkBoundaryPlaceholder]s in the appropriate places, but users are
+/// free to place their own, either by having more rules in between, or straight await replacing the
+/// `InjectNetworkBoundaryPlaceholders` with a custom one.
 #[derive(Debug)]
 pub struct ApplyNetworkBoundaries;
 
@@ -23,16 +31,13 @@ impl PhysicalOptimizerRule for ApplyNetworkBoundaries {
         &self,
         plan: Arc<dyn ExecutionPlan>,
         config: &ConfigOptions,
-    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+    ) -> Result<Arc<dyn ExecutionPlan>> {
         let d_ctx = DistributedContext::ensure(self, &plan)?;
-
-        let Some(annotated) = d_ctx.annotated_plan.lock().unwrap().take() else {
-            return Ok(plan);
-        };
 
         let mut stage_id = 1;
         let query_id = Uuid::new_v4();
-        let distributed = apply_network_boundaries(annotated, config, query_id, &mut stage_id)?;
+        let distributed =
+            apply_network_boundaries(&d_ctx.plan, config, query_id, 1, &mut stage_id)?;
 
         let child = if stage_id == 1 {
             // The plan did not get distributed, so rolling back to the original plan.
@@ -53,94 +58,108 @@ impl PhysicalOptimizerRule for ApplyNetworkBoundaries {
     }
 }
 
-/// Takes an [AnnotatedPlan] and returns a modified [ExecutionPlan] with all the network boundaries
-/// appropriately placed. This step performs the following modifications to the original
-/// [ExecutionPlan]:
+/// Takes an [ExecutionPlan] with [NetworkBoundaryPlaceholder] in it, and returns a modified
+/// [ExecutionPlan] with all the network boundaries appropriately placed.
+///
+/// This step performs the following modifications to the original [ExecutionPlan]:
 /// - The leaf nodes are scaled up in parallelism based on the number of distributed tasks in
 ///   which they are going to run. This is configurable by the user via the [TaskEstimator] trait.
-/// - The appropriate network boundaries are placed in the plan depending on how it was annotated,
+/// - The appropriate network boundaries are placed in the plan depending on where are the placeholders,
 ///   so new nodes like [NetworkBroadcastExec], [NetworkCoalesceExec] and [NetworkShuffleExec] will be present.
 fn apply_network_boundaries(
-    annotated_plan: AnnotatedPlan,
+    plan: &Arc<dyn ExecutionPlan>,
     cfg: &ConfigOptions,
     query_id: Uuid,
+    current_task_count: usize,
     stage_id: &mut usize,
-) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+) -> Result<Arc<dyn ExecutionPlan>> {
     let d_cfg = DistributedConfig::from_config_options(cfg)?;
-    let children = annotated_plan.children;
-    let task_count = annotated_plan.task_count.as_usize();
-    let max_child_task_count = children.iter().map(|v| v.task_count.as_usize()).max();
-    let new_children = children
-        .into_iter()
-        .map(|child| apply_network_boundaries(child, cfg, query_id, stage_id))
-        .collect::<Result<Vec<_>, _>>()?;
-    match annotated_plan.plan_or_nb {
-        // This is a leaf node. It needs to be scaled up in order to account for it running in
-        // multiple tasks.
-        PlanOrNetworkBoundary::Plan(plan) if plan.children().is_empty() => {
-            let scaled_up = d_cfg.__private_task_estimator.scale_up_leaf_node(
-                &plan,
-                annotated_plan.task_count.as_usize(),
-                cfg,
-            );
-            Ok(scaled_up.unwrap_or(plan))
-        }
-        // This is a normal intermediate plan, just pass it through with the mapped children.
-        PlanOrNetworkBoundary::Plan(plan) => plan.with_new_children(new_children),
+
+    let children = plan.children();
+    // This is a leaf node. It needs to be scaled up in order to account for it running in
+    // multiple tasks.
+    if children.is_empty() {
+        return Ok(d_cfg
+            .__private_task_estimator
+            .scale_up_leaf_node(plan, current_task_count, cfg)
+            .unwrap_or(Arc::clone(plan)));
+    }
+
+    let new_children: Vec<_> =
+        if let Some(ci_union) = plan.as_any().downcast_ref::<ChildrenIsolatorUnionExec>() {
+            // This is a ChildrenIsolatorUnionExec, and it has the capability of assigning
+            // individual task counts to their children.
+            let task_counts = ci_union.children_task_count();
+            children
+                .into_iter()
+                .enumerate()
+                .map(|(i, child)| {
+                    apply_network_boundaries(child, cfg, query_id, task_counts[i], stage_id)
+                })
+                .collect::<Result<_>>()?
+        } else if let Some(nb) = plan.as_any().downcast_ref::<NetworkBoundaryPlaceholder>() {
+            // This is a network boundary, so there's a new task count to be propagated down the
+            // plan: the one established by this network boundary placeholder.
+            children
+                .into_iter()
+                .map(|child| {
+                    apply_network_boundaries(child, cfg, query_id, nb.input_task_count, stage_id)
+                })
+                .collect::<Result<_>>()?
+        } else {
+            // Just propagate the current task count without doing anything special.
+            children
+                .into_iter()
+                .map(|child| {
+                    apply_network_boundaries(child, cfg, query_id, current_task_count, stage_id)
+                })
+                .collect::<Result<_>>()?
+        };
+
+    let Some(nb) = plan.as_any().downcast_ref::<NetworkBoundaryPlaceholder>() else {
+        // Not a network boundary, so continue as normal.
+        return Arc::clone(plan).with_new_children(new_children);
+    };
+
+    // Network boundaries can only have 1 child.
+    let input = require_one_child(new_children)?;
+
+    // It would need a network boundary, but on both sides of the boundary there is just 1 task,
+    // so we are fine with not introducing any network boundary.
+    if current_task_count == 1 && nb.input_task_count == 1 {
+        return Ok(input);
+    }
+
+    let node: Arc<dyn ExecutionPlan> = match nb.kind {
         // This is a shuffle, so inject a NetworkShuffleExec here in the plan.
-        PlanOrNetworkBoundary::Shuffle => {
-            // It would need a network boundary, but on both sides of the boundary there is just 1 task,
-            // so we are fine with not introducing any network boundary.
-            if task_count == 1 && max_child_task_count == Some(1) {
-                return require_one_child(new_children);
-            }
-            let node = Arc::new(NetworkShuffleExec::try_new(
-                require_one_child(new_children)?,
-                query_id,
-                *stage_id,
-                task_count,
-                max_child_task_count.unwrap_or(1),
-            )?);
-            stage_id.add_assign(1);
-            Ok(node)
-        }
+        NetworkBoundaryKind::Shuffle => Arc::new(NetworkShuffleExec::try_new(
+            input,
+            query_id,
+            *stage_id,
+            current_task_count,
+            nb.input_task_count,
+        )?),
         // DataFusion is trying to coalesce multiple partitions into one, so we should do the
         // same with tasks.
-        PlanOrNetworkBoundary::Coalesce => {
-            // It would need a network boundary, but on both sides of the boundary there is just 1 task,
-            // so we are fine with not introducing any network boundary.
-            if task_count == 1 && max_child_task_count == Some(1) {
-                return require_one_child(new_children);
-            }
-            let node = Arc::new(NetworkCoalesceExec::try_new(
-                require_one_child(new_children)?,
-                query_id,
-                *stage_id,
-                task_count,
-                max_child_task_count.unwrap_or(1),
-            )?);
-            stage_id.add_assign(1);
-            Ok(node)
-        }
+        NetworkBoundaryKind::Coalesce => Arc::new(NetworkCoalesceExec::try_new(
+            input,
+            query_id,
+            *stage_id,
+            current_task_count,
+            nb.input_task_count,
+        )?),
         // This is a CollectLeft HashJoinExec with the build side marked as being broadcast. we
         // need to insert a NetworkBroadcastExec and scale up the BroadcastExec consumer_tasks.
-        PlanOrNetworkBoundary::Broadcast => {
-            // It would need a network boundary, but on both sides of the boundary there is just 1 task,
-            // so we are fine with not introducing any network boundary.
-            if task_count == 1 && max_child_task_count == Some(1) {
-                return require_one_child(new_children);
-            }
-            let node = Arc::new(NetworkBroadcastExec::try_new(
-                require_one_child(new_children)?,
-                query_id,
-                *stage_id,
-                task_count,
-                max_child_task_count.unwrap_or(1),
-            )?);
-            stage_id.add_assign(1);
-            Ok(node)
-        }
-    }
+        NetworkBoundaryKind::Broadcast => Arc::new(NetworkBroadcastExec::try_new(
+            input,
+            query_id,
+            *stage_id,
+            current_task_count,
+            nb.input_task_count,
+        )?),
+    };
+    stage_id.add_assign(1);
+    Ok(node)
 }
 
 #[cfg(test)]

--- a/src/distributed_planner/rules/rule_6_batch_coalesce_below_boundaries.rs
+++ b/src/distributed_planner/rules/rule_6_batch_coalesce_below_boundaries.rs
@@ -1,8 +1,9 @@
 use crate::common::require_one_child;
+use crate::distributed_planner::distributed_context::DistributedContext;
 use crate::{DistributedConfig, NetworkBoundaryExt};
-use datafusion::common::DataFusionError;
 use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::config::ConfigOptions;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::coalesce_batches::CoalesceBatchesExec;
 use std::sync::Arc;
@@ -10,60 +11,75 @@ use std::sync::Arc;
 /// Rearranges the [CoalesceBatchesExec] nodes in the plan so that they are placed right below
 /// the network boundaries, so that fewer but bigger record batches are sent over the wire across
 /// stages.
-pub(crate) fn batch_coalescing_below_network_boundaries(
-    plan: Arc<dyn ExecutionPlan>,
-    cfg: &ConfigOptions,
-) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-    let d_cfg = DistributedConfig::from_config_options(cfg)?;
+#[derive(Debug)]
+pub struct BatchCoalesceBelowBoundaries;
 
-    // Only apply this rule if the normal execution batch size is not already bigger than the
-    // shuffle batch size. Exchanging data between workers is better done with batches as big as
-    // possible, and if the normal execution batch size is already big, we don't want to proactively
-    // reduce it.
-    if d_cfg.shuffle_batch_size <= cfg.execution.batch_size {
-        return Ok(plan);
-    }
+impl PhysicalOptimizerRule for BatchCoalesceBelowBoundaries {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        cfg: &ConfigOptions,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        DistributedContext::ensure(self, &plan)?;
 
-    let transformed = plan.transform_up(|plan| {
-        if !plan.is_network_boundary() {
-            return Ok(Transformed::no(plan));
+        let d_cfg = DistributedConfig::from_config_options(cfg)?;
+
+        // Only apply this rule if the normal execution batch size is not already bigger than the
+        // shuffle batch size. Exchanging data between workers is better done with batches as big as
+        // possible, and if the normal execution batch size is already big, we don't want to proactively
+        // reduce it.
+        if d_cfg.shuffle_batch_size <= cfg.execution.batch_size {
+            return Ok(plan);
         }
 
-        let input = require_one_child(plan.children())?;
-        if let Some(existing_coalesce) = input.as_any().downcast_ref::<CoalesceBatchesExec>() {
-            // There was already a CoalesceBatchesExec below...
-            if existing_coalesce.target_batch_size() == d_cfg.shuffle_batch_size {
-                // ...so either leave it alone if the batch size is correctly set...
-                Ok(Transformed::no(plan))
+        let transformed = plan.transform_up(|plan| {
+            if !plan.is_network_boundary() {
+                return Ok(Transformed::no(plan));
+            }
+
+            let input = require_one_child(plan.children())?;
+            if let Some(existing_coalesce) = input.as_any().downcast_ref::<CoalesceBatchesExec>() {
+                // There was already a CoalesceBatchesExec below...
+                if existing_coalesce.target_batch_size() == d_cfg.shuffle_batch_size {
+                    // ...so either leave it alone if the batch size is correctly set...
+                    Ok(Transformed::no(plan))
+                } else {
+                    // ... or replace it with one with the correct batch size.
+                    let coalesce_input = existing_coalesce.input();
+                    let new_coalesce = CoalesceBatchesExec::new(
+                        Arc::clone(coalesce_input),
+                        d_cfg.shuffle_batch_size,
+                    )
+                    .with_fetch(existing_coalesce.fetch());
+                    let new_plan = plan.with_new_children(vec![Arc::new(new_coalesce)])?;
+                    Ok(Transformed::yes(new_plan))
+                }
             } else {
-                // ... or replace it with one with the correct batch size.
-                let coalesce_input = existing_coalesce.input();
+                // No CoalesceBatchesExec below, need to put one.
+                let coalesce_input = input;
                 let new_coalesce =
-                    CoalesceBatchesExec::new(Arc::clone(coalesce_input), d_cfg.shuffle_batch_size)
-                        .with_fetch(existing_coalesce.fetch());
+                    CoalesceBatchesExec::new(coalesce_input, d_cfg.shuffle_batch_size);
                 let new_plan = plan.with_new_children(vec![Arc::new(new_coalesce)])?;
                 Ok(Transformed::yes(new_plan))
             }
-        } else {
-            // No CoalesceBatchesExec below, need to put one.
-            let coalesce_input = input;
-            let new_coalesce = CoalesceBatchesExec::new(coalesce_input, d_cfg.shuffle_batch_size);
-            let new_plan = plan.with_new_children(vec![Arc::new(new_coalesce)])?;
-            Ok(Transformed::yes(new_plan))
-        }
-    })?;
+        })?;
 
-    Ok(transformed.data)
+        Ok(transformed.data)
+    }
+
+    fn name(&self) -> &str {
+        "BatchCoalesceBelowBoundaries"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
 }
-
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::test_utils::in_memory_channel_resolver::InMemoryWorkerResolver;
     use crate::test_utils::parquet::register_parquet_tables;
-    use crate::{
-        DistributedExt, DistributedPhysicalOptimizerRule, assert_snapshot, display_plan_ascii,
-    };
+    use crate::{DistributedExt, SessionStateBuilderExt, assert_snapshot, display_plan_ascii};
     use datafusion::execution::SessionStateBuilder;
     use datafusion::prelude::{SessionConfig, SessionContext};
     use itertools::Itertools;
@@ -158,7 +174,7 @@ mod tests {
         let state = SessionStateBuilder::new()
             .with_default_features()
             .with_config(SessionConfig::new().with_target_partitions(4))
-            .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+            .with_distributed_physical_optimizer_rules()
             .with_distributed_worker_resolver(InMemoryWorkerResolver::new(3))
             .build();
 

--- a/src/distributed_planner/rules/rule_7_end_distributed_context.rs
+++ b/src/distributed_planner/rules/rule_7_end_distributed_context.rs
@@ -1,0 +1,27 @@
+use crate::distributed_planner::distributed_context::DistributedContext;
+use datafusion::config::ConfigOptions;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::ExecutionPlan;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct EndDistributedContext;
+
+impl PhysicalOptimizerRule for EndDistributedContext {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        let d_ctx = DistributedContext::ensure(self, &plan)?;
+        Ok(Arc::clone(&d_ctx.plan))
+    }
+
+    fn name(&self) -> &str {
+        "EndDistributedContext"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}

--- a/src/distributed_planner/session_state_builder_ext.rs
+++ b/src/distributed_planner/session_state_builder_ext.rs
@@ -1,0 +1,35 @@
+use crate::{
+    AddCoalesceOnTop, AnnotatePlan, ApplyNetworkBoundaries, BatchCoalesceBelowBoundaries,
+    EndDistributedContext, InsertBroadcast, StartDistributedContext,
+};
+use datafusion::execution::SessionStateBuilder;
+use std::sync::Arc;
+
+pub trait SessionStateBuilderExt {
+    /// Adds all the distributed physical optimizer rules to the [SessionStateBuilder] in the
+    /// correct order and placement.
+    fn with_distributed_physical_optimizer_rules(self) -> Self;
+
+    /// Same as [SessionStateBuilderExt::with_distributed_physical_optimizer_rules] but with an in-place mutation.
+    fn set_distributed_physical_optimizer_rules(&mut self);
+}
+
+impl SessionStateBuilderExt for SessionStateBuilder {
+    fn with_distributed_physical_optimizer_rules(mut self) -> Self {
+        self.set_distributed_physical_optimizer_rules();
+        self
+    }
+
+    fn set_distributed_physical_optimizer_rules(&mut self) {
+        let rules = self.physical_optimizer_rules().get_or_insert_default();
+        rules.extend_from_slice(&[
+            Arc::new(StartDistributedContext),
+            Arc::new(AddCoalesceOnTop),
+            Arc::new(InsertBroadcast),
+            Arc::new(AnnotatePlan),
+            Arc::new(ApplyNetworkBoundaries),
+            Arc::new(BatchCoalesceBelowBoundaries),
+            Arc::new(EndDistributedContext),
+        ])
+    }
+}

--- a/src/distributed_planner/session_state_builder_ext.rs
+++ b/src/distributed_planner/session_state_builder_ext.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AddCoalesceOnTop, AnnotatePlan, ApplyNetworkBoundaries, BatchCoalesceBelowBoundaries,
-    EndDistributedContext, InsertBroadcast, StartDistributedContext,
+    AddCoalesceOnTop, ApplyNetworkBoundaries, BatchCoalesceBelowBoundaries, EndDistributedContext,
+    InjectNetworkBoundaryPlaceholders, InsertBroadcast, StartDistributedContext,
 };
 use datafusion::execution::SessionStateBuilder;
 use std::sync::Arc;
@@ -10,7 +10,8 @@ pub trait SessionStateBuilderExt {
     /// correct order and placement.
     fn with_distributed_physical_optimizer_rules(self) -> Self;
 
-    /// Same as [SessionStateBuilderExt::with_distributed_physical_optimizer_rules] but with an in-place mutation.
+    /// Same as [SessionStateBuilderExt::with_distributed_physical_optimizer_rules] but with an
+    /// in-place mutation.
     fn set_distributed_physical_optimizer_rules(&mut self);
 }
 
@@ -22,11 +23,15 @@ impl SessionStateBuilderExt for SessionStateBuilder {
 
     fn set_distributed_physical_optimizer_rules(&mut self) {
         let rules = self.physical_optimizer_rules().get_or_insert_default();
+        // Any rule related to Distributed DataFusion needs to be placed between the
+        // StartDistributedContext and the EndDistributedContext rules, as those are
+        // designed to propagate contextual information only relevant for distributed
+        // planning
         rules.extend_from_slice(&[
             Arc::new(StartDistributedContext),
             Arc::new(AddCoalesceOnTop),
             Arc::new(InsertBroadcast),
-            Arc::new(AnnotatePlan),
+            Arc::new(InjectNetworkBoundaryPlaceholders),
             Arc::new(ApplyNetworkBoundaries),
             Arc::new(BatchCoalesceBelowBoundaries),
             Arc::new(EndDistributedContext),

--- a/src/execution_plans/children_isolator_union.rs
+++ b/src/execution_plans/children_isolator_union.rs
@@ -144,6 +144,16 @@ impl ChildrenIsolatorUnionExec {
             task_idx_map,
         })
     }
+
+    pub(crate) fn children_task_count(&self) -> Vec<usize> {
+        let mut result = vec![0; self.children.len()];
+        for children_in_task in &self.task_idx_map {
+            for (child_idx, ctx) in children_in_task {
+                result[*child_idx] = ctx.task_count
+            }
+        }
+        result
+    }
 }
 
 impl DisplayAs for ChildrenIsolatorUnionExec {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,9 @@ pub use observability::{
 };
 
 pub use distributed_planner::{
-    AddCoalesceOnTop, AnnotatePlan, ApplyNetworkBoundaries, BatchCoalesceBelowBoundaries,
-    EndDistributedContext, InsertBroadcast, StartDistributedContext,
+    AddCoalesceOnTop, ApplyNetworkBoundaries, BatchCoalesceBelowBoundaries, DistributedContext,
+    EndDistributedContext, InjectNetworkBoundaryPlaceholders, InsertBroadcast, NetworkBoundaryKind,
+    NetworkBoundaryPlaceholder, StartDistributedContext,
 };
 
 pub use protobuf::StageKey;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub mod test_utils;
 pub use arrow_ipc::CompressionType;
 pub use distributed_ext::DistributedExt;
 pub use distributed_planner::{
-    DistributedConfig, DistributedPhysicalOptimizerRule, NetworkBoundary, NetworkBoundaryExt,
+    DistributedConfig, NetworkBoundary, NetworkBoundaryExt, SessionStateBuilderExt,
     TaskCountAnnotation, TaskEstimation, TaskEstimator,
 };
 pub use execution_plans::{
@@ -48,6 +48,11 @@ pub use observability::{
     GetTaskProgressRequest, GetTaskProgressResponse, ObservabilityService,
     ObservabilityServiceClient, ObservabilityServiceImpl, ObservabilityServiceServer, PingRequest,
     PingResponse, StageKey as ObservabilityStageKey, TaskProgress, TaskStatus,
+};
+
+pub use distributed_planner::{
+    AddCoalesceOnTop, AnnotatePlan, ApplyNetworkBoundaries, BatchCoalesceBelowBoundaries,
+    EndDistributedContext, InsertBroadcast, StartDistributedContext,
 };
 
 pub use protobuf::StageKey;

--- a/src/metrics/task_metrics_collector.rs
+++ b/src/metrics/task_metrics_collector.rs
@@ -130,7 +130,7 @@ mod tests {
         count_plan_nodes_up_to_network_boundary, get_stages_and_stage_keys,
     };
     use crate::test_utils::session_context::register_temp_parquet_table;
-    use crate::{DistributedExt, DistributedPhysicalOptimizerRule};
+    use crate::{DistributedExt, SessionStateBuilderExt};
     use datafusion::execution::{SessionStateBuilder, context::SessionContext};
     use datafusion::prelude::SessionConfig;
     use datafusion::{
@@ -151,7 +151,7 @@ mod tests {
             .with_config(config)
             .with_distributed_worker_resolver(InMemoryWorkerResolver::new(10))
             .with_distributed_channel_resolver(InMemoryChannelResolver::default())
-            .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+            .with_distributed_physical_optimizer_rules()
             .with_distributed_task_estimator(2)
             .with_distributed_metrics_collection(true)
             .unwrap()

--- a/src/metrics/task_metrics_rewriter.rs
+++ b/src/metrics/task_metrics_rewriter.rs
@@ -264,7 +264,7 @@ pub fn stage_metrics_rewriter(
 
 #[cfg(test)]
 mod tests {
-    use crate::Stage;
+    use crate::DistributedExec;
     use crate::metrics::DISTRIBUTED_DATAFUSION_TASK_ID_LABEL;
     use crate::metrics::proto::{
         MetricsSetProto, df_metrics_set_to_proto, metrics_set_proto_to_df,
@@ -280,7 +280,7 @@ mod tests {
     use crate::test_utils::metrics::make_test_metrics_set_proto_from_seed;
     use crate::test_utils::plans::count_plan_nodes_up_to_network_boundary;
     use crate::test_utils::session_context::register_temp_parquet_table;
-    use crate::{DistributedExec, DistributedPhysicalOptimizerRule};
+    use crate::{SessionStateBuilderExt, Stage};
     use bytes::Bytes;
     use datafusion::arrow::array::{Int32Array, StringArray};
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
@@ -324,7 +324,7 @@ mod tests {
                 .with_distributed_channel_resolver(InMemoryChannelResolver::default())
                 .with_distributed_metrics_collection(true)
                 .unwrap()
-                .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+                .with_distributed_physical_optimizer_rules()
                 .with_distributed_task_estimator(2)
         }
 

--- a/src/test_utils/localhost.rs
+++ b/src/test_utils/localhost.rs
@@ -1,13 +1,10 @@
-use crate::{
-    DistributedExt, DistributedPhysicalOptimizerRule, Worker, WorkerResolver, WorkerSessionBuilder,
-};
+use crate::{DistributedExt, SessionStateBuilderExt, Worker, WorkerResolver, WorkerSessionBuilder};
 use async_trait::async_trait;
 use datafusion::common::DataFusionError;
 use datafusion::common::runtime::JoinSet;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::prelude::SessionContext;
 use std::error::Error;
-use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::TcpListener;
 use tonic::transport::Server;
@@ -68,7 +65,7 @@ where
     let worker_resolver = LocalHostWorkerResolver::new(ports);
     let mut state = SessionStateBuilder::new()
         .with_default_features()
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_physical_optimizer_rules()
         .with_distributed_worker_resolver(worker_resolver)
         .build();
     state.config_mut().options_mut().execution.target_partitions = 3;

--- a/tests/custom_network_boundary_placeholders.rs
+++ b/tests/custom_network_boundary_placeholders.rs
@@ -1,0 +1,133 @@
+#[cfg(all(feature = "integration", test))]
+mod tests {
+    use datafusion::arrow::util::pretty::pretty_format_batches;
+    use datafusion::common::Result;
+    use datafusion::common::tree_node::{Transformed, TreeNode};
+    use datafusion::config::ConfigOptions;
+    use datafusion::execution::SessionStateBuilder;
+    use datafusion::physical_optimizer::PhysicalOptimizerRule;
+    use datafusion::physical_plan::{ExecutionPlan, displayable, execute_stream};
+    use datafusion::prelude::SessionContext;
+    use datafusion_distributed::test_utils::localhost::start_localhost_context;
+    use datafusion_distributed::test_utils::parquet::register_parquet_tables;
+    use datafusion_distributed::{
+        ApplyNetworkBoundaries, DefaultSessionBuilder, DistributedExt, NetworkBoundaryKind,
+        NetworkBoundaryPlaceholder, SessionStateBuilderExt, assert_snapshot,
+    };
+    use futures::TryStreamExt;
+    use itertools::Itertools;
+    use std::error::Error;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn custom_network_boundary_placeholder() -> Result<(), Box<dyn Error>> {
+        // stacks an extra Coalesce network boundary on top of existing ones, with a reduced number
+        // of tasks. This rule needs to run between the InjectNetworkBoundaryPlaceholders and the
+        // ApplyNetworkBoundaries rule, as it uses the NetworkBoundaryPlaceholder API for injecting
+        // network boundaries in custom places.
+        #[derive(Debug)]
+        struct HierarchicalCoalesce;
+
+        impl PhysicalOptimizerRule for HierarchicalCoalesce {
+            fn optimize(
+                &self,
+                plan: Arc<dyn ExecutionPlan>,
+                _: &ConfigOptions,
+            ) -> Result<Arc<dyn ExecutionPlan>> {
+                plan.transform_up(|plan| {
+                    // upon finding a NetworkBoundaryPlaceholder of Coalesce kind, stack another
+                    //  one on top with half the input tasks.
+                    if let Some(nb) = plan.as_any().downcast_ref::<NetworkBoundaryPlaceholder>()
+                        && matches!(nb.kind, NetworkBoundaryKind::Coalesce)
+                    {
+                        return Ok(Transformed::yes(Arc::new(NetworkBoundaryPlaceholder {
+                            kind: NetworkBoundaryKind::Coalesce,
+                            input_task_count: nb.input_task_count.div_ceil(2),
+                            input: plan,
+                        })));
+                    };
+                    Ok(Transformed::no(plan))
+                })
+                .map(|v| v.data)
+            }
+
+            fn name(&self) -> &str {
+                "HierarchicalCoalesce"
+            }
+
+            fn schema_check(&self) -> bool {
+                true
+            }
+        }
+
+        let (ctx, _guard, _) = start_localhost_context(3, DefaultSessionBuilder).await;
+        // NOTE: for some reason SessionStateBuilder::new_from_existing does not propagate the
+        //  optimizer rules, so we need to build one new session from scratch.
+        let mut builder = SessionStateBuilder::new()
+            .with_default_features()
+            .with_config(ctx.copied_config())
+            .with_distributed_cardinality_effect_task_scale_factor(1.0)?
+            .with_distributed_physical_optimizer_rules();
+
+        // Insert the custom rule right before ApplyNetworkBoundaries.
+        let rules = builder.physical_optimizer_rules().get_or_insert_default();
+        insert_before(rules, HierarchicalCoalesce, ApplyNetworkBoundaries);
+
+        let ctx = SessionContext::from(builder.build());
+        register_parquet_tables(&ctx).await?;
+
+        let query =
+            r#"SELECT count(*), "RainToday" FROM weather GROUP BY "RainToday" ORDER BY count(*)"#;
+
+        let df = ctx.sql(query).await?;
+        let physical = df.create_physical_plan().await?;
+        let physical_str = displayable(physical.as_ref()).indent(true).to_string();
+
+        assert_snapshot!(physical_str,
+            @r"
+        DistributedExec
+          ProjectionExec: expr=[count(*)@0 as count(*), RainToday@1 as RainToday]
+            SortPreservingMergeExec: [count(Int64(1))@2 ASC NULLS LAST]
+              [Stage 3] => NetworkCoalesceExec: output_partitions=12, input_tasks=2
+                [Stage 2] => NetworkCoalesceExec: output_partitions=6, input_tasks=3
+                  SortExec: expr=[count(*)@0 ASC NULLS LAST], preserve_partitioning=[true]
+                    ProjectionExec: expr=[count(Int64(1))@1 as count(*), RainToday@0 as RainToday, count(Int64(1))@1 as count(Int64(1))]
+                      AggregateExec: mode=FinalPartitioned, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))]
+                        [Stage 1] => NetworkShuffleExec: output_partitions=3, input_tasks=3
+                          RepartitionExec: partitioning=Hash([RainToday@0], 9), input_partitions=1
+                            AggregateExec: mode=Partial, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))]
+                              PartitionIsolatorExec: t0:[p0,__,__] t1:[__,p0,__] t2:[__,__,p0] 
+                                DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[RainToday], file_type=parquet
+        ",
+        );
+
+        let batches = pretty_format_batches(
+            &execute_stream(physical, ctx.task_ctx())?
+                .try_collect::<Vec<_>>()
+                .await?,
+        )?;
+
+        assert_snapshot!(batches, @r"
+        +----------+-----------+
+        | count(*) | RainToday |
+        +----------+-----------+
+        | 66       | Yes       |
+        | 300      | No        |
+        +----------+-----------+
+        ");
+
+        Ok(())
+    }
+
+    /// Inserts a [PhysicalOptimizerRule] before another one.
+    fn insert_before<T: PhysicalOptimizerRule + Send + Sync + 'static>(
+        rules: &mut Vec<Arc<dyn PhysicalOptimizerRule + Send + Sync>>,
+        value: T,
+        reference: impl PhysicalOptimizerRule,
+    ) {
+        let Some((pos, _)) = rules.iter().find_position(|v| v.name() == reference.name()) else {
+            return;
+        };
+        rules.insert(pos, Arc::new(value));
+    }
+}

--- a/tests/udfs.rs
+++ b/tests/udfs.rs
@@ -16,8 +16,9 @@ mod tests {
     use datafusion::physical_plan::{ExecutionPlan, execute_stream};
     use datafusion_distributed::test_utils::localhost::start_localhost_context;
     use datafusion_distributed::{
-        DistributedExt, DistributedPhysicalOptimizerRule, WorkerQueryContext, assert_snapshot,
-        display_plan_ascii,
+        AddCoalesceOnTop, AnnotatePlan, ApplyNetworkBoundaries, BatchCoalesceBelowBoundaries,
+        DistributedExt, EndDistributedContext, InsertBroadcast, StartDistributedContext,
+        WorkerQueryContext, assert_snapshot, display_plan_ascii,
     };
     use futures::TryStreamExt;
     use std::any::Any;
@@ -57,9 +58,17 @@ mod tests {
         };
 
         let node = wrap(wrap(Arc::new(EmptyExec::new(Arc::new(Schema::empty())))));
+        let cfg = ctx.copied_config();
+        let opts = cfg.options();
 
-        let physical_distributed =
-            DistributedPhysicalOptimizerRule.optimize(node, ctx.copied_config().options())?;
+        // TODO: refactor this test so that it doesn't do this weird thing.
+        let node = StartDistributedContext.optimize(node, opts)?;
+        let node = AddCoalesceOnTop.optimize(node, opts)?;
+        let node = InsertBroadcast.optimize(node, opts)?;
+        let node = AnnotatePlan.optimize(node, opts)?;
+        let node = ApplyNetworkBoundaries.optimize(node, opts)?;
+        let node = BatchCoalesceBelowBoundaries.optimize(node, opts)?;
+        let physical_distributed = EndDistributedContext.optimize(node, opts)?;
 
         let physical_distributed_str = display_plan_ascii(physical_distributed.as_ref(), false);
 

--- a/tests/udfs.rs
+++ b/tests/udfs.rs
@@ -16,9 +16,9 @@ mod tests {
     use datafusion::physical_plan::{ExecutionPlan, execute_stream};
     use datafusion_distributed::test_utils::localhost::start_localhost_context;
     use datafusion_distributed::{
-        AddCoalesceOnTop, AnnotatePlan, ApplyNetworkBoundaries, BatchCoalesceBelowBoundaries,
-        DistributedExt, EndDistributedContext, InsertBroadcast, StartDistributedContext,
-        WorkerQueryContext, assert_snapshot, display_plan_ascii,
+        AddCoalesceOnTop, ApplyNetworkBoundaries, BatchCoalesceBelowBoundaries, DistributedExt,
+        EndDistributedContext, InjectNetworkBoundaryPlaceholders, InsertBroadcast,
+        StartDistributedContext, WorkerQueryContext, assert_snapshot, display_plan_ascii,
     };
     use futures::TryStreamExt;
     use std::any::Any;
@@ -65,7 +65,7 @@ mod tests {
         let node = StartDistributedContext.optimize(node, opts)?;
         let node = AddCoalesceOnTop.optimize(node, opts)?;
         let node = InsertBroadcast.optimize(node, opts)?;
-        let node = AnnotatePlan.optimize(node, opts)?;
+        let node = InjectNetworkBoundaryPlaceholders.optimize(node, opts)?;
         let node = ApplyNetworkBoundaries.optimize(node, opts)?;
         let node = BatchCoalesceBelowBoundaries.optimize(node, opts)?;
         let physical_distributed = EndDistributedContext.optimize(node, opts)?;


### PR DESCRIPTION
Closes https://github.com/datafusion-contrib/datafusion-distributed/issues/347

This PR ships two main things:

## Split the `DistributedPhysicalOptimizerRule` into multiple, more scoped ones

Previously, all the planning in the project was done in one rule. Now, it's split in multiple more composable ones, so that users are free to insert their own rules in the middle:

```rust
StartDistributedContext
AddCoalesceOnTop
InsertBroadcast
InjectNetworkBoundaryPlaceholders
ApplyNetworkBoundaries
BatchCoalesceBelowBoundaries
EndDistributedContext
```

The big bulk of the work happens in:
- `InjectNetworkBoundaryPlaceholders` which injects network boundary placeholders in the middle of the plan, that just contain information about the network boundary type and the number of input tasks.
- `ApplyNetworkBoundaries` which reads the network boundary placeholders and inject the actual network boundaries.

## Expose the `NetworkBoundaryPlaceholder` as part of the public API

In https://github.com/datafusion-contrib/datafusion-distributed/issues/347, we discussed about exposing the annotations system as part of the public API, and https://github.com/apache/datafusion/issues/20396 upstream aims to provide such a public API in vanilla DataFusion.

While that's powerful, after some consideration, this project would have a hard time exposing a stable API if the full power of the annotations is exposed, so instead, another approach is attempted:
- All the annotation system (`AnnotatedPan` struct, etc...) is made private, is not even exposed outside of the `rule_4_inject_network_boundary_placeholders.rs` file, so it's private even to this project itself.
- The new API for customizing distributed plan is given in the form of `NetworkBoundaryPlaceholder`s, which are planning-time `ExecutionPlan` implementations with a very narrow API:
  - The NetworkBoundary kind to inject (coalesce, shuffle, or broadcast)
  - The input task count of the stage below

The chain of optimizer rules use this same `NetworkBoundaryPlaceholder` API for injecting its network boundaries, which is what allows making `AnnotatedPlan` private even within the project, and at the same time, allows users to inject their own rules in between `InjectNetworkBoundaryPlaceholders` and `ApplyNetworkBoundaries`, or even replace `InjectNetworkBoundaryPlaceholders` all together with their own custom implementation.

This test demonstrates how to use the `NetworkBoundaryPlaceholder` API for customizing a distributed plan:
https://github.com/datafusion-contrib/datafusion-distributed/blob/2dd97539bf736e83c1697b763c5ba1c724a1e69d/tests/custom_network_boundary_placeholders.rs