### PR TITLE
Fix system metrics never collecting due to async closure in `thread::spawn`

### DIFF
--- a/src/observability/service.rs
+++ b/src/observability/service.rs
@@ -5,8 +5,6 @@ use datafusion::physical_plan::ExecutionPlan;
 use moka::future::Cache;
 use std::sync::Arc;
 #[cfg(feature = "system-metrics")]
-use std::thread;
-#[cfg(feature = "system-metrics")]
 use std::time::Duration;
 #[cfg(feature = "system-metrics")]
 use sysinfo::{Pid, ProcessRefreshKind};
@@ -39,10 +37,8 @@ impl ObservabilityServiceImpl {
             let pid = Pid::from_u32(std::process::id());
             let mut sys = sysinfo::System::new_all();
 
-            // Spawn background thread to send system metrics.
-            // This is done to prevent stalling the tokio thread
-            // due to the sys call, leading to task pool starvation.
-            thread::spawn(move || {
+            // Spawn background task to periodically collect and send system metrics.
+            tokio::task::spawn(async move {
                 loop {
                     sys.refresh_process_specifics(
                         pid,
@@ -64,7 +60,7 @@ impl ObservabilityServiceImpl {
                         break;
                     };
 
-                    thread::sleep(Duration::from_millis(100));
+                    tokio::time::sleep(Duration::from_millis(100)).await;
                 }
             });
         }


### PR DESCRIPTION
This change fixes the background system metrics collection thread that silently never ran, causing CPU and memory to always report as zero in the console. Instead of having a dedicated background thread we have a dedicated tokio task handle system metrics collection on a worker's observability service.