### PR TITLE
Add shuffle benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,8 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "arrow-string",
+ "half",
+ "rand 0.9.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ insta = { version = "1.46.0", features = ["filters"], optional = true }
 tpchgen = { git = "https://github.com/clflushopt/tpchgen-rs", rev = "e83365a5a9101906eb9f78c5607b83bc59849acf", optional = true }
 tpchgen-arrow = { git = "https://github.com/clflushopt/tpchgen-rs", rev = "e83365a5a9101906eb9f78c5607b83bc59849acf", optional = true }
 parquet = { version = "57.1.0", optional = true }
-arrow = { version = "57.1.0", optional = true }
+arrow = { version = "57.1.0", optional = true, features = ["test_utils"] }
 hyper-util = { version = "0.1.16", optional = true }
 pretty_assertions = { version = "1.4", optional = true }
 reqwest = { version = "0.12", optional = true }
@@ -80,7 +80,7 @@ insta = { version = "1.46.0", features = ["filters"] }
 tpchgen = { git = "https://github.com/clflushopt/tpchgen-rs", rev = "e83365a5a9101906eb9f78c5607b83bc59849acf" }
 tpchgen-arrow = { git = "https://github.com/clflushopt/tpchgen-rs", rev = "e83365a5a9101906eb9f78c5607b83bc59849acf" }
 parquet = "57.1.0"
-arrow = "57.1.0"
+arrow = { version = "57.1.0", features = ["test_utils"] }
 tokio-stream = { version = "0.1.17", features = ["sync"] }
 hyper-util = "0.1.16"
 pretty_assertions = "1.4"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -49,3 +49,7 @@ path = "cdk/bin/worker.rs"
 [[bench]]
 name = "broadcast_cache_scenarios"
 harness = false
+
+[[bench]]
+name = "shuffle"
+harness = false

--- a/benchmarks/benches/shuffle.rs
+++ b/benchmarks/benches/shuffle.rs
@@ -1,0 +1,77 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use datafusion_distributed::{CompressionType, ShuffleBench};
+use std::time::{Duration, Instant};
+use tokio::runtime::Builder as RuntimeBuilder;
+
+fn shuffle(c: &mut Criterion) {
+    let rt = RuntimeBuilder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+
+    let mut group = c.benchmark_group("shuffle");
+    group.sample_size(10);
+
+    let benches = vec![
+        ShuffleBench {
+            producer_tasks: 1,
+            consumer_tasks: 1,
+            partitions: 8,
+            total_rows: 1_000_000,
+            batch_size: 1024,
+            compression: None,
+        },
+        ShuffleBench {
+            producer_tasks: 1,
+            consumer_tasks: 1,
+            partitions: 8,
+            total_rows: 1_000_000,
+            batch_size: 1024,
+            compression: Some(CompressionType::LZ4_FRAME),
+        },
+        ShuffleBench {
+            producer_tasks: 8,
+            consumer_tasks: 1,
+            partitions: 8,
+            total_rows: 1_000_000,
+            batch_size: 1024,
+            compression: None,
+        },
+        ShuffleBench {
+            producer_tasks: 1,
+            consumer_tasks: 8,
+            partitions: 8,
+            total_rows: 1_000_000,
+            batch_size: 1024,
+            compression: None,
+        },
+        ShuffleBench {
+            producer_tasks: 8,
+            consumer_tasks: 8,
+            partitions: 8,
+            total_rows: 1_000_000,
+            batch_size: 1024,
+            compression: None,
+        },
+    ];
+
+    for bench in benches {
+        let name = bench.to_string();
+        group.bench_function(BenchmarkId::new("stream", name), |b| {
+            b.iter_custom(|iters| {
+                let mut total = Duration::ZERO;
+                for _ in 0..iters {
+                    let start = Instant::now();
+                    rt.block_on(bench.run()).unwrap();
+                    total += start.elapsed();
+                }
+                total
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, shuffle);
+criterion_main!(benches);

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,7 +1,9 @@
 mod children_helpers;
 mod map_last_stream;
 mod on_drop_stream;
+mod task_context_helpers;
 
 pub(crate) use children_helpers::require_one_child;
 pub(crate) use map_last_stream::map_last_stream;
 pub(crate) use on_drop_stream::on_drop_stream;
+pub(crate) use task_context_helpers::task_ctx_with_extension;

--- a/src/common/task_context_helpers.rs
+++ b/src/common/task_context_helpers.rs
@@ -1,0 +1,18 @@
+use datafusion::execution::TaskContext;
+use std::sync::Arc;
+
+/// Builds a new [TaskContext] by cloning the provided one and adding the config extension to it.
+pub(crate) fn task_ctx_with_extension<T: Send + Sync + 'static>(
+    ctx: &TaskContext,
+    ext: T,
+) -> TaskContext {
+    TaskContext::new(
+        ctx.task_id(),
+        ctx.session_id(),
+        ctx.session_config().clone().with_extension(Arc::new(ext)),
+        ctx.scalar_functions().clone(),
+        ctx.aggregate_functions().clone(),
+        ctx.window_functions().clone(),
+        ctx.runtime_env(),
+    )
+}

--- a/src/execution_plans/benchmarks/mod.rs
+++ b/src/execution_plans/benchmarks/mod.rs
@@ -1,0 +1,3 @@
+mod shuffle_bench;
+
+pub use shuffle_bench::ShuffleBench;

--- a/src/execution_plans/benchmarks/shuffle_bench.rs
+++ b/src/execution_plans/benchmarks/shuffle_bench.rs
@@ -1,0 +1,192 @@
+use crate::common::task_ctx_with_extension;
+use crate::flight_service::WorkerConnectionPool;
+use crate::flight_service::test_utils::memory_worker::MemoryWorker;
+use crate::stage::MaybeEncodedPlan;
+use crate::{
+    BoxCloneSyncChannel, ChannelResolver, DistributedExt, DistributedTaskContext, ExecutionTask,
+    NetworkShuffleExec, Stage, create_flight_client,
+};
+use arrow::datatypes::DataType::{
+    Boolean, Dictionary, Float64, Int32, Int64, List, Timestamp, UInt8, Utf8,
+};
+use arrow::datatypes::{Field, Schema, TimeUnit};
+use arrow::util::data_gen::create_random_batch;
+use arrow_flight::flight_service_client::FlightServiceClient;
+use arrow_ipc::CompressionType;
+use bytes::Bytes;
+use datafusion::common::{Result, exec_err};
+use datafusion::execution::SessionStateBuilder;
+use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::{ExecutionPlan, PlanProperties};
+use futures::TryStreamExt;
+use std::fmt::{Display, Formatter};
+use std::sync::Arc;
+use tokio::task::JoinSet;
+use url::Url;
+use uuid::Uuid;
+
+/// [ChannelResolver] implementation that returns gRPC clients backed by an in-memory
+/// tokio duplex rather than a TCP connection.
+#[derive(Clone)]
+pub struct InMemoryChannelsResolver {
+    channels: Vec<BoxCloneSyncChannel>,
+}
+
+#[async_trait::async_trait]
+impl ChannelResolver for InMemoryChannelsResolver {
+    async fn get_flight_client_for_url(
+        &self,
+        url: &Url,
+    ) -> Result<FlightServiceClient<BoxCloneSyncChannel>> {
+        let Some(port) = url.port() else {
+            return exec_err!("Missing port in url {url}");
+        };
+        Ok(create_flight_client(self.channels[port as usize].clone()))
+    }
+}
+
+/// Configuration for the worker connection pool benchmark.
+pub struct ShuffleBench {
+    pub producer_tasks: usize,
+    pub consumer_tasks: usize,
+    pub partitions: usize,
+    pub total_rows: usize,
+    pub batch_size: usize,
+    pub compression: Option<CompressionType>,
+}
+
+impl Display for ShuffleBench {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}producer_{}consumer_{}partitions_{}rows_{}batch_{:?}compression",
+            self.producer_tasks,
+            self.consumer_tasks,
+            self.partitions,
+            self.total_rows,
+            self.batch_size,
+            self.compression
+        )
+    }
+}
+
+impl ShuffleBench {
+    pub async fn run(&self) -> Result<()> {
+        #[rustfmt::skip]
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", Int64, false),
+            Field::new("metric", Float64, false),
+            Field::new("flag", Boolean, true),
+            Field::new("label", Utf8, true),
+            Field::new("category", Dictionary(Box::new(Int32), Box::new(Utf8)), true),
+            Field::new("raw", UInt8, false),
+            Field::new("ts", Timestamp(TimeUnit::Nanosecond, None), false),
+            Field::new("count", Int32, false),
+            Field::new("tags", List(Arc::new(Field::new_list_field(Utf8, true))), true),
+        ]));
+        let base_batch = create_random_batch(Arc::clone(&schema), self.batch_size, 0.1, 0.5)?;
+
+        let mut batches = vec![];
+        let mut total_rows = self.total_rows;
+        while total_rows > 0 {
+            batches.push(base_batch.clone());
+            total_rows = total_rows.saturating_sub(self.batch_size);
+        }
+        let mut workers = vec![];
+        for input_task_i in 0..self.producer_tasks {
+            workers.push(MemoryWorker::new(input_task_i));
+        }
+
+        let partitions_per_producer_task = self.partitions * self.consumer_tasks;
+
+        // Round-robin the batches across workers and partitions.
+        let mut worker_i = 0;
+        let mut partition_i = 0;
+        while let Some(batch) = batches.pop() {
+            workers[worker_i].add_batch(partition_i, batch);
+            partition_i += 1;
+            if partition_i >= partitions_per_producer_task {
+                partition_i = 0;
+                worker_i += 1;
+            }
+            if worker_i >= workers.len() {
+                worker_i = 0
+            }
+        }
+
+        let mut channels = vec![];
+        for worker in workers {
+            channels.push(worker.into_channel().await);
+        }
+
+        let channel_resolver = InMemoryChannelsResolver { channels };
+
+        let task_ctx = SessionStateBuilder::new()
+            .with_distributed_channel_resolver(channel_resolver)
+            .with_distributed_compression(self.compression)?
+            .build()
+            .task_ctx();
+
+        let input_stage = Stage {
+            query_id: Uuid::from_u128(0),
+            num: 0,
+            plan: MaybeEncodedPlan::Encoded(Bytes::new()),
+            tasks: (0..self.producer_tasks)
+                .map(|i| ExecutionTask {
+                    url: Some(Url::parse(&format!("http://localhost:{i}")).unwrap()),
+                })
+                .collect(),
+        };
+
+        let mut join_set = JoinSet::default();
+        for i in 0..self.consumer_tasks {
+            let shuffle = NetworkShuffleExec {
+                properties: PlanProperties::new(
+                    EquivalenceProperties::new(schema.clone()),
+                    Partitioning::UnknownPartitioning(self.partitions),
+                    EmissionType::Incremental,
+                    Boundedness::Bounded,
+                ),
+                input_stage: input_stage.clone(),
+                worker_connections: WorkerConnectionPool::new(self.producer_tasks),
+                metrics_collection: Arc::new(Default::default()),
+            };
+            let task_ctx = Arc::new(task_ctx_with_extension(
+                &task_ctx,
+                DistributedTaskContext {
+                    task_index: i,
+                    task_count: self.consumer_tasks,
+                },
+            ));
+
+            for p in 0..shuffle.properties.partitioning.partition_count() {
+                let stream = shuffle.execute(p, Arc::clone(&task_ctx))?;
+                join_set.spawn(async move { stream.try_collect::<Vec<_>>().await });
+            }
+        }
+        for task in join_set.join_all().await {
+            task?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_benchmark_works() -> Result<()> {
+        ShuffleBench {
+            producer_tasks: 4,
+            consumer_tasks: 4,
+            partitions: 4,
+            total_rows: 100_000,
+            batch_size: 1024,
+            compression: None,
+        }
+        .run()
+        .await
+    }
+}

--- a/src/execution_plans/children_isolator_union.rs
+++ b/src/execution_plans/children_isolator_union.rs
@@ -1,4 +1,5 @@
 use crate::DistributedTaskContext;
+use crate::common::task_ctx_with_extension;
 use datafusion::arrow::array::RecordBatch;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::common::{internal_err, plan_err};
@@ -237,18 +238,7 @@ impl ExecutionPlan for ChildrenIsolatorUnionExec {
                 // We need to intercept the DistributedTaskContext and insert a modified one that
                 // tells the child that is running in "isolation" (see the beginning of this file
                 // for a longer explanation)
-                let context = Arc::new(TaskContext::new(
-                    context.task_id(),
-                    context.session_id(),
-                    context
-                        .session_config()
-                        .clone()
-                        .with_extension(Arc::new(child_task_ctx)),
-                    context.scalar_functions().clone(),
-                    context.aggregate_functions().clone(),
-                    context.window_functions().clone(),
-                    context.runtime_env(),
-                ));
+                let context = Arc::new(task_ctx_with_extension(context.as_ref(), child_task_ctx));
 
                 let stream = input.execute(partition, context)?;
 

--- a/src/execution_plans/mod.rs
+++ b/src/execution_plans/mod.rs
@@ -8,6 +8,9 @@ mod network_coalesce;
 mod network_shuffle;
 mod partition_isolator;
 
+#[cfg(any(test, feature = "integration"))]
+pub mod benchmarks;
+
 pub use broadcast::BroadcastExec;
 pub use children_isolator_union::ChildrenIsolatorUnionExec;
 pub use distributed::DistributedExec;

--- a/src/flight_service/do_get.rs
+++ b/src/flight_service/do_get.rs
@@ -63,13 +63,13 @@ pub struct DoGet {
 /// TaskData stores state for a single task being executed by this Endpoint. It may be shared
 /// by concurrent requests for the same task which execute separate partitions.
 pub struct TaskData {
-    pub(super) plan: Arc<dyn ExecutionPlan>,
+    pub(crate) plan: Arc<dyn ExecutionPlan>,
     /// `num_partitions_remaining` is initialized to the total number of partitions in the task (not
     /// only tasks in the partition group). This is decremented for each request to the endpoint
     /// for this task. Once this count is zero, the task is likely complete. The task may not be
     /// complete because it's possible that the same partition was retried and this count was
     /// decremented more than once for the same partition.
-    num_partitions_remaining: Arc<AtomicUsize>,
+    pub(crate) num_partitions_remaining: Arc<AtomicUsize>,
 }
 
 impl TaskData {

--- a/src/flight_service/mod.rs
+++ b/src/flight_service/mod.rs
@@ -1,6 +1,8 @@
 mod do_get;
 mod session_builder;
 mod spawn_select_all;
+#[cfg(any(test, feature = "integration"))]
+pub(crate) mod test_utils;
 mod worker;
 mod worker_connection_pool;
 

--- a/src/flight_service/test_utils/memory_worker.rs
+++ b/src/flight_service/test_utils/memory_worker.rs
@@ -1,0 +1,88 @@
+use crate::{BoxCloneSyncChannel, StageKey, TaskData, Worker};
+use bytes::Bytes;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::datasource::memory::MemorySourceConfig;
+use hyper_util::rt::TokioIo;
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use tonic::transport::{Endpoint, Server};
+use uuid::Uuid;
+
+pub fn test_stage_key(task_number: u64) -> StageKey {
+    StageKey {
+        query_id: Bytes::from(Uuid::from_u128(0).as_bytes().to_vec()),
+        stage_id: 0,
+        task_number,
+    }
+}
+
+pub struct MemoryWorker {
+    task_index: usize,
+    schema: Option<SchemaRef>,
+    partitions_batches: Vec</* partition */ Vec<RecordBatch>>,
+}
+
+impl MemoryWorker {
+    pub fn new(task_index: usize) -> Self {
+        Self {
+            task_index,
+            schema: None,
+            partitions_batches: vec![],
+        }
+    }
+
+    pub fn add_batch(&mut self, partition_i: usize, batch: RecordBatch) {
+        while partition_i >= self.partitions_batches.len() {
+            self.partitions_batches.push(vec![]);
+        }
+        let batches = self.partitions_batches.get_mut(partition_i).unwrap();
+        if self.schema.is_none() {
+            self.schema = Some(batch.schema());
+        }
+        batches.push(batch);
+    }
+
+    pub async fn into_channel(self) -> BoxCloneSyncChannel {
+        let schema = self.schema.expect("Schema was not set");
+        let worker = Worker::default();
+        let plan = MemorySourceConfig::try_new_exec(&self.partitions_batches, schema.clone(), None)
+            .expect("Failing to build MemorySourceConfig");
+        let swmr_task_data = worker
+            .task_data_entries
+            .get_with(test_stage_key(self.task_index as _), async {
+                Default::default()
+            })
+            .await;
+        swmr_task_data
+            .get_or_init(|| async move {
+                TaskData {
+                    plan: plan.clone(),
+                    num_partitions_remaining: Arc::new(AtomicUsize::new(
+                        self.partitions_batches.len(),
+                    )),
+                }
+            })
+            .await;
+
+        let (client, server) = tokio::io::duplex(1024 * 1024);
+
+        let mut client = Some(client);
+        let channel = Endpoint::try_from(format!("http://localhost:{}", self.task_index))
+            .expect("Invalid dummy URL for building an endpoint. This should never happen")
+            .connect_with_connector_lazy(tower::service_fn(move |_| {
+                let client = client
+                    .take()
+                    .expect("Client taken twice. This should never happen");
+                async move { Ok::<_, std::io::Error>(TokioIo::new(client)) }
+            }));
+
+        tokio::spawn(async move {
+            Server::builder()
+                .add_service(worker.into_flight_server())
+                .serve_with_incoming(tokio_stream::once(Ok::<_, std::io::Error>(server)))
+                .await
+        });
+        BoxCloneSyncChannel::new(channel)
+    }
+}

--- a/src/flight_service/test_utils/mod.rs
+++ b/src/flight_service/test_utils/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod memory_worker;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,3 +51,6 @@ pub use observability::{
 };
 
 pub use protobuf::StageKey;
+
+#[cfg(any(feature = "integration", test))]
+pub use execution_plans::benchmarks::ShuffleBench;


### PR DESCRIPTION
Adds a microbenchmark for shuffles.

The intention is to scope down as much as possible the way performance is measured specifically for shuffle operations in order to qualify further improvements.

The benchmark can be run with:

```
cargo bench -p datafusion-distributed-benchmarks --bench shuffle
```