### PR TITLE
Shuffle project files for preparing to crates.io release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,6 +2165,7 @@ dependencies = [
  "crossbeam-queue",
  "dashmap",
  "datafusion",
+ "datafusion-distributed-benchmarks",
  "datafusion-proto",
  "delegate",
  "futures",
@@ -2179,7 +2180,6 @@ dependencies = [
  "pretty_assertions",
  "prost",
  "rand 0.9.2",
- "reqwest",
  "sketches-ddsketch",
  "structopt",
  "sysinfo",
@@ -2190,30 +2190,23 @@ dependencies = [
  "tonic",
  "tonic-prost",
  "tower",
- "tpchgen",
- "tpchgen-arrow",
  "url",
  "uuid",
- "zip",
 ]
 
 [[package]]
 name = "datafusion-distributed-benchmarks"
 version = "0.1.0"
 dependencies = [
- "arrow-flight",
+ "arrow",
  "async-trait",
  "aws-config",
  "aws-sdk-ec2",
  "axum 0.7.9",
  "built",
- "chrono",
- "clap 4.5.60",
  "criterion",
- "dashmap",
  "datafusion",
  "datafusion-distributed",
- "datafusion-proto",
  "env_logger",
  "futures",
  "log",
@@ -2221,35 +2214,30 @@ dependencies = [
  "object_store",
  "openssl",
  "parquet",
- "prost",
+ "reqwest",
  "serde",
  "serde_json",
  "structopt",
  "sysinfo",
  "tokio",
  "tonic",
+ "tpchgen",
+ "tpchgen-arrow",
  "url",
+ "zip",
 ]
 
 [[package]]
 name = "datafusion-distributed-cli"
 version = "0.1.0"
 dependencies = [
- "arrow-flight",
- "async-trait",
  "clap 4.5.60",
  "datafusion",
  "datafusion-cli",
  "datafusion-distributed",
  "dirs",
  "env_logger",
- "hyper-util",
- "object_store",
  "tokio",
- "tokio-stream",
- "tonic",
- "tower",
- "url",
 ]
 
 [[package]]
@@ -2257,12 +2245,12 @@ name = "datafusion-distributed-console"
 version = "0.1.0"
 dependencies = [
  "arrow",
- "arrow-flight",
  "async-trait",
  "color-eyre",
  "crossterm",
  "datafusion",
  "datafusion-distributed",
+ "datafusion-distributed-benchmarks",
  "futures",
  "ratatui",
  "structopt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,31 +45,21 @@ crossbeam-queue = "0.3"
 sysinfo = { version = "0.30", optional = true }
 sketches-ddsketch = { version = "0.3", features = ["use_serde"] }
 bincode = "1"
+tonic-prost = "0.14.2"
 
 # integration_tests deps
 insta = { version = "1.46.0", features = ["filters"], optional = true }
-tpchgen = { git = "https://github.com/clflushopt/tpchgen-rs", rev = "438e9c2dbc25b2fff82c0efc08b3f13b5707874f", optional = true }
-tpchgen-arrow = { git = "https://github.com/clflushopt/tpchgen-rs", rev = "438e9c2dbc25b2fff82c0efc08b3f13b5707874f", optional = true }
 parquet = { version = "58", optional = true }
 arrow = { version = "58", optional = true, features = ["test_utils"] }
 hyper-util = { version = "0.1.16", optional = true }
-pretty_assertions = { version = "1.4", optional = true }
-reqwest = { version = "0.12", optional = true }
-zip = { version = "6.0", optional = true }
-tonic-prost = "0.14.2"
 
 [features]
 avro = ["datafusion/avro"]
 integration = [
   "insta",
-  "tpchgen",
-  "tpchgen-arrow",
   "parquet",
   "arrow",
   "hyper-util",
-  "pretty_assertions",
-  "reqwest",
-  "zip",
 ]
 
 system-metrics = ["sysinfo"]
@@ -80,15 +70,12 @@ clickbench = ["integration"]
 sysinfo = ["dep:sysinfo"]
 
 [dev-dependencies]
+datafusion-distributed-benchmarks = { path = "benchmarks" }
 structopt = "0.3"
 insta = { version = "1.46.0", features = ["filters"] }
-tpchgen = { git = "https://github.com/clflushopt/tpchgen-rs", rev = "438e9c2dbc25b2fff82c0efc08b3f13b5707874f" }
-tpchgen-arrow = { git = "https://github.com/clflushopt/tpchgen-rs", rev = "438e9c2dbc25b2fff82c0efc08b3f13b5707874f" }
 parquet = "58"
 arrow = { version = "58", features = ["test_utils"] }
 tokio-stream = { version = "0.1.17", features = ["sync"] }
 hyper-util = "0.1.16"
 pretty_assertions = "1.4"
-reqwest = "0.12"
-zip = "6.0"
 test-case = "3.3.1"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -6,7 +6,6 @@ default-run = "dfbench"
 
 [dependencies]
 datafusion = { workspace = true }
-datafusion-proto = { workspace = true }
 datafusion-distributed = { path = "..", features = [
   "integration",
   "system-metrics",
@@ -19,19 +18,19 @@ serde = "1.0.219"
 serde_json = "1.0.141"
 env_logger = "0.11.8"
 async-trait = "0.1.89"
-chrono = "0.4.42"
 futures = "0.3.31"
-dashmap = "6.0.1"
-prost = "0.14.1"
 url = "2.5.7"
-arrow-flight = "58"
+arrow = { version = "58", features = ["test_utils"] }
 tonic = { version = "0.14.1", features = ["transport"] }
+tpchgen = { git = "https://github.com/clflushopt/tpchgen-rs", rev = "438e9c2dbc25b2fff82c0efc08b3f13b5707874f" }
+tpchgen-arrow = { git = "https://github.com/clflushopt/tpchgen-rs", rev = "438e9c2dbc25b2fff82c0efc08b3f13b5707874f" }
+reqwest = "0.12"
+zip = "6.0"
 axum = "0.7"
 object_store = { version = "0.13", features = ["aws"] }
 aws-config = "1"
 aws-sdk-ec2 = "1"
-openssl = { version = "0.10", features = ["vendored"] }
-clap = "4.5"
+openssl = { version = "0.10", features = ["vendored"] } # Keep this. Necessary for the remote benchmarks worker.
 mimalloc = "0.1"
 
 [dev-dependencies]

--- a/benchmarks/cdk/.gitignore
+++ b/benchmarks/cdk/.gitignore
@@ -2,6 +2,7 @@
 !jest.config.js
 *.d.ts
 node_modules
+.cdk-outputs.json
 
 # CDK asset staging directory
 .cdk.staging

--- a/benchmarks/src/datasets/clickbench.rs
+++ b/benchmarks/src/datasets/clickbench.rs
@@ -1,4 +1,4 @@
-use crate::test_utils::benchmarks_common;
+use super::common;
 use datafusion::common::DataFusionError;
 use std::fs;
 use std::io::Write;
@@ -10,11 +10,11 @@ const URL: &str =
     "https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet";
 
 pub fn get_queries() -> Vec<String> {
-    benchmarks_common::get_queries("testdata/clickbench/queries")
+    common::get_queries("testdata/clickbench/queries")
 }
 
 pub fn get_query(id: &str) -> Result<String, DataFusionError> {
-    benchmarks_common::get_query("testdata/clickbench/queries", id)
+    common::get_query("testdata/clickbench/queries", id)
 }
 
 /// Downloads the datafusion-benchmarks repository as a zip file

--- a/benchmarks/src/datasets/common.rs
+++ b/benchmarks/src/datasets/common.rs
@@ -3,8 +3,15 @@ use datafusion::prelude::{ParquetReadOptions, SessionContext};
 use std::fs;
 use std::path::Path;
 
-pub(crate) fn get_queries(path: &str) -> Vec<String> {
-    let queries_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join(path);
+/// Returns the workspace root directory (parent of the benchmarks crate).
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("benchmarks crate should be inside a workspace")
+}
+
+pub fn get_queries(path: &str) -> Vec<String> {
+    let queries_dir = workspace_root().join(path);
     let mut result = vec![];
     for file in queries_dir.read_dir().unwrap() {
         let file = file.unwrap();
@@ -36,8 +43,8 @@ pub(crate) fn get_queries(path: &str) -> Vec<String> {
     result
 }
 
-pub(crate) fn get_query(path: &str, id: &str) -> Result<String, DataFusionError> {
-    let queries_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join(path);
+pub fn get_query(path: &str, id: &str) -> Result<String, DataFusionError> {
+    let queries_dir = workspace_root().join(path);
 
     if !queries_dir.exists() {
         return internal_err!(

--- a/benchmarks/src/datasets/mod.rs
+++ b/benchmarks/src/datasets/mod.rs
@@ -1,0 +1,6 @@
+pub mod clickbench;
+mod common;
+pub mod tpcds;
+pub mod tpch;
+
+pub use common::register_tables;

--- a/benchmarks/src/datasets/tpcds.rs
+++ b/benchmarks/src/datasets/tpcds.rs
@@ -1,4 +1,4 @@
-use crate::test_utils::benchmarks_common;
+use super::common;
 use arrow::datatypes::{DataType, Field};
 use datafusion::common::internal_err;
 use datafusion::error::DataFusionError;
@@ -18,11 +18,11 @@ use std::sync::Arc;
 const URL: &str = "https://github.com/apache/datafusion-benchmarks/archive/refs/heads/main.zip";
 
 pub fn get_queries() -> Vec<String> {
-    benchmarks_common::get_queries("testdata/tpcds/queries")
+    common::get_queries("testdata/tpcds/queries")
 }
 
 pub fn get_query(id: &str) -> Result<String, DataFusionError> {
-    benchmarks_common::get_query("testdata/tpcds/queries", id)
+    common::get_query("testdata/tpcds/queries", id)
 }
 
 /// Downloads the datafusion-benchmarks repository as a zip file

--- a/benchmarks/src/datasets/tpch.rs
+++ b/benchmarks/src/datasets/tpch.rs
@@ -1,8 +1,9 @@
-use crate::test_utils::benchmarks_common;
+use super::common;
 use arrow::record_batch::RecordBatch;
 use datafusion::error::DataFusionError;
 use parquet::{arrow::arrow_writer::ArrowWriter, file::properties::WriterProperties};
 use std::fs;
+use std::path::Path;
 use tpchgen::generators::{
     CustomerGenerator, LineItemGenerator, NationGenerator, OrderGenerator, PartGenerator,
     PartSuppGenerator, RegionGenerator, SupplierGenerator,
@@ -13,19 +14,17 @@ use tpchgen_arrow::{
 };
 
 pub fn get_queries() -> Vec<String> {
-    benchmarks_common::get_queries("testdata/tpch/queries")
+    common::get_queries("testdata/tpch/queries")
 }
 
 pub fn get_query(id: &str) -> Result<String, DataFusionError> {
-    benchmarks_common::get_query("testdata/tpch/queries", id)
+    common::get_query("testdata/tpch/queries", id)
 }
 
-// generate_table creates a parquet file in the data directory from an arrow RecordBatch row
-// source.
 fn generate_table<A>(
     mut data_source: A,
     table_name: &str,
-    data_dir: &std::path::Path,
+    data_dir: &Path,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
     A: Iterator<Item = RecordBatch>,
@@ -49,18 +48,16 @@ where
     Ok(())
 }
 
-// generate_tpch_data generates all TPC-H tables in the specified data directory.
-pub fn generate_tpch_data(data_dir: &std::path::Path, sf: f64, parts: i32) {
+/// Generates all TPC-H tables as parquet files in the specified data directory.
+pub fn generate_tpch_data(data_dir: &Path, sf: f64, parts: i32) {
     fs::create_dir_all(data_dir).expect("Failed to create data directory");
 
     macro_rules! must_generate_tpch_table {
         ($generator:ident, $arrow:ident, $name:literal) => {
             let data_dir = data_dir.join($name);
             fs::create_dir_all(data_dir.clone()).expect("Failed to create data directory");
-            // create three partitions for the table
             (1..=parts).for_each(|part| {
                 generate_table(
-                    // TODO: Consider adjusting the partitions and batch sizes.
                     $arrow::new($generator::new(sf, part, parts)).with_batch_size(1000),
                     &format!("{part}"),
                     &data_dir,

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod datasets;

--- a/benchmarks/src/prepare_clickbench.rs
+++ b/benchmarks/src/prepare_clickbench.rs
@@ -1,5 +1,5 @@
 use datafusion::error::DataFusionError;
-use datafusion_distributed::test_utils::clickbench;
+use datafusion_distributed_benchmarks::datasets::clickbench;
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 

--- a/benchmarks/src/prepare_tpcds.rs
+++ b/benchmarks/src/prepare_tpcds.rs
@@ -1,5 +1,5 @@
 use datafusion::error::DataFusionError;
-use datafusion_distributed::test_utils::tpcds;
+use datafusion_distributed_benchmarks::datasets::tpcds;
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 

--- a/benchmarks/src/run.rs
+++ b/benchmarks/src/run.rs
@@ -27,12 +27,11 @@ use datafusion::execution::SessionStateBuilder;
 use datafusion::physical_plan::display::DisplayableExecutionPlan;
 use datafusion::physical_plan::{collect, displayable};
 use datafusion::prelude::*;
-use datafusion_distributed::test_utils::benchmarks_common;
 use datafusion_distributed::test_utils::localhost::LocalHostWorkerResolver;
-use datafusion_distributed::test_utils::{clickbench, tpcds, tpch};
 use datafusion_distributed::{
     DistributedExt, DistributedPhysicalOptimizerRule, NetworkBoundaryExt, Worker,
 };
+use datafusion_distributed_benchmarks::datasets::{clickbench, register_tables, tpcds, tpch};
 use std::error::Error;
 use std::fs;
 use std::path::PathBuf;
@@ -198,7 +197,7 @@ impl RunOpt {
             .with_distributed_max_tasks_per_stage(self.max_tasks_per_stage)?
             .build();
         let ctx = SessionContext::new_with_state(state);
-        benchmarks_common::register_tables(&ctx, &self.get_path()?).await?;
+        register_tables(&ctx, &self.get_path()?).await?;
 
         println!("Running benchmarks with the following options: {self:?}");
         let mut benchmark_run = BenchmarkRun::new(

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,14 +11,6 @@ tokio = { version = "1.48", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
 dirs = "6"
-arrow-flight = "58"
-object_store = { version = "0.13.2", default-features =  false }
-tonic = { version = "0.14.1", features = ["transport"] }
-tower = "0.5.2"
-hyper-util = "0.1.16"
-tokio-stream = "0.1.17"
-async-trait = "0.1.89"
-url = "2.5.7"
 
 [[bin]]
 name = "datafusion-distributed-cli"

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -13,12 +13,12 @@ ratatui = "0.30.0"
 tokio = { version = "1.49.0", features = ["full"] }
 tonic = "0.14.2"
 datafusion-distributed = { path = "..", features = ["integration", "system-metrics"] }
-arrow-flight = "58"
 url = "2.5.7"
 tokio-stream = "0.1.18"
 
 [dev-dependencies]
 arrow = "58"
 async-trait = "0.1.89"
+datafusion-distributed-benchmarks = { path = "../benchmarks" }
 futures = "0.3.31"
 url = "2.5.7"

--- a/console/examples/tpcds_runner.rs
+++ b/console/examples/tpcds_runner.rs
@@ -7,8 +7,10 @@ use datafusion_distributed::{
     DistributedExt, DistributedMetricsFormat, DistributedPhysicalOptimizerRule, WorkerResolver,
     display_plan_ascii,
 };
+use datafusion_distributed_benchmarks::datasets::{register_tables, tpcds};
 use futures::TryStreamExt;
 use std::error::Error;
+use std::fs;
 use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::Arc;
@@ -73,9 +75,6 @@ async fn run_queries(
     explain_analyze: bool,
     show_distributed_plan: bool,
 ) -> Result<(), Box<dyn Error>> {
-    use datafusion_distributed::test_utils::{benchmarks_common, tpcds};
-    use std::fs;
-
     println!(
         "Running TPC-DS queries (SF={scale_factor}, partitions={parquet_partitions}) against workers: {cluster_ports:?}"
     );
@@ -107,7 +106,7 @@ async fn run_queries(
         .with_distributed_cardinality_effect_task_scale_factor(2.0)?
         .with_distributed_broadcast_joins(true)?;
 
-    benchmarks_common::register_tables(&ctx, &data_dir).await?;
+    register_tables(&ctx, &data_dir).await?;
 
     // Determine which queries to run
     let queries: Vec<String> = if query_id == "all" {

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -1,5 +1,3 @@
-pub mod benchmarks_common;
-pub mod clickbench;
 pub mod in_memory_channel_resolver;
 pub mod insta;
 pub mod localhost;
@@ -9,5 +7,3 @@ pub mod parquet;
 pub mod plans;
 pub mod property_based;
 pub mod session_context;
-pub mod tpcds;
-pub mod tpch;

--- a/tests/clickbench_correctness_test.rs
+++ b/tests/clickbench_correctness_test.rs
@@ -9,10 +9,10 @@ mod tests {
     use datafusion_distributed::test_utils::property_based::{
         compare_ordering, compare_result_set,
     };
-    use datafusion_distributed::test_utils::{benchmarks_common, clickbench};
     use datafusion_distributed::{
         DefaultSessionBuilder, DistributedExec, DistributedExt, display_plan_ascii,
     };
+    use datafusion_distributed_benchmarks::datasets::{clickbench, register_tables};
     use std::ops::Range;
     use std::path::Path;
     use std::sync::Arc;
@@ -284,8 +284,8 @@ mod tests {
             .with_distributed_cardinality_effect_task_scale_factor(CARDINALITY_TASK_COUNT_FACTOR)?
             .with_distributed_broadcast_joins(true)?;
 
-        benchmarks_common::register_tables(&s_ctx, &data_dir).await?;
-        benchmarks_common::register_tables(&d_ctx, &data_dir).await?;
+        register_tables(&s_ctx, &data_dir).await?;
+        register_tables(&d_ctx, &data_dir).await?;
 
         let (s_plan, s_results) = run(&s_ctx, &query_sql).await;
         let (d_plan, d_results) = run(&d_ctx, &query_sql).await;

--- a/tests/clickbench_plans_test.rs
+++ b/tests/clickbench_plans_test.rs
@@ -2,10 +2,10 @@
 mod tests {
     use datafusion::error::Result;
     use datafusion_distributed::test_utils::localhost::start_localhost_context;
-    use datafusion_distributed::test_utils::{benchmarks_common, clickbench};
     use datafusion_distributed::{
         DefaultSessionBuilder, DistributedExec, DistributedExt, assert_snapshot, display_plan_ascii,
     };
+    use datafusion_distributed_benchmarks::datasets::{clickbench, register_tables};
     use std::ops::Range;
     use std::path::Path;
     use tokio::sync::OnceCell;
@@ -918,7 +918,7 @@ mod tests {
             .with_distributed_cardinality_effect_task_scale_factor(CARDINALITY_TASK_COUNT_FACTOR)?
             .with_distributed_broadcast_joins(true)?;
 
-        benchmarks_common::register_tables(&d_ctx, &data_dir).await?;
+        register_tables(&d_ctx, &data_dir).await?;
 
         let df = d_ctx.sql(&query_sql).await?;
         let plan = df.create_physical_plan().await?;

--- a/tests/stateful_data_cleanup.rs
+++ b/tests/stateful_data_cleanup.rs
@@ -5,8 +5,8 @@ mod tests {
     use datafusion::physical_plan::execute_stream;
     use datafusion::prelude::SessionContext;
     use datafusion_distributed::test_utils::localhost::start_localhost_context;
-    use datafusion_distributed::test_utils::{benchmarks_common, tpch};
     use datafusion_distributed::{DefaultSessionBuilder, DistributedExt};
+    use datafusion_distributed_benchmarks::datasets::{register_tables, tpch};
     use futures::TryStreamExt;
     use std::fs;
     use std::path::Path;
@@ -72,7 +72,7 @@ mod tests {
         let d_ctx = d_ctx
             .with_distributed_cardinality_effect_task_scale_factor(CARDINALITY_TASK_COUNT_FACTOR)?;
 
-        benchmarks_common::register_tables(&d_ctx, &data_dir).await?;
+        register_tables(&d_ctx, &data_dir).await?;
 
         let df = d_ctx.sql(&query_sql).await?;
         let task_ctx = d_ctx.task_ctx();

--- a/tests/tpcds_correctness_test.rs
+++ b/tests/tpcds_correctness_test.rs
@@ -9,10 +9,10 @@ mod tests {
     use datafusion_distributed::test_utils::property_based::{
         compare_ordering, compare_result_set,
     };
-    use datafusion_distributed::test_utils::{benchmarks_common, tpcds};
     use datafusion_distributed::{
         DefaultSessionBuilder, DistributedExec, DistributedExt, display_plan_ascii,
     };
+    use datafusion_distributed_benchmarks::datasets::{register_tables, tpcds};
     use std::fs;
     use std::path::Path;
     use std::sync::Arc;
@@ -573,8 +573,8 @@ mod tests {
             .with_distributed_cardinality_effect_task_scale_factor(CARDINALITY_TASK_COUNT_FACTOR)?
             .with_distributed_broadcast_joins(true)?;
 
-        benchmarks_common::register_tables(&s_ctx, &data_dir).await?;
-        benchmarks_common::register_tables(&d_ctx, &data_dir).await?;
+        register_tables(&s_ctx, &data_dir).await?;
+        register_tables(&d_ctx, &data_dir).await?;
 
         let (s_plan, s_results) = run(&s_ctx, &query_sql).await;
         let (d_plan, d_results) = run(&d_ctx, &query_sql).await;

--- a/tests/tpcds_plans_test.rs
+++ b/tests/tpcds_plans_test.rs
@@ -2,10 +2,10 @@
 mod tests {
     use datafusion::error::Result;
     use datafusion_distributed::test_utils::localhost::start_localhost_context;
-    use datafusion_distributed::test_utils::{benchmarks_common, tpcds};
     use datafusion_distributed::{
         DefaultSessionBuilder, DistributedExec, DistributedExt, assert_snapshot, display_plan_ascii,
     };
+    use datafusion_distributed_benchmarks::datasets::{register_tables, tpcds};
     use std::env;
     use std::fs;
     use std::path::Path;
@@ -10596,7 +10596,7 @@ mod tests {
             .with_distributed_cardinality_effect_task_scale_factor(CARDINALITY_TASK_COUNT_FACTOR)?
             .with_distributed_broadcast_joins(true)?;
 
-        benchmarks_common::register_tables(&d_ctx, &data_dir).await?;
+        register_tables(&d_ctx, &data_dir).await?;
 
         let df = d_ctx.sql(&query_sql).await?;
         let plan = df.create_physical_plan().await?;

--- a/tests/tpch_correctness_test.rs
+++ b/tests/tpch_correctness_test.rs
@@ -3,8 +3,8 @@ mod tests {
     use datafusion::physical_plan::execute_stream;
     use datafusion::prelude::SessionContext;
     use datafusion_distributed::test_utils::localhost::start_localhost_context;
-    use datafusion_distributed::test_utils::{benchmarks_common, tpch};
     use datafusion_distributed::{DefaultSessionBuilder, DistributedExt};
+    use datafusion_distributed_benchmarks::datasets::{register_tables, tpch};
     use futures::TryStreamExt;
     use std::error::Error;
     use std::fmt::Display;
@@ -157,7 +157,7 @@ mod tests {
             .execution
             .target_partitions = PARTITIONS;
 
-        benchmarks_common::register_tables(&ctx, &data_dir).await?;
+        register_tables(&ctx, &data_dir).await?;
 
         // Query 15 has three queries in it, one creating the view, the second
         // executing, which we want to capture the output of, and the third

--- a/tests/tpch_plans_test.rs
+++ b/tests/tpch_plans_test.rs
@@ -1,10 +1,10 @@
 #[cfg(all(feature = "integration", feature = "tpch", test))]
 mod tests {
     use datafusion_distributed::test_utils::localhost::start_localhost_context;
-    use datafusion_distributed::test_utils::{benchmarks_common, tpch};
     use datafusion_distributed::{
         DefaultSessionBuilder, DistributedExt, assert_snapshot, display_plan_ascii,
     };
+    use datafusion_distributed_benchmarks::datasets::{register_tables, tpch};
     use std::error::Error;
     use std::fs;
     use std::path::Path;
@@ -1130,7 +1130,7 @@ mod tests {
             .execution
             .target_partitions = PARTITIONS;
 
-        benchmarks_common::register_tables(&d_ctx, &data_dir).await?;
+        register_tables(&d_ctx, &data_dir).await?;
 
         // Query 15 has three queries in it, one creating the view, the second
         // executing, which we want to capture the output of, and the third


### PR DESCRIPTION
The way the project is laid out today make it unsuitable to be published to crates.io, mainly because of the main crate having git dependencies.

This PR just shuffles files and modules around so that we can have a clean main crate that can be sent to crates.io.