### PR TITLE
Asynchronous distributed planning

### DIFF
--- a/benchmarks/cdk/bin/worker.rs
+++ b/benchmarks/cdk/bin/worker.rs
@@ -10,8 +10,8 @@ use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::physical_plan::execute_stream;
 use datafusion::prelude::SessionContext;
 use datafusion_distributed::{
-    ChannelResolver, DistributedExt, DistributedMetricsFormat, DistributedPhysicalOptimizerRule,
-    Worker, WorkerResolver, display_plan_ascii, get_distributed_channel_resolver,
+    ChannelResolver, DistributedExt, DistributedMetricsFormat, SessionStateBuilderExt, Worker,
+    WorkerResolver, display_plan_ascii, get_distributed_channel_resolver,
     get_distributed_worker_resolver, rewrite_distributed_plan_with_metrics,
 };
 use futures::{StreamExt, TryFutureExt};
@@ -94,7 +94,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .with_default_features()
         .with_runtime_env(Arc::clone(&runtime_env))
         .with_distributed_worker_resolver(Ec2WorkerResolver::new())
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_planner()
         .with_distributed_broadcast_joins(cmd.broadcast_joins)?
         .build();
     let ctx = SessionContext::from(state);

--- a/benchmarks/src/run.rs
+++ b/benchmarks/src/run.rs
@@ -28,9 +28,7 @@ use datafusion::physical_plan::display::DisplayableExecutionPlan;
 use datafusion::physical_plan::{collect, displayable};
 use datafusion::prelude::*;
 use datafusion_distributed::test_utils::localhost::LocalHostWorkerResolver;
-use datafusion_distributed::{
-    DistributedExt, DistributedPhysicalOptimizerRule, NetworkBoundaryExt, Worker,
-};
+use datafusion_distributed::{DistributedExt, NetworkBoundaryExt, SessionStateBuilderExt, Worker};
 use datafusion_distributed_benchmarks::datasets::{clickbench, register_tables, tpcds, tpch};
 use std::error::Error;
 use std::fs;
@@ -178,7 +176,7 @@ impl RunOpt {
             .with_default_features()
             .with_config(self.config()?)
             .with_distributed_worker_resolver(LocalHostWorkerResolver::new(self.workers.clone()))
-            .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+            .with_distributed_planner()
             .with_distributed_files_per_task(
                 self.files_per_task.unwrap_or(get_available_parallelism()),
             )?

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -36,7 +36,7 @@ use datafusion_cli::{
 use datafusion_distributed::test_utils::in_memory_channel_resolver::{
     InMemoryChannelResolver, InMemoryWorkerResolver,
 };
-use datafusion_distributed::{DistributedExt, DistributedPhysicalOptimizerRule};
+use datafusion_distributed::{DistributedExt, SessionStateBuilderExt};
 use std::env;
 use std::path::Path;
 use std::process::ExitCode;
@@ -148,7 +148,7 @@ async fn main_inner() -> Result<()> {
         .with_default_features()
         .with_config(session_config)
         .with_runtime_env(runtime_env)
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_planner()
         .with_distributed_worker_resolver(InMemoryWorkerResolver::new(16))
         .with_distributed_channel_resolver(InMemoryChannelResolver::default())
         .build();

--- a/console/examples/console_run.rs
+++ b/console/examples/console_run.rs
@@ -4,11 +4,10 @@ use datafusion::common::DataFusionError;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::prelude::{ParquetReadOptions, SessionContext};
 use datafusion_distributed::{
-    DistributedExt, DistributedPhysicalOptimizerRule, WorkerResolver, display_plan_ascii,
+    DistributedExt, SessionStateBuilderExt, WorkerResolver, display_plan_ascii,
 };
 use futures::TryStreamExt;
 use std::error::Error;
-use std::sync::Arc;
 use structopt::StructOpt;
 use url::Url;
 
@@ -38,7 +37,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let state = SessionStateBuilder::new()
         .with_default_features()
         .with_distributed_worker_resolver(localhost_resolver)
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_planner()
         .with_distributed_files_per_task(1)?
         .build();
 

--- a/console/examples/tpcds_runner.rs
+++ b/console/examples/tpcds_runner.rs
@@ -4,7 +4,7 @@ use datafusion::execution::SessionStateBuilder;
 use datafusion::physical_plan::execute_stream;
 use datafusion::prelude::SessionContext;
 use datafusion_distributed::{
-    DistributedExt, DistributedMetricsFormat, DistributedPhysicalOptimizerRule, WorkerResolver,
+    DistributedExt, DistributedMetricsFormat, SessionStateBuilderExt, WorkerResolver,
     display_plan_ascii,
 };
 use datafusion_distributed_benchmarks::datasets::{register_tables, tpcds};
@@ -97,7 +97,7 @@ async fn run_queries(
     let state = SessionStateBuilder::new()
         .with_default_features()
         .with_distributed_worker_resolver(localhost_resolver)
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_planner()
         .build();
 
     let ctx = SessionContext::from(state);

--- a/docs/source/user-guide/channel-resolver.md
+++ b/docs/source/user-guide/channel-resolver.md
@@ -43,7 +43,7 @@ async fn main() {
     let state = SessionStateBuilder::new()
         // these two are mandatory.
         .with_distributed_worker_resolver(todo!())
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_planner()
         // the CustomChannelResolver needs to be passed here once...
         .with_distributed_channel_resolver(channel_resolver.clone())
         .build();

--- a/docs/source/user-guide/concepts.md
+++ b/docs/source/user-guide/concepts.md
@@ -24,10 +24,10 @@ You'll see these concepts mentioned extensively across the documentation and the
 
 Some other more tangible concepts are the structs and traits exposed publicly, the most important are:
 
-## [DistributedPhysicalOptimizerRule](https://github.com/datafusion-contrib/datafusion-distributed/blob/main/src/distributed_planner/distributed_physical_optimizer_rule.rs)
+## [SessionStateBuilderExt](https://github.com/datafusion-contrib/datafusion-distributed/blob/main/src/distributed_planner/session_state_builder_ext.rs)
 
-A physical optimizer rule that transforms single-node DataFusion query plans into distributed query plans. It reads
-a fully formed physical plan and injects the appropriate nodes to execute the query in a distributed fashion.
+An extension trait for `SessionStateBuilder` that provides `with_distributed_planner()`. This registers a custom
+query planner that transforms single-node DataFusion query plans into distributed query plans after physical planning.
 
 It builds the distributed plan from bottom to top, injecting network boundaries at appropriate locations based on
 the nodes present in the original plan.

--- a/docs/source/user-guide/getting-started.md
+++ b/docs/source/user-guide/getting-started.md
@@ -49,7 +49,7 @@ impl WorkerResolver for LocalhostWorkerResolver {
 }
 ```
 
-Register both the `WorkerResolver` implementation and the `DistributedPhysicalOptimizerRule` in DataFusion's
+Register the `WorkerResolver` implementation and the distributed planner in DataFusion's
 `SessionStateBuilder` to enable distributed query planning:
 
 ```rs
@@ -59,7 +59,7 @@ let localhost_worker_resolver = LocalhostWorkerResolver {
 
 let state = SessionStateBuilder::new()
     .with_distributed_worker_resolver(localhost_worker_resolver)
-    .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+    .with_distributed_planner()
     .build();
 
 let ctx = SessionContext::from(state);

--- a/docs/source/user-guide/worker-resolver.md
+++ b/docs/source/user-guide/worker-resolver.md
@@ -24,7 +24,7 @@ impl WorkerResolver for CustomWorkerResolver {
 async fn main() {
     let state = SessionStateBuilder::new()
         .with_distributed_worker_resolver(CustomWorkerResolver)
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_planner()
         .build();
 }
 ```

--- a/docs/source/user-guide/worker.md
+++ b/docs/source/user-guide/worker.md
@@ -248,7 +248,7 @@ With the resolver in place, wire it into the session and tag each worker with a 
 
 ```rust
 use datafusion::execution::SessionStateBuilder;
-use datafusion_distributed::{DistributedExt, DistributedPhysicalOptimizerRule, Worker};
+use datafusion_distributed::{DistributedExt, Worker};
 
 let worker_version = std::env::var("COMMIT_HASH").unwrap_or_default();
 
@@ -262,7 +262,7 @@ let resolver = VersionAwareWorkerResolver::start_version_filtering(
 let state = SessionStateBuilder::new()
     .with_default_features()
     .with_distributed_worker_resolver(resolver)
-    .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+    .with_distributed_planner()
     .build();
 
 let ctx = SessionContext::from(state);

--- a/examples/custom_execution_plan.rs
+++ b/examples/custom_execution_plan.rs
@@ -39,8 +39,8 @@ use datafusion_distributed::test_utils::in_memory_channel_resolver::{
     InMemoryChannelResolver, InMemoryWorkerResolver,
 };
 use datafusion_distributed::{
-    DistributedExt, DistributedPhysicalOptimizerRule, DistributedTaskContext, TaskEstimation,
-    TaskEstimator, WorkerQueryContext, display_plan_ascii,
+    DistributedExt, DistributedTaskContext, SessionStateBuilderExt, TaskEstimation, TaskEstimator,
+    WorkerQueryContext, display_plan_ascii,
 };
 use datafusion_proto::physical_plan::PhysicalExtensionCodec;
 use datafusion_proto::protobuf;
@@ -382,7 +382,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_config(config)
         .with_distributed_worker_resolver(worker_resolver)
         .with_distributed_channel_resolver(channel_resolver)
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_planner()
         .with_distributed_user_codec(NumbersExecCodec)
         .with_distributed_task_estimator(NumbersTaskEstimator)
         .build();

--- a/examples/in_memory_cluster.rs
+++ b/examples/in_memory_cluster.rs
@@ -4,14 +4,13 @@ use datafusion::common::DataFusionError;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::prelude::{ParquetReadOptions, SessionContext};
 use datafusion_distributed::{
-    BoxCloneSyncChannel, ChannelResolver, DistributedExt, DistributedPhysicalOptimizerRule, Worker,
+    BoxCloneSyncChannel, ChannelResolver, DistributedExt, SessionStateBuilderExt, Worker,
     WorkerQueryContext, WorkerResolver, WorkerServiceClient, create_worker_client,
     display_plan_ascii,
 };
 use futures::TryStreamExt;
 use hyper_util::rt::TokioIo;
 use std::error::Error;
-use std::sync::Arc;
 use structopt::StructOpt;
 use tonic::transport::{Endpoint, Server};
 
@@ -38,7 +37,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .with_default_features()
         .with_distributed_worker_resolver(InMemoryWorkerResolver)
         .with_distributed_channel_resolver(InMemoryChannelResolver::new())
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_planner()
         .with_distributed_files_per_task(1)?
         .build();
 

--- a/examples/localhost_run.rs
+++ b/examples/localhost_run.rs
@@ -4,11 +4,10 @@ use datafusion::common::DataFusionError;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::prelude::{ParquetReadOptions, SessionContext};
 use datafusion_distributed::{
-    DistributedExt, DistributedPhysicalOptimizerRule, WorkerResolver, display_plan_ascii,
+    DistributedExt, SessionStateBuilderExt, WorkerResolver, display_plan_ascii,
 };
 use futures::TryStreamExt;
 use std::error::Error;
-use std::sync::Arc;
 use structopt::StructOpt;
 use url::Url;
 
@@ -39,7 +38,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let state = SessionStateBuilder::new()
         .with_default_features()
         .with_distributed_worker_resolver(localhost_resolver)
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_planner()
         .with_distributed_files_per_task(1)?
         .build();
 

--- a/examples/localhost_versioned_run.rs
+++ b/examples/localhost_versioned_run.rs
@@ -4,12 +4,11 @@ use datafusion::common::DataFusionError;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::prelude::{ParquetReadOptions, SessionContext};
 use datafusion_distributed::{
-    DefaultChannelResolver, DistributedExt, DistributedPhysicalOptimizerRule, GetWorkerInfoRequest,
+    DefaultChannelResolver, DistributedExt, GetWorkerInfoRequest, SessionStateBuilderExt,
     WorkerResolver, create_worker_client, display_plan_ascii,
 };
 use futures::TryStreamExt;
 use std::error::Error;
-use std::sync::Arc;
 use structopt::StructOpt;
 use url::Url;
 
@@ -93,7 +92,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let state = SessionStateBuilder::new()
         .with_default_features()
         .with_distributed_worker_resolver(localhost_resolver)
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_planner()
         .with_distributed_files_per_task(1)?
         .build();
 

--- a/src/distributed_ext.rs
+++ b/src/distributed_ext.rs
@@ -197,7 +197,7 @@ pub trait DistributedExt: Sized {
     /// # use datafusion::prelude::SessionConfig;
     /// # use url::Url;
     /// # use std::sync::Arc;
-    /// # use datafusion_distributed::{BoxCloneSyncChannel, WorkerResolver, DistributedExt, DistributedPhysicalOptimizerRule, WorkerQueryContext};
+    /// # use datafusion_distributed::{BoxCloneSyncChannel, WorkerResolver, DistributedExt, SessionStateBuilderExt, WorkerQueryContext};
     ///
     /// struct CustomWorkerResolver;
     ///
@@ -211,9 +211,7 @@ pub trait DistributedExt: Sized {
     /// // This tweaks the SessionState so that it can plan for distributed queries and execute them.
     /// let state = SessionStateBuilder::new()
     ///     .with_distributed_worker_resolver(CustomWorkerResolver)
-    ///     // the DistributedPhysicalOptimizerRule also needs to be passed so that query plans
-    ///     // get distributed.
-    ///     .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+    ///     .with_distributed_planner()
     ///     .build();
     /// ```
     fn with_distributed_worker_resolver<T: WorkerResolver + Send + Sync + 'static>(
@@ -241,7 +239,7 @@ pub trait DistributedExt: Sized {
     /// # use datafusion::prelude::SessionConfig;
     /// # use url::Url;
     /// # use std::sync::Arc;
-    /// # use datafusion_distributed::{BoxCloneSyncChannel, ChannelResolver, DistributedExt, DistributedPhysicalOptimizerRule, WorkerQueryContext, WorkerServiceClient};
+    /// # use datafusion_distributed::{BoxCloneSyncChannel, ChannelResolver, DistributedExt, SessionStateBuilderExt, WorkerQueryContext, WorkerServiceClient};
     ///
     /// struct CustomChannelResolver;
     ///
@@ -256,9 +254,7 @@ pub trait DistributedExt: Sized {
     /// // This tweaks the SessionState so that it can plan for distributed queries and execute them.
     /// let state = SessionStateBuilder::new()
     ///     .with_distributed_channel_resolver(CustomChannelResolver)
-    ///     // the DistributedPhysicalOptimizerRule also needs to be passed so that query plans
-    ///     // get distributed.
-    ///     .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+    ///     .with_distributed_planner()
     ///     .build();
     ///
     /// // This function can be provided to a Worker so that, upon receiving a distributed

--- a/src/distributed_planner/batch_coalescing_below_network_boundaries.rs
+++ b/src/distributed_planner/batch_coalescing_below_network_boundaries.rs
@@ -61,12 +61,10 @@ pub(crate) fn batch_coalescing_below_network_boundaries(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::distributed_planner::session_state_builder_ext::SessionStateBuilderExt;
     use crate::test_utils::in_memory_channel_resolver::InMemoryWorkerResolver;
     use crate::test_utils::parquet::register_parquet_tables;
-    use crate::{
-        DistributedExt, DistributedPhysicalOptimizerRule, assert_snapshot, display_plan_ascii,
-    };
+    use crate::{DistributedExt, assert_snapshot, display_plan_ascii};
     use datafusion::execution::SessionStateBuilder;
     use datafusion::prelude::{SessionConfig, SessionContext};
     use itertools::Itertools;
@@ -161,7 +159,7 @@ mod tests {
         let state = SessionStateBuilder::new()
             .with_default_features()
             .with_config(SessionConfig::new().with_target_partitions(4))
-            .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+            .with_distributed_planner()
             .with_distributed_worker_resolver(InMemoryWorkerResolver::new(3))
             .build();
 

--- a/src/distributed_planner/distribute_plan.rs
+++ b/src/distributed_planner/distribute_plan.rs
@@ -1,80 +1,83 @@
 use crate::common::require_one_child;
-use crate::distributed_planner::batch_coalescing_below_network_boundaries;
+use crate::distributed_planner::batch_coalescing_below_network_boundaries::batch_coalescing_below_network_boundaries;
+use crate::distributed_planner::insert_broadcast::insert_broadcast_execs;
 use crate::distributed_planner::plan_annotator::{
     AnnotatedPlan, PlanOrNetworkBoundary, annotate_plan,
 };
 use crate::{
-    DistributedConfig, DistributedExec, NetworkBroadcastExec, NetworkCoalesceExec,
+    DistributedConfig, NetworkBoundaryExt, NetworkBroadcastExec, NetworkCoalesceExec,
     NetworkShuffleExec, TaskEstimator,
 };
+use datafusion::common::DataFusionError;
+use datafusion::common::tree_node::TreeNode;
 use datafusion::config::ConfigOptions;
-use datafusion::error::DataFusionError;
-use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
-use std::fmt::Debug;
 use std::ops::AddAssign;
 use std::sync::Arc;
 use uuid::Uuid;
 
-use super::insert_broadcast::insert_broadcast_execs;
-
-/// Physical optimizer rule that inspects the plan, places the appropriate network
-/// boundaries, and breaks it down into stages that can be executed in a distributed manner.
+/// Inspects the plan, places the appropriate network boundaries, and breaks it down into stages
+/// that can be executed in a distributed manner.
 ///
-/// The rule has three steps:
+/// It performs the following operations:
 ///
-/// 1. Annotate the plan with [annotate_plan]: adds some annotations to each node about how
+/// 1. It prepares the plan for distribution, adding some extra single-node nodes like
+///    [BroadcastExec] or [CoalescePartitionsExec] that will signal the following steps to
+///    introduce network boundaries in the appropriate places.
+///
+/// 2. Annotate the plan with [annotate_plan]: adds some annotations to each node about how
 ///    many distributed tasks should be used in the stage containing them, and whether they
 ///    need a network boundary below or not.
 ///    For more information about this step, read [annotate_plan] docs.
 ///
-/// 2. Based on the [AnnotatedPlan] returned by [annotate_plan], place all the appropriate
+/// 3. Based on the [AnnotatedPlan] returned by [annotate_plan], place all the appropriate
 ///    network boundaries ([NetworkShuffleExec] and [NetworkCoalesceExec]) with the task count
 ///    assignation that the annotations required. After this, the plan is already a distributed
 ///    executable plan.
 ///
-/// 3. Place the [CoalesceBatchesExec] in the appropriate places (just below network boundaries),
+/// 4. Place the [CoalesceBatchesExec] in the appropriate places (just below network boundaries),
 ///    so that we send fewer and bigger record batches over the wire instead of a lot of small ones.
-#[derive(Debug, Default)]
-pub struct DistributedPhysicalOptimizerRule;
-
-impl PhysicalOptimizerRule for DistributedPhysicalOptimizerRule {
-    fn optimize(
-        &self,
-        original: Arc<dyn ExecutionPlan>,
-        cfg: &ConfigOptions,
-    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
-        if original.as_any().is::<DistributedExec>() {
-            return Ok(original);
-        }
-
-        let mut plan = Arc::clone(&original);
-        if original.output_partitioning().partition_count() > 1 {
-            plan = Arc::new(CoalescePartitionsExec::new(plan))
-        }
-
-        plan = insert_broadcast_execs(plan, cfg)?;
-
-        let annotated = annotate_plan(plan, cfg)?;
-
-        let mut stage_id = 1;
-        let distributed = distribute_plan(annotated, cfg, Uuid::new_v4(), &mut stage_id)?;
-        if stage_id == 1 {
-            return Ok(original);
-        }
-        let distributed = batch_coalescing_below_network_boundaries(distributed, cfg)?;
-
-        Ok(Arc::new(DistributedExec::new(distributed)))
+///
+/// This function returns None if the plan was left undistributed.
+pub(super) async fn distribute_plan(
+    original: Arc<dyn ExecutionPlan>,
+    cfg: &ConfigOptions,
+) -> datafusion::common::Result<Option<Arc<dyn ExecutionPlan>>> {
+    // This function should be idempotent, as people need to be able to call this function at will,
+    // and the DistributedExec node should not execute it's content again if it was already called.
+    if original.exists(|plan| Ok(plan.is_network_boundary()))? {
+        return Ok(None);
     }
 
-    fn name(&self) -> &str {
-        "DistributedPhysicalOptimizer"
+    let mut plan = Arc::clone(&original);
+
+    // Add a CoalescePartitionsExec on top of the plan if necessary. The plan annotator will see
+    // this and will place a NetworkCoalesceExec below it.
+    if plan.output_partitioning().partition_count() > 1 {
+        plan = Arc::new(CoalescePartitionsExec::new(plan));
     }
 
-    fn schema_check(&self) -> bool {
-        true
+    // Insert BroadcastExec nodes in collect left joins so that the plan annotator can inject
+    // broadcast network boundaries above.
+    plan = insert_broadcast_execs(plan, cfg)?;
+
+    // Annotate the plan with network boundary and task count information.
+    let annotated = annotate_plan(plan, cfg).await?;
+
+    // Based on the annotations, place the actual network boundaries with the appropriate dimensions.
+    let mut stage_id = 1;
+    let plan = _distribute_plan(annotated, cfg, Uuid::new_v4(), &mut stage_id)?;
+    if stage_id == 1 {
+        return Ok(None);
     }
+
+    // Place some batch coalescing nodes before network boundaries in order to send big batches
+    // over the wire.
+    // TODO: This should be removed after DataFusion 53 upgrade, as CoalesceBatchesExec is deprecated.
+    let plan = batch_coalescing_below_network_boundaries(plan, cfg)?;
+
+    Ok(Some(plan))
 }
 
 /// Takes an [AnnotatedPlan] and returns a modified [ExecutionPlan] with all the network boundaries
@@ -84,7 +87,7 @@ impl PhysicalOptimizerRule for DistributedPhysicalOptimizerRule {
 ///   which they are going to run. This is configurable by the user via the [TaskEstimator] trait.
 /// - The appropriate network boundaries are placed in the plan depending on how it was annotated,
 ///   so new nodes like [NetworkBroadcastExec], [NetworkCoalesceExec] and [NetworkShuffleExec] will be present.
-fn distribute_plan(
+fn _distribute_plan(
     annotated_plan: AnnotatedPlan,
     cfg: &ConfigOptions,
     query_id: Uuid,
@@ -96,7 +99,7 @@ fn distribute_plan(
     let max_child_task_count = children.iter().map(|v| v.task_count.as_usize()).max();
     let new_children = children
         .into_iter()
-        .map(|child| distribute_plan(child, cfg, query_id, stage_id))
+        .map(|child| _distribute_plan(child, cfg, query_id, stage_id))
         .collect::<Result<Vec<_>, _>>()?;
     match annotated_plan.plan_or_nb {
         // This is a leaf node. It needs to be scaled up in order to account for it running in
@@ -174,12 +177,9 @@ mod tests {
         BuildSideOneTaskEstimator, TestPlanOptions, base_session_builder, context_with_query,
         sql_to_physical_plan,
     };
-    use crate::{
-        DistributedExt, DistributedPhysicalOptimizerRule, assert_snapshot, display_plan_ascii,
-    };
+    use crate::{DistributedExt, SessionStateBuilderExt, assert_snapshot, display_plan_ascii};
     use datafusion::execution::SessionStateBuilder;
     use datafusion::physical_plan::displayable;
-    use std::sync::Arc;
     /* schema for the "weather" table
 
      MinTemp [type=DOUBLE] [repetitiontype=OPTIONAL]
@@ -227,7 +227,7 @@ mod tests {
             b.with_distributed_worker_resolver(InMemoryWorkerResolver::new(3))
         })
         .await;
-        assert_snapshot!(plan, @"
+        assert_snapshot!(plan, @r"
         ┌───── DistributedExec ── Tasks: t0:[p0] 
         │ ProjectionExec: expr=[count(*)@0 as count(*), RainToday@1 as RainToday]
         │   SortPreservingMergeExec: [count(Int64(1))@2 ASC NULLS LAST]
@@ -257,7 +257,7 @@ mod tests {
             b.with_distributed_worker_resolver(InMemoryWorkerResolver::new(2))
         })
         .await;
-        assert_snapshot!(plan, @"
+        assert_snapshot!(plan, @r"
         ┌───── DistributedExec ── Tasks: t0:[p0] 
         │ ProjectionExec: expr=[count(*)@0 as count(*), RainToday@1 as RainToday]
         │   SortPreservingMergeExec: [count(Int64(1))@2 ASC NULLS LAST]
@@ -310,7 +310,7 @@ mod tests {
                 .unwrap()
         })
         .await;
-        assert_snapshot!(plan, @"
+        assert_snapshot!(plan, @r"
         ┌───── DistributedExec ── Tasks: t0:[p0] 
         │ ProjectionExec: expr=[count(*)@0 as count(*), RainToday@1 as RainToday]
         │   SortPreservingMergeExec: [count(Int64(1))@2 ASC NULLS LAST]
@@ -360,7 +360,7 @@ mod tests {
             b.with_distributed_worker_resolver(InMemoryWorkerResolver::new(3))
         })
         .await;
-        assert_snapshot!(plan, @"
+        assert_snapshot!(plan, @r"
         ┌───── DistributedExec ── Tasks: t0:[p0] 
         │ ProjectionExec: expr=[count(*)@0 as count(*), RainToday@1 as RainToday]
         │   SortPreservingMergeExec: [count(Int64(1))@2 ASC NULLS LAST]
@@ -427,7 +427,7 @@ mod tests {
             b.with_distributed_worker_resolver(InMemoryWorkerResolver::new(3))
         })
         .await;
-        assert_snapshot!(plan, @"
+        assert_snapshot!(plan, @r"
         ┌───── DistributedExec ── Tasks: t0:[p0] 
         │ CoalescePartitionsExec
         │   HashJoinExec: mode=CollectLeft, join_type=Left, on=[(RainTomorrow@1, RainTomorrow@1)], projection=[MinTemp@0, MaxTemp@2]
@@ -470,7 +470,7 @@ mod tests {
             b.with_distributed_worker_resolver(InMemoryWorkerResolver::new(3))
         })
         .await;
-        assert_snapshot!(plan, @"
+        assert_snapshot!(plan, @r"
         ┌───── DistributedExec ── Tasks: t0:[p0] 
         │ SortPreservingMergeExec: [MinTemp@0 DESC]
         │   [Stage 1] => NetworkCoalesceExec: output_partitions=3, input_tasks=3
@@ -492,7 +492,7 @@ mod tests {
             b.with_distributed_worker_resolver(InMemoryWorkerResolver::new(3))
         })
         .await;
-        assert_snapshot!(plan, @"
+        assert_snapshot!(plan, @r"
         ┌───── DistributedExec ── Tasks: t0:[p0] 
         │ CoalescePartitionsExec
         │   [Stage 2] => NetworkCoalesceExec: output_partitions=8, input_tasks=2
@@ -589,7 +589,7 @@ mod tests {
             b.with_distributed_worker_resolver(InMemoryWorkerResolver::new(6))
         })
         .await;
-        assert_snapshot!(plan, @"
+        assert_snapshot!(plan, @r"
         ┌───── DistributedExec ── Tasks: t0:[p0] 
         │ CoalescePartitionsExec
         │   [Stage 1] => NetworkCoalesceExec: output_partitions=24, input_tasks=6
@@ -621,7 +621,7 @@ mod tests {
             b.with_distributed_worker_resolver(InMemoryWorkerResolver::new(3))
         })
         .await;
-        assert_snapshot!(plan, @"
+        assert_snapshot!(plan, @r"
         ┌───── DistributedExec ── Tasks: t0:[p0] 
         │ CoalescePartitionsExec
         │   [Stage 1] => NetworkCoalesceExec: output_partitions=12, input_tasks=3
@@ -732,7 +732,7 @@ mod tests {
         ON a."RainToday" = b."RainToday"
         "#;
         let annotated = sql_to_explain_with_broadcast(query, 3, true).await;
-        assert_snapshot!(annotated, @"
+        assert_snapshot!(annotated, @r"
         ┌───── DistributedExec ── Tasks: t0:[p0] 
         │ CoalescePartitionsExec
         │   [Stage 2] => NetworkCoalesceExec: output_partitions=3, input_tasks=3
@@ -761,7 +761,7 @@ mod tests {
         INNER JOIN weather c ON b."RainToday" = c."RainToday"
         "#;
         let plan = sql_to_explain_with_broadcast(query, 3, true).await;
-        assert_snapshot!(plan, @"
+        assert_snapshot!(plan, @r"
         ┌───── DistributedExec ── Tasks: t0:[p0] 
         │ CoalescePartitionsExec
         │   [Stage 3] => NetworkCoalesceExec: output_partitions=3, input_tasks=3
@@ -806,7 +806,7 @@ mod tests {
         ");
 
         let plan = sql_to_explain_with_broadcast(query, 3, true).await;
-        assert_snapshot!(plan, @"
+        assert_snapshot!(plan, @r"
         ┌───── DistributedExec ── Tasks: t0:[p0] 
         │ CoalescePartitionsExec
         │   [Stage 2] => NetworkCoalesceExec: output_partitions=3, input_tasks=3
@@ -877,7 +877,7 @@ mod tests {
         ON a."RainToday" = b."RainToday"
         "#;
         let plan = sql_to_explain_with_broadcast_one_to_many(query, 3).await;
-        assert_snapshot!(plan, @"
+        assert_snapshot!(plan, @r"
         ┌───── DistributedExec ── Tasks: t0:[p0] 
         │ CoalescePartitionsExec
         │   [Stage 2] => NetworkCoalesceExec: output_partitions=3, input_tasks=3
@@ -949,8 +949,7 @@ mod tests {
             options.broadcast_enabled,
         );
         if use_optimizer {
-            builder =
-                builder.with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule));
+            builder = builder.with_distributed_planner()
         }
         let builder = configure(builder);
         let (ctx, query) = context_with_query(builder, query).await;

--- a/src/distributed_planner/distribute_plan.rs
+++ b/src/distributed_planner/distribute_plan.rs
@@ -44,8 +44,7 @@ pub(super) async fn distribute_plan(
     original: Arc<dyn ExecutionPlan>,
     cfg: &ConfigOptions,
 ) -> datafusion::common::Result<Option<Arc<dyn ExecutionPlan>>> {
-    // This function should be idempotent, as people need to be able to call this function at will,
-    // and the DistributedExec node should not execute it's content again if it was already called.
+    // Keep this function idempotent.
     if original.exists(|plan| Ok(plan.is_network_boundary()))? {
         return Ok(None);
     }

--- a/src/distributed_planner/distributed_config.rs
+++ b/src/distributed_planner/distributed_config.rs
@@ -118,8 +118,8 @@ impl ConfigExtension for DistributedConfig {
 // FIXME: Ideally, both ChannelResolverExtension and TaskEstimators would be passed as
 //  extensions in SessionConfig's AnyMap instead of the ConfigOptions. However, we need
 //  to pass this as ConfigOptions as we need these two fields to be present during
-//  planning in the DistributedPhysicalOptimizerRule, and the signature of the optimize()
-//  method there accepts a ConfigOptions instead of a SessionConfig.
+//  planning in the DistributedQueryPlanner, and the signature of the create_physical_plan()
+//  method there accepts a SessionState which only provides ConfigOptions.
 //  The following PR addresses this: https://github.com/apache/datafusion/pull/18168
 //  but it still has not been accepted or merged.
 //  Because of this, all the boilerplate trait implementations below are needed.

--- a/src/distributed_planner/mod.rs
+++ b/src/distributed_planner/mod.rs
@@ -1,14 +1,14 @@
 mod batch_coalescing_below_network_boundaries;
+mod distribute_plan;
 mod distributed_config;
-mod distributed_physical_optimizer_rule;
 mod insert_broadcast;
 mod network_boundary;
 mod plan_annotator;
+mod session_state_builder_ext;
 mod task_estimator;
 
-pub(crate) use batch_coalescing_below_network_boundaries::batch_coalescing_below_network_boundaries;
 pub use distributed_config::DistributedConfig;
-pub use distributed_physical_optimizer_rule::DistributedPhysicalOptimizerRule;
 pub use network_boundary::{NetworkBoundary, NetworkBoundaryExt};
+pub use session_state_builder_ext::SessionStateBuilderExt;
 pub(crate) use task_estimator::set_distributed_task_estimator;
 pub use task_estimator::{TaskCountAnnotation, TaskEstimation, TaskEstimator};

--- a/src/distributed_planner/plan_annotator.rs
+++ b/src/distributed_planner/plan_annotator.rs
@@ -180,12 +180,12 @@ async fn _annotate_plan(
     };
 
     let children = plan.children();
-    let mut tasks = Vec::with_capacity(children.len());
+    let mut futures = Vec::with_capacity(children.len());
     for child in children {
         let child = Arc::clone(child);
-        tasks.push(Box::pin(_annotate_plan(child, Some(&plan), cfg, false)));
+        futures.push(Box::pin(_annotate_plan(child, Some(&plan), cfg, false)));
     }
-    let annotated_children = futures::future::try_join_all(tasks).await?;
+    let annotated_children = futures::future::try_join_all(futures).await?;
 
     if plan.children().is_empty() {
         // This is a leaf node, maybe a DataSourceExec, or maybe something else custom from the

--- a/src/distributed_planner/plan_annotator.rs
+++ b/src/distributed_planner/plan_annotator.rs
@@ -1,7 +1,7 @@
 use crate::TaskCountAnnotation::{Desired, Maximum};
 use crate::execution_plans::ChildrenIsolatorUnionExec;
 use crate::{BroadcastExec, DistributedConfig, TaskCountAnnotation, TaskEstimator};
-use datafusion::common::{DataFusionError, plan_datafusion_err};
+use datafusion::common::{DataFusionError, Result, plan_datafusion_err};
 use datafusion::config::ConfigOptions;
 use datafusion::physical_expr::Partitioning;
 use datafusion::physical_plan::ExecutionPlan;
@@ -158,19 +158,19 @@ impl Debug for AnnotatedPlan {
 /// ```
 ///
 /// ```
-pub(super) fn annotate_plan(
+pub(super) async fn annotate_plan(
     plan: Arc<dyn ExecutionPlan>,
     cfg: &ConfigOptions,
 ) -> Result<AnnotatedPlan, DataFusionError> {
-    _annotate_plan(plan, None, cfg, true)
+    _annotate_plan(plan, None, cfg, true).await
 }
 
-fn _annotate_plan(
+async fn _annotate_plan(
     plan: Arc<dyn ExecutionPlan>,
     parent: Option<&Arc<dyn ExecutionPlan>>,
     cfg: &ConfigOptions,
     root: bool,
-) -> Result<AnnotatedPlan, DataFusionError> {
+) -> Result<AnnotatedPlan> {
     let d_cfg = DistributedConfig::from_config_options(cfg)?;
     let broadcast_joins = d_cfg.broadcast_joins;
     let estimator = &d_cfg.__private_task_estimator;
@@ -179,11 +179,13 @@ fn _annotate_plan(
         v => v,
     };
 
-    let annotated_children = plan
-        .children()
-        .iter()
-        .map(|child| _annotate_plan(Arc::clone(child), Some(&plan), cfg, false))
-        .collect::<Result<Vec<_>, _>>()?;
+    let children = plan.children();
+    let mut tasks = Vec::with_capacity(children.len());
+    for child in children {
+        let child = Arc::clone(child);
+        tasks.push(Box::pin(_annotate_plan(child, Some(&plan), cfg, false)));
+    }
+    let annotated_children = futures::future::try_join_all(tasks).await?;
 
     if plan.children().is_empty() {
         // This is a leaf node, maybe a DataSourceExec, or maybe something else custom from the
@@ -265,7 +267,7 @@ fn _annotate_plan(
         // If the parent is trying to coalesce all partitions into one, we need to introduce
         // a network coalesce right below it (or in other words, above the current node)
         && (parent.as_any().is::<CoalescePartitionsExec>()
-            || parent.as_any().is::<SortPreservingMergeExec>())
+        || parent.as_any().is::<SortPreservingMergeExec>())
     {
         // A BroadcastExec underneath a coalesce parent means the build side will cross stages.
         if plan.as_any().is::<BroadcastExec>() {
@@ -980,10 +982,12 @@ mod tests {
         let df = ctx.sql(&query).await.unwrap();
         let mut plan = df.create_physical_plan().await.unwrap();
 
-        plan = insert_broadcast_execs(plan, ctx.state_ref().read().config_options().as_ref())
+        let session_config = ctx.copied_config();
+        plan = insert_broadcast_execs(plan, session_config.options())
             .expect("failed to insert broadcasts");
 
-        let annotated = annotate_plan(plan, ctx.state_ref().read().config_options().as_ref())
+        let annotated = annotate_plan(plan, session_config.options())
+            .await
             .expect("failed to annotate plan");
         format!("{annotated:?}")
     }

--- a/src/distributed_planner/session_state_builder_ext.rs
+++ b/src/distributed_planner/session_state_builder_ext.rs
@@ -1,0 +1,60 @@
+use crate::DistributedExec;
+use crate::distributed_planner::distribute_plan::distribute_plan;
+use async_trait::async_trait;
+use datafusion::common::Result;
+use datafusion::execution::context::QueryPlanner;
+use datafusion::execution::{SessionState, SessionStateBuilder};
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
+use std::sync::Arc;
+
+/// Extension trait for [SessionStateBuilder].
+pub trait SessionStateBuilderExt {
+    /// Injects a [QueryPlanner] implementation that attempts to distribute the plan after the
+    /// normal planning passes are performed.
+    ///
+    /// It will wrap the existing query planner, if one, adding the distribution logic at the end
+    /// of it, so while setting up the [SessionStateBuilder], it's important to call
+    /// [SessionStateBuilderExt::with_distributed_planner] *after* calling
+    /// [SessionStateBuilder::with_query_planner].
+    fn with_distributed_planner(self) -> Self;
+}
+
+impl SessionStateBuilderExt for SessionStateBuilder {
+    fn with_distributed_planner(mut self) -> Self {
+        let prev = std::mem::take(self.query_planner());
+        self.with_query_planner(Arc::new(DistributedQueryPlanner { prev }))
+    }
+}
+#[derive(Debug)]
+struct DistributedQueryPlanner {
+    prev: Option<Arc<dyn QueryPlanner + Send + Sync>>,
+}
+
+#[async_trait]
+impl QueryPlanner for DistributedQueryPlanner {
+    async fn create_physical_plan(
+        &self,
+        logical_plan: &LogicalPlan,
+        session_state: &SessionState,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let s_plan = match &self.prev {
+            None => {
+                // Use the default physical planner.
+                let planner = DefaultPhysicalPlanner::default();
+                planner
+                    .create_physical_plan(logical_plan, session_state)
+                    .await?
+            }
+            Some(prev) => {
+                prev.create_physical_plan(logical_plan, session_state)
+                    .await?
+            }
+        };
+        match distribute_plan(Arc::clone(&s_plan), session_state.config_options()).await? {
+            Some(d_plan) => Ok(Arc::new(DistributedExec::new(d_plan))),
+            None => Ok(s_plan),
+        }
+    }
+}

--- a/src/distributed_planner/session_state_builder_ext.rs
+++ b/src/distributed_planner/session_state_builder_ext.rs
@@ -14,9 +14,9 @@ pub trait SessionStateBuilderExt {
     /// Injects a [QueryPlanner] implementation that attempts to distribute the plan after the
     /// normal planning passes are performed.
     ///
-    /// It will wrap the existing query planner, if one, adding the distribution logic at the end
-    /// of it, so while setting up the [SessionStateBuilder], it's important to call
-    /// [SessionStateBuilderExt::with_distributed_planner] *after* calling
+    /// It will wrap the existing query planner if one, so while setting up DataFusion's
+    /// [SessionStateBuilder], it's important to inject the custom user query planner implementation
+    /// with [SessionStateBuilderExt::with_distributed_planner] strictly *before* calling
     /// [SessionStateBuilder::with_query_planner].
     fn with_distributed_planner(self) -> Self;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub mod test_utils;
 pub use arrow_ipc::CompressionType;
 pub use distributed_ext::DistributedExt;
 pub use distributed_planner::{
-    DistributedConfig, DistributedPhysicalOptimizerRule, NetworkBoundary, NetworkBoundaryExt,
+    DistributedConfig, NetworkBoundary, NetworkBoundaryExt, SessionStateBuilderExt,
     TaskCountAnnotation, TaskEstimation, TaskEstimator,
 };
 pub use execution_plans::{

--- a/src/metrics/task_metrics_collector.rs
+++ b/src/metrics/task_metrics_collector.rs
@@ -130,7 +130,7 @@ mod tests {
         count_plan_nodes_up_to_network_boundary, get_stages_and_task_keys,
     };
     use crate::test_utils::session_context::register_temp_parquet_table;
-    use crate::{DistributedExt, DistributedPhysicalOptimizerRule};
+    use crate::{DistributedExt, SessionStateBuilderExt};
     use datafusion::execution::{SessionStateBuilder, context::SessionContext};
     use datafusion::prelude::SessionConfig;
     use datafusion::{
@@ -151,7 +151,7 @@ mod tests {
             .with_config(config)
             .with_distributed_worker_resolver(InMemoryWorkerResolver::new(10))
             .with_distributed_channel_resolver(InMemoryChannelResolver::default())
-            .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+            .with_distributed_planner()
             .with_distributed_task_estimator(2)
             .with_distributed_metrics_collection(true)
             .unwrap()

--- a/src/metrics/task_metrics_rewriter.rs
+++ b/src/metrics/task_metrics_rewriter.rs
@@ -284,7 +284,7 @@ mod tests {
     use crate::test_utils::plans::count_plan_nodes_up_to_network_boundary;
     use crate::test_utils::session_context::register_temp_parquet_table;
     use crate::worker::generated::worker as pb;
-    use crate::{DistributedExec, DistributedPhysicalOptimizerRule};
+    use crate::{DistributedExec, SessionStateBuilderExt};
     use datafusion::arrow::array::{Int32Array, StringArray};
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::arrow::record_batch::RecordBatch;
@@ -328,7 +328,7 @@ mod tests {
                 .with_distributed_channel_resolver(InMemoryChannelResolver::default())
                 .with_distributed_metrics_collection(true)
                 .unwrap()
-                .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+                .with_distributed_planner()
                 .with_distributed_task_estimator(2)
         }
 

--- a/src/test_utils/localhost.rs
+++ b/src/test_utils/localhost.rs
@@ -1,13 +1,10 @@
-use crate::{
-    DistributedExt, DistributedPhysicalOptimizerRule, Worker, WorkerResolver, WorkerSessionBuilder,
-};
+use crate::{DistributedExt, SessionStateBuilderExt, Worker, WorkerResolver, WorkerSessionBuilder};
 use async_trait::async_trait;
 use datafusion::common::DataFusionError;
 use datafusion::common::runtime::JoinSet;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::prelude::SessionContext;
 use std::error::Error;
-use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::TcpListener;
 use tonic::transport::Server;
@@ -68,7 +65,7 @@ where
     let worker_resolver = LocalHostWorkerResolver::new(ports);
     let mut state = SessionStateBuilder::new()
         .with_default_features()
-        .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule))
+        .with_distributed_planner()
         .with_distributed_worker_resolver(worker_resolver)
         .build();
     state.config_mut().options_mut().execution.target_partitions = 3;

--- a/tests/udfs.rs
+++ b/tests/udfs.rs
@@ -1,6 +1,5 @@
 #[cfg(all(feature = "integration", test))]
 mod tests {
-    use arrow::datatypes::{Field, Schema};
     use arrow::util::pretty::pretty_format_batches;
     use datafusion::arrow::datatypes::DataType;
     use datafusion::error::DataFusionError;
@@ -8,17 +7,10 @@ mod tests {
     use datafusion::logical_expr::{
         ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
     };
-    use datafusion::physical_expr::expressions::lit;
-    use datafusion::physical_expr::{Partitioning, ScalarFunctionExpr};
-    use datafusion::physical_optimizer::PhysicalOptimizerRule;
-    use datafusion::physical_plan::empty::EmptyExec;
-    use datafusion::physical_plan::repartition::RepartitionExec;
-    use datafusion::physical_plan::{ExecutionPlan, execute_stream};
+    use datafusion::physical_plan::execute_stream;
     use datafusion_distributed::test_utils::localhost::start_localhost_context;
-    use datafusion_distributed::{
-        DistributedExt, DistributedPhysicalOptimizerRule, WorkerQueryContext, assert_snapshot,
-        display_plan_ascii,
-    };
+    use datafusion_distributed::test_utils::parquet::register_parquet_tables;
+    use datafusion_distributed::{WorkerQueryContext, assert_snapshot, display_plan_ascii};
     use futures::TryStreamExt;
     use std::any::Any;
     use std::error::Error;
@@ -30,48 +22,39 @@ mod tests {
             Ok(ctx.builder.with_scalar_functions(vec![udf()]).build())
         }
 
-        let (mut ctx, _guard, _) = start_localhost_context(3, build_state).await;
-        ctx = SessionStateBuilder::from(ctx.state())
-            .with_distributed_task_estimator(2)
+        let (ctx, _guard, _) = start_localhost_context(3, build_state).await;
+        let ctx = SessionStateBuilder::from(ctx.state())
             .with_scalar_functions(vec![udf()])
             .build()
             .into();
 
-        let wrap = |input: Arc<dyn ExecutionPlan>| -> Arc<dyn ExecutionPlan> {
-            Arc::new(
-                RepartitionExec::try_new(
-                    input,
-                    Partitioning::Hash(
-                        vec![Arc::new(ScalarFunctionExpr::new(
-                            "test_udf",
-                            udf(),
-                            vec![lit(1)],
-                            Arc::new(Field::new("return", DataType::Int32, false)),
-                            Default::default(),
-                        ))],
-                        1,
-                    ),
-                )
-                .unwrap(),
-            )
-        };
+        register_parquet_tables(&ctx).await?;
 
-        let node = wrap(wrap(Arc::new(EmptyExec::new(Arc::new(Schema::empty())))));
-
-        let physical_distributed =
-            DistributedPhysicalOptimizerRule.optimize(node, ctx.copied_config().options())?;
-
+        let df = ctx
+            .sql(r#"SELECT test_udf("RainToday"), count(*) FROM weather GROUP BY test_udf("RainToday") ORDER BY count(*)"#)
+            .await?;
+        let physical_distributed = df.create_physical_plan().await?;
         let physical_distributed_str = display_plan_ascii(physical_distributed.as_ref(), false);
 
         assert_snapshot!(physical_distributed_str,
             @r"
         ┌───── DistributedExec ── Tasks: t0:[p0] 
-        │ [Stage 2] => NetworkShuffleExec: output_partitions=1, input_tasks=2
+        │ ProjectionExec: expr=[test_udf(weather.RainToday)@0 as test_udf(weather.RainToday), count(*)@1 as count(*)]
+        │   SortPreservingMergeExec: [count(Int64(1))@2 ASC NULLS LAST]
+        │     [Stage 2] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
         └──────────────────────────────────────────────────
-          ┌───── Stage 1 ── Tasks: t0:[p0..p1] t1:[p0..p1] 
-          │ RepartitionExec: partitioning=Hash([test_udf(1)], 2), input_partitions=1
-          │   EmptyExec
+          ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p0..p2] 
+          │ SortExec: expr=[count(*)@1 ASC NULLS LAST], preserve_partitioning=[true]
+          │   ProjectionExec: expr=[test_udf(weather.RainToday)@0 as test_udf(weather.RainToday), count(Int64(1))@1 as count(*), count(Int64(1))@1 as count(Int64(1))]
+          │     AggregateExec: mode=FinalPartitioned, gby=[test_udf(weather.RainToday)@0 as test_udf(weather.RainToday)], aggr=[count(Int64(1))]
+          │       [Stage 1] => NetworkShuffleExec: output_partitions=3, input_tasks=3
           └──────────────────────────────────────────────────
+            ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p0..p5] t2:[p0..p5] 
+            │ RepartitionExec: partitioning=Hash([test_udf(weather.RainToday)@0], 6), input_partitions=1
+            │   AggregateExec: mode=Partial, gby=[test_udf(RainToday@0) as test_udf(weather.RainToday)], aggr=[count(Int64(1))]
+            │     PartitionIsolatorExec: tasks=3 partitions=3
+            │       DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[RainToday], file_type=parquet
+            └──────────────────────────────────────────────────
         ",
         );
 
@@ -82,8 +65,12 @@ mod tests {
         )?;
 
         assert_snapshot!(batches, @r"
-        ++
-        ++
+        +-----------------------------+----------+
+        | test_udf(weather.RainToday) | count(*) |
+        +-----------------------------+----------+
+        | Yes                         | 66       |
+        | No                          | 300      |
+        +-----------------------------+----------+
         ");
         Ok(())
     }


### PR DESCRIPTION
Closes #382

Allows running asynchronous code during distributed planning.

The rationale of this change is explained in #382.

---

> [!NOTE]
> I don't think the tpch_sf1 improvements are real, they just happen to have less network noise at the moment of running.

```
=== Comparing tpch_sf1 results from engine 'datafusion-distributed-custom-worker-service' [prev] with 'datafusion-distributed-async-distributed-planning' [new] ===
      q1: prev= 237 ms, new= 236 ms, diff=1.00 faster ✔
      q2: prev= 336 ms, new= 288 ms, diff=1.17 faster ✔
      q3: prev= 514 ms, new= 446 ms, diff=1.15 faster ✔
      q4: prev= 214 ms, new= 145 ms, diff=1.48 faster ✅
      q5: prev= 298 ms, new= 228 ms, diff=1.31 faster ✅
      q6: prev= 237 ms, new= 168 ms, diff=1.41 faster ✅
      q7: prev= 345 ms, new= 323 ms, diff=1.07 faster ✔
      q8: prev= 360 ms, new= 343 ms, diff=1.05 faster ✔
      q9: prev= 379 ms, new= 311 ms, diff=1.22 faster ✅
     q10: prev= 258 ms, new= 220 ms, diff=1.17 faster ✔
     q11: prev= 350 ms, new= 272 ms, diff=1.29 faster ✅
     q12: prev= 201 ms, new= 199 ms, diff=1.01 faster ✔
     q13: prev= 224 ms, new= 163 ms, diff=1.37 faster ✅
     q14: prev= 234 ms, new= 191 ms, diff=1.23 faster ✅
     q15: prev= 304 ms, new= 201 ms, diff=1.51 faster ✅
     q16: prev= 331 ms, new= 280 ms, diff=1.18 faster ✔
     q17: prev= 374 ms, new= 362 ms, diff=1.03 faster ✔
     q18: prev= 313 ms, new= 264 ms, diff=1.19 faster ✔
     q19: prev= 455 ms, new= 394 ms, diff=1.15 faster ✔
     q20: prev= 300 ms, new= 334 ms, diff=1.11 slower ✖
     q21: prev= 607 ms, new= 580 ms, diff=1.05 faster ✔
     q22: prev= 228 ms, new= 229 ms, diff=1.00 slower ✖
   TOTAL: prev=21325.567500000005 ms, new=18566.214098 ms, diff=1.15 faster ✔


=== Comparing tpch_sf10 results from engine 'datafusion-distributed-custom-worker-service' [prev] with 'datafusion-distributed-async-distributed-planning' [new] ===
      q1: prev=1291 ms, new=1241 ms, diff=1.04 faster ✔
      q2: prev= 452 ms, new= 451 ms, diff=1.00 faster ✔
      q3: prev=1057 ms, new= 939 ms, diff=1.13 faster ✔
      q4: prev= 551 ms, new= 602 ms, diff=1.09 slower ✖
      q5: prev=1518 ms, new=1448 ms, diff=1.05 faster ✔
      q6: prev= 813 ms, new= 681 ms, diff=1.19 faster ✔
      q7: prev=1654 ms, new=1604 ms, diff=1.03 faster ✔
      q8: prev=1867 ms, new=1793 ms, diff=1.04 faster ✔
      q9: prev=2208 ms, new=2249 ms, diff=1.02 slower ✖
     q10: prev=1172 ms, new=1090 ms, diff=1.08 faster ✔
     q11: prev= 397 ms, new= 397 ms, diff=1.00 slower ✖
     q12: prev= 829 ms, new= 775 ms, diff=1.07 faster ✔
     q13: prev= 682 ms, new= 686 ms, diff=1.01 slower ✖
     q14: prev= 703 ms, new= 789 ms, diff=1.12 slower ✖
     q15: prev= 884 ms, new= 951 ms, diff=1.08 slower ✖
     q16: prev= 353 ms, new= 342 ms, diff=1.03 faster ✔
     q17: prev=1914 ms, new=2039 ms, diff=1.07 slower ✖
     q18: prev=1972 ms, new=1872 ms, diff=1.05 faster ✔
     q19: prev= 899 ms, new= 830 ms, diff=1.08 faster ✔
     q20: prev= 822 ms, new= 815 ms, diff=1.01 faster ✔
     q21: prev=2452 ms, new=2329 ms, diff=1.05 faster ✔
     q22: prev= 360 ms, new= 336 ms, diff=1.07 faster ✔
   TOTAL: prev=74580.649137 ms, new=72810.241408 ms, diff=1.02 faster ✔
```

