### PR TITLE
Attach cached parquet metadata reader factory after worker plan decode

### DIFF
--- a/src/flight_service/do_get.rs
+++ b/src/flight_service/do_get.rs
@@ -21,7 +21,12 @@ use crate::flight_service::spawn_select_all::spawn_select_all;
 use datafusion::arrow::ipc::CompressionType;
 use datafusion::arrow::ipc::writer::IpcWriteOptions;
 use datafusion::common::exec_datafusion_err;
+use datafusion::common::tree_node::{Transformed, TreeNode};
+use datafusion::datasource::physical_plan::parquet::CachedParquetFileReaderFactory;
+use datafusion::datasource::physical_plan::{FileScanConfig, ParquetSource};
+use datafusion::datasource::source::DataSourceExec;
 use datafusion::error::DataFusionError;
+use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::execution::{SendableRecordBatchStream, SessionStateBuilder};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_proto::physical_plan::AsExecutionPlan;
@@ -120,6 +125,7 @@ impl Worker {
             .get_or_try_init(|| async {
                 let proto_node = PhysicalPlanNode::try_decode(doget.plan_proto.as_ref())?;
                 let mut plan = proto_node.try_into_physical_plan(&task_ctx, &codec)?;
+                plan = attach_cached_parquet_reader_factory(plan, session_state.runtime_env())?;
                 for hook in self.hooks.on_plan.iter() {
                     plan = hook(plan)
                 }
@@ -246,6 +252,43 @@ impl Worker {
             _ => Status::internal(format!("Error during flight stream: {err}")),
         }))))
     }
+}
+
+fn attach_cached_parquet_reader_factory(
+    plan: Arc<dyn ExecutionPlan>,
+    runtime_env: &Arc<RuntimeEnv>,
+) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+    let runtime_env = Arc::clone(runtime_env);
+    let transformed = plan.transform_up(move |plan| {
+        if let Some(dse) = plan.as_any().downcast_ref::<DataSourceExec>() {
+            if let Some(file_scan) = dse.data_source().as_any().downcast_ref::<FileScanConfig>() {
+                if let Some(parquet_source) = file_scan
+                    .file_source
+                    .as_any()
+                    .downcast_ref::<ParquetSource>()
+                {
+                    if parquet_source.parquet_file_reader_factory().is_some() {
+                        return Ok(Transformed::no(plan));
+                    }
+
+                    let store = runtime_env.object_store(file_scan.object_store_url.clone())?;
+                    let metadata_cache = runtime_env.cache_manager.get_file_metadata_cache();
+                    let reader_factory =
+                        Arc::new(CachedParquetFileReaderFactory::new(store, metadata_cache));
+                    let new_source = parquet_source
+                        .clone()
+                        .with_parquet_file_reader_factory(reader_factory);
+
+                    let mut new_scan = file_scan.clone();
+                    new_scan.file_source = Arc::new(new_source);
+                    let new_exec = DataSourceExec::new(Arc::new(new_scan));
+                    return Ok(Transformed::yes(Arc::new(new_exec)));
+                }
+            }
+        }
+        Ok(Transformed::no(plan))
+    })?;
+    Ok(transformed.data)
 }
 
 fn build_flight_data_stream(


### PR DESCRIPTION
## Summary
- traverse the decoded worker physical plan and find `DataSourceExec` parquet file scans then attach `CachedParquetFileReaderFactory` using the worker `RuntimeEnv` object store and metadata cache
```
BEFORE:

DataSourceExec: file_groups={3 groups: [[datafusion-distributed/testdata/weather/result-000000.parquet], [datafusion-distributed/testdata/weather/result-000001.parquet], [datafusion-distributed/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, RainToday], file_type=parquet, predicate=MinTemp@0 > 10, pruning_predicate=MinTemp_null_count@1 != row_count@2 AND MinTemp_max@0 > 10, required_guarantees=[], metrics=[output_rows=210, elapsed_compute=3ns, output_bytes=7.3 KB, output_batches=3, files_ranges_pruned_statistics=3 total → 3 matched, row_groups_pruned_statistics=3 total → 3 matched, row_groups_pruned_bloom_filter=3 total → 3 matched, page_index_rows_pruned=366 total → 210 matched, batches_split=0, bytes_scanned=33.54 K, file_open_errors=0, file_scan_errors=0, num_predicate_creation_errors=0, predicate_cache_inner_records=0, predicate_cache_records=0, predicate_evaluation_errors=0, pushdown_rows_matched=0, pushdown_rows_pruned=0, bloom_filter_eval_time=33.13µs, metadata_load_time=25.65ms, page_index_eval_time=52.42µs, row_pushdown_eval_time=6ns, statistics_eval_time=36.17µs, time_elapsed_opening=26.08ms, time_elapsed_processing=2.47ms, time_elapsed_scanning_total=19.24ms, time_elapsed_scanning_until_data=19.14ms, scan_efficiency_ratio=24% (33.54 K/137.4 K)]

AFTER:

DataSourceExec: file_groups={3 groups: [[datafusion-distributed/testdata/weather/result-000000.parquet], [datafusion-distributed/testdata/weather/result-000001.parquet], [datafusion-distributed/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, RainToday], file_type=parquet, predicate=MinTemp@0 > 10, pruning_predicate=MinTemp_null_count@1 != row_count@2 AND MinTemp_max@0 > 10, required_guarantees=[], metrics=[output_rows=210, elapsed_compute=3ns, output_bytes=7.3 KB, output_batches=3, files_ranges_pruned_statistics=3 total → 3 matched, row_groups_pruned_statistics=3 total → 3 matched, row_groups_pruned_bloom_filter=3 total → 3 matched, page_index_rows_pruned=366 total → 210 matched, batches_split=0, bytes_scanned=4.82 K, file_open_errors=0, file_scan_errors=0, num_predicate_creation_errors=0, predicate_cache_inner_records=0, predicate_cache_records=0, predicate_evaluation_errors=0, pushdown_rows_matched=0, pushdown_rows_pruned=0, bloom_filter_eval_time=49.88µs, metadata_load_time=12.77ms, page_index_eval_time=85.30µs, row_pushdown_eval_time=6ns, statistics_eval_time=59.63µs, time_elapsed_opening=13.42ms, time_elapsed_processing=2.89ms, time_elapsed_scanning_total=19.75ms, time_elapsed_scanning_until_data=19.60ms, scan_efficiency_ratio=3.5% (4.82 K/137.4 K)]
```

## Why

metadata_cache is not in the workers workers. I dont see it where we serialize/deserialize `ParquetScanExecNode`, the metadata cache is not included at all. [ParquetScanExecNode](https://github.com/apache/datafusion/blob/e894a03bea638e35677eaf27876966013dd64bf4/datafusion/proto/src/generated/prost.rs#L1621) is constructed from `ParquetSource` here: https://github.com/apache/datafusion/blob/33b86fe02e7bbe63135995c2dbb47bf83c08143c/datafusion/proto/src/physical_plan/mod.rs#L2913


My understanding is that this is intentional, because the cache is in local memory. Passing the factory over the network wouldn’t make sense because it will reference the coordinators local metadata cache.