### PR TITLE
Factor out UUID functions into common module

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -2,8 +2,10 @@ mod children_helpers;
 mod map_last_stream;
 mod on_drop_stream;
 mod task_context_helpers;
+mod uuid;
 
 pub(crate) use children_helpers::require_one_child;
 pub(crate) use map_last_stream::map_last_stream;
 pub(crate) use on_drop_stream::on_drop_stream;
 pub(crate) use task_context_helpers::task_ctx_with_extension;
+pub(crate) use uuid::{deserialize_uuid, serialize_uuid};

--- a/src/common/uuid.rs
+++ b/src/common/uuid.rs
@@ -1,0 +1,11 @@
+use datafusion::common::Result;
+use datafusion_proto::protobuf::proto_error;
+use uuid::Uuid;
+
+pub(crate) fn deserialize_uuid(id: &[u8]) -> Result<Uuid> {
+    Uuid::from_slice(id).map_err(|err| proto_error(format!("Invalid Uuid bytes: {err}")))
+}
+
+pub(crate) fn serialize_uuid(id: &Uuid) -> Vec<u8> {
+    id.as_bytes().to_vec()
+}

--- a/src/execution_plans/distributed.rs
+++ b/src/execution_plans/distributed.rs
@@ -1,4 +1,4 @@
-use crate::common::require_one_child;
+use crate::common::{require_one_child, serialize_uuid};
 use crate::config_extension_ext::get_config_extension_propagation_headers;
 use crate::distributed_planner::NetworkBoundaryExt;
 use crate::networking::get_distributed_worker_resolver;
@@ -139,7 +139,7 @@ impl DistributedExec {
                         plan_proto: bytes.clone(),
                         task_count: stage.tasks.len() as _,
                         task_key: Some(TaskKey {
-                            query_id: stage.query_id.as_bytes().to_vec(),
+                            query_id: serialize_uuid(&stage.query_id),
                             stage_id: stage.num as _,
                             task_number: i as _,
                         }),

--- a/src/metrics/task_metrics_rewriter.rs
+++ b/src/metrics/task_metrics_rewriter.rs
@@ -1,3 +1,4 @@
+use crate::common::serialize_uuid;
 use crate::distributed_planner::NetworkBoundaryExt;
 use crate::execution_plans::DistributedExec;
 use crate::execution_plans::MetricsWrapperExec;
@@ -218,7 +219,7 @@ pub fn stage_metrics_rewriter(
 
         for task_id in 0..stage.tasks.len() {
             let task_key = TaskKey {
-                query_id: stage.query_id.as_bytes().to_vec(),
+                query_id: serialize_uuid(&stage.query_id),
                 stage_id: stage.num as u64,
                 task_number: task_id as u64,
             };
@@ -298,6 +299,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::DistributedExt;
+    use crate::common::serialize_uuid;
     use crate::metrics::task_metrics_rewriter::MetricsWrapperExec;
     use crate::worker::generated::worker::TaskKey;
     use datafusion::physical_plan::empty::EmptyExec;
@@ -437,7 +439,7 @@ mod tests {
         let mut metrics_collection = HashMap::new();
         for task_id in 0..stage.tasks.len() {
             let task_key = TaskKey {
-                query_id: stage.query_id.as_bytes().to_vec(),
+                query_id: serialize_uuid(&stage.query_id),
                 stage_id: stage.num as u64,
                 task_number: task_id as u64,
             };
@@ -478,7 +480,7 @@ mod tests {
             {
                 let expected_task_node_metrics = metrics_collection
                     .get(&TaskKey {
-                        query_id: stage.query_id.as_bytes().to_vec(),
+                        query_id: serialize_uuid(&stage.query_id),
                         stage_id: stage.num as u64,
                         task_number: task_id as u64,
                     })

--- a/src/protobuf/distributed_codec.rs
+++ b/src/protobuf/distributed_codec.rs
@@ -1,4 +1,5 @@
 use super::get_distributed_user_codecs;
+use crate::common::{deserialize_uuid, serialize_uuid};
 use crate::execution_plans::{
     BroadcastExec, ChildrenIsolatorUnionExec, NetworkBroadcastExec, NetworkCoalesceExec,
 };
@@ -67,8 +68,7 @@ impl PhysicalExtensionCodec for DistributedCodec {
             };
 
             Ok(Stage {
-                query_id: uuid::Uuid::from_slice(proto.query_id.as_ref())
-                    .map_err(|_| proto_error("Invalid query_id in StageProto"))?,
+                query_id: deserialize_uuid(proto.query_id.as_ref())?,
                 num: proto.num as usize,
                 plan: inputs.first().cloned(),
                 tasks: decode_tasks(proto.tasks)?,
@@ -231,7 +231,7 @@ impl PhysicalExtensionCodec for DistributedCodec {
     ) -> datafusion::common::Result<()> {
         fn encode_stage_proto(stage: &Stage) -> Result<StageProto, DataFusionError> {
             Ok(StageProto {
-                query_id: Bytes::from(stage.query_id.as_bytes().to_vec()),
+                query_id: serialize_uuid(&stage.query_id).into(),
                 num: stage.num as u64,
                 tasks: encode_tasks(&stage.tasks),
             })

--- a/src/test_utils/plans.rs
+++ b/src/test_utils/plans.rs
@@ -1,5 +1,6 @@
 use super::parquet::register_parquet_tables;
 use crate::NetworkBoundaryExt;
+use crate::common::serialize_uuid;
 use crate::distributed_ext::DistributedExt;
 use crate::execution_plans::DistributedExec;
 use crate::stage::Stage;
@@ -62,7 +63,7 @@ pub fn get_stages_and_task_keys(
         // Add each task.
         for j in 0..stage.tasks.len() {
             task_keys.insert(TaskKey {
-                query_id: stage.query_id.as_bytes().to_vec(),
+                query_id: serialize_uuid(&stage.query_id),
                 stage_id: stage.num as u64,
                 task_number: j as u64,
             });

--- a/src/worker/test_utils/memory_worker.rs
+++ b/src/worker/test_utils/memory_worker.rs
@@ -1,3 +1,4 @@
+use crate::common::serialize_uuid;
 use crate::config_extension_ext::set_distributed_option_extension;
 use crate::worker::generated::worker::TaskKey;
 use crate::{BoxCloneSyncChannel, DistributedConfig, DistributedExt, TaskData, Worker};
@@ -14,7 +15,7 @@ use uuid::Uuid;
 
 pub fn test_task_key(task_number: u64) -> TaskKey {
     TaskKey {
-        query_id: Uuid::from_u128(0).as_bytes().to_vec(),
+        query_id: serialize_uuid(&Uuid::from_u128(0)),
         stage_id: 0,
         task_number,
     }

--- a/src/worker/worker_connection_pool.rs
+++ b/src/worker/worker_connection_pool.rs
@@ -1,4 +1,4 @@
-use crate::common::on_drop_stream;
+use crate::common::{on_drop_stream, serialize_uuid};
 use crate::metrics::LatencyMetricExt;
 use crate::networking::get_distributed_channel_resolver;
 use crate::passthrough_headers::get_passthrough_headers;
@@ -165,7 +165,7 @@ impl WorkerConnection {
                 target_partition_start: target_partition_range.start as u64,
                 target_partition_end: target_partition_range.end as u64,
                 task_key: Some(TaskKey {
-                    query_id: input_stage.query_id.as_bytes().to_vec(),
+                    query_id: serialize_uuid(&input_stage.query_id),
                     stage_id: input_stage.num as u64,
                     task_number: target_task as u64,
                 }),

--- a/tests/udfs.rs
+++ b/tests/udfs.rs
@@ -43,13 +43,13 @@ mod tests {
         │   SortPreservingMergeExec: [count(Int64(1))@2 ASC NULLS LAST]
         │     [Stage 2] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
         └──────────────────────────────────────────────────
-          ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p0..p2]
+          ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p0..p2] 
           │ SortExec: expr=[count(*)@1 ASC NULLS LAST], preserve_partitioning=[true]
           │   ProjectionExec: expr=[test_udf(weather.RainToday)@0 as test_udf(weather.RainToday), count(Int64(1))@1 as count(*), count(Int64(1))@1 as count(Int64(1))]
           │     AggregateExec: mode=FinalPartitioned, gby=[test_udf(weather.RainToday)@0 as test_udf(weather.RainToday)], aggr=[count(Int64(1))]
           │       [Stage 1] => NetworkShuffleExec: output_partitions=3, input_tasks=3
           └──────────────────────────────────────────────────
-            ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p0..p5] t2:[p0..p5]
+            ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p0..p5] t2:[p0..p5] 
             │ RepartitionExec: partitioning=Hash([test_udf(weather.RainToday)@0], 6), input_partitions=1
             │   AggregateExec: mode=Partial, gby=[test_udf(RainToday@0) as test_udf(weather.RainToday)], aggr=[count(Int64(1))]
             │     PartitionIsolatorExec: tasks=3 partitions=3

--- a/tests/udfs.rs
+++ b/tests/udfs.rs
@@ -43,13 +43,13 @@ mod tests {
         │   SortPreservingMergeExec: [count(Int64(1))@2 ASC NULLS LAST]
         │     [Stage 2] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
         └──────────────────────────────────────────────────
-          ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p0..p2] 
+          ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p0..p2]
           │ SortExec: expr=[count(*)@1 ASC NULLS LAST], preserve_partitioning=[true]
           │   ProjectionExec: expr=[test_udf(weather.RainToday)@0 as test_udf(weather.RainToday), count(Int64(1))@1 as count(*), count(Int64(1))@1 as count(Int64(1))]
           │     AggregateExec: mode=FinalPartitioned, gby=[test_udf(weather.RainToday)@0 as test_udf(weather.RainToday)], aggr=[count(Int64(1))]
           │       [Stage 1] => NetworkShuffleExec: output_partitions=3, input_tasks=3
           └──────────────────────────────────────────────────
-            ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p0..p5] t2:[p0..p5] 
+            ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p0..p5] t2:[p0..p5]
             │ RepartitionExec: partitioning=Hash([test_udf(weather.RainToday)@0], 6), input_partitions=1
             │   AggregateExec: mode=Partial, gby=[test_udf(RainToday@0) as test_udf(weather.RainToday)], aggr=[count(Int64(1))]
             │     PartitionIsolatorExec: tasks=3 partitions=3


### PR DESCRIPTION
Just some preparatory refactor for keeping future PRs clean:
- https://github.com/datafusion-contrib/datafusion-distributed/pull/399

This refactor, even if small, is not really related to that PR, so I factored it out.