### PR TITLE
Add PerTaskPlanTransformer that allows per-task plan specialization

### DIFF
--- a/src/distributed_ext.rs
+++ b/src/distributed_ext.rs
@@ -2,6 +2,10 @@ use crate::config_extension_ext::{
     set_distributed_option_extension, set_distributed_option_extension_from_headers,
 };
 use crate::distributed_planner::set_distributed_task_estimator;
+use crate::execution_plans::per_task_plan_transformer::{
+    PerTaskPlanTransformer, set_distributed_per_task_plan_transformer,
+    set_distributed_per_task_plan_transformer_arc,
+};
 use crate::networking::{set_distributed_channel_resolver, set_distributed_worker_resolver};
 use crate::passthrough_headers::set_passthrough_headers;
 use crate::protobuf::{set_distributed_user_codec, set_distributed_user_codec_arc};
@@ -528,6 +532,40 @@ pub trait DistributedExt: Sized {
         &mut self,
         max_tasks_per_stage: usize,
     ) -> Result<(), DataFusionError>;
+
+    /// Registers a [PerTaskPlanTransformer] that the coordinator will call before serializing the
+    /// plan for each task.
+    ///
+    /// When set, the coordinator produces distinct plan bytes per task by calling
+    /// `transform_for_task(plan, task_index, task_count)` instead of sharing a single serialized
+    /// plan across all workers. This enables per-task plan specialization — for example, emptying
+    /// file groups that a given task will not access, which avoids unnecessary disk-cache
+    /// population on workers.
+    fn with_distributed_per_task_plan_transformer<T: PerTaskPlanTransformer + 'static>(
+        self,
+        transformer: T,
+    ) -> Self;
+
+    /// Same as [DistributedExt::with_distributed_per_task_plan_transformer] but with an
+    /// in-place mutation.
+    fn set_distributed_per_task_plan_transformer<T: PerTaskPlanTransformer + 'static>(
+        &mut self,
+        transformer: T,
+    );
+
+    /// Same as [DistributedExt::with_distributed_per_task_plan_transformer] but with a dynamic
+    /// argument.
+    fn with_distributed_per_task_plan_transformer_arc(
+        self,
+        transformer: Arc<dyn PerTaskPlanTransformer>,
+    ) -> Self;
+
+    /// Same as [DistributedExt::set_distributed_per_task_plan_transformer] but with a dynamic
+    /// argument.
+    fn set_distributed_per_task_plan_transformer_arc(
+        &mut self,
+        transformer: Arc<dyn PerTaskPlanTransformer>,
+    );
 }
 
 impl DistributedExt for SessionConfig {
@@ -649,6 +687,20 @@ impl DistributedExt for SessionConfig {
         Ok(())
     }
 
+    fn set_distributed_per_task_plan_transformer<T: PerTaskPlanTransformer + 'static>(
+        &mut self,
+        transformer: T,
+    ) {
+        set_distributed_per_task_plan_transformer(self, transformer)
+    }
+
+    fn set_distributed_per_task_plan_transformer_arc(
+        &mut self,
+        transformer: Arc<dyn PerTaskPlanTransformer>,
+    ) {
+        set_distributed_per_task_plan_transformer_arc(self, transformer)
+    }
+
     delegate! {
         to self {
             #[call(set_distributed_option_extension)]
@@ -714,6 +766,14 @@ impl DistributedExt for SessionConfig {
             #[call(set_distributed_max_tasks_per_stage)]
             #[expr($?;Ok(self))]
             fn with_distributed_max_tasks_per_stage(mut self, max_tasks_per_stage: usize) -> Result<Self, DataFusionError>;
+
+            #[call(set_distributed_per_task_plan_transformer)]
+            #[expr($;self)]
+            fn with_distributed_per_task_plan_transformer<T: PerTaskPlanTransformer + 'static>(mut self, transformer: T) -> Self;
+
+            #[call(set_distributed_per_task_plan_transformer_arc)]
+            #[expr($;self)]
+            fn with_distributed_per_task_plan_transformer_arc(mut self, transformer: Arc<dyn PerTaskPlanTransformer>) -> Self;
         }
     }
 }
@@ -800,6 +860,16 @@ impl DistributedExt for SessionStateBuilder {
             #[call(set_distributed_max_tasks_per_stage)]
             #[expr($?;Ok(self))]
             fn with_distributed_max_tasks_per_stage(mut self, max_tasks_per_stage: usize) -> Result<Self, DataFusionError>;
+
+            fn set_distributed_per_task_plan_transformer<T: PerTaskPlanTransformer + 'static>(&mut self, transformer: T);
+            #[call(set_distributed_per_task_plan_transformer)]
+            #[expr($;self)]
+            fn with_distributed_per_task_plan_transformer<T: PerTaskPlanTransformer + 'static>(mut self, transformer: T) -> Self;
+
+            fn set_distributed_per_task_plan_transformer_arc(&mut self, transformer: Arc<dyn PerTaskPlanTransformer>);
+            #[call(set_distributed_per_task_plan_transformer_arc)]
+            #[expr($;self)]
+            fn with_distributed_per_task_plan_transformer_arc(mut self, transformer: Arc<dyn PerTaskPlanTransformer>) -> Self;
         }
     }
 }
@@ -886,6 +956,16 @@ impl DistributedExt for SessionState {
             #[call(set_distributed_max_tasks_per_stage)]
             #[expr($?;Ok(self))]
             fn with_distributed_max_tasks_per_stage(mut self, max_tasks_per_stage: usize) -> Result<Self, DataFusionError>;
+
+            fn set_distributed_per_task_plan_transformer<T: PerTaskPlanTransformer + 'static>(&mut self, transformer: T);
+            #[call(set_distributed_per_task_plan_transformer)]
+            #[expr($;self)]
+            fn with_distributed_per_task_plan_transformer<T: PerTaskPlanTransformer + 'static>(mut self, transformer: T) -> Self;
+
+            fn set_distributed_per_task_plan_transformer_arc(&mut self, transformer: Arc<dyn PerTaskPlanTransformer>);
+            #[call(set_distributed_per_task_plan_transformer_arc)]
+            #[expr($;self)]
+            fn with_distributed_per_task_plan_transformer_arc(mut self, transformer: Arc<dyn PerTaskPlanTransformer>) -> Self;
         }
     }
 }
@@ -972,6 +1052,16 @@ impl DistributedExt for SessionContext {
             #[call(set_distributed_max_tasks_per_stage)]
             #[expr($?;Ok(self))]
             fn with_distributed_max_tasks_per_stage(self, max_tasks_per_stage: usize) -> Result<Self, DataFusionError>;
+
+            fn set_distributed_per_task_plan_transformer<T: PerTaskPlanTransformer + 'static>(&mut self, transformer: T);
+            #[call(set_distributed_per_task_plan_transformer)]
+            #[expr($;self)]
+            fn with_distributed_per_task_plan_transformer<T: PerTaskPlanTransformer + 'static>(self, transformer: T) -> Self;
+
+            fn set_distributed_per_task_plan_transformer_arc(&mut self, transformer: Arc<dyn PerTaskPlanTransformer>);
+            #[call(set_distributed_per_task_plan_transformer_arc)]
+            #[expr($;self)]
+            fn with_distributed_per_task_plan_transformer_arc(self, transformer: Arc<dyn PerTaskPlanTransformer>) -> Self;
         }
     }
 }

--- a/src/distributed_planner/distributed_config.rs
+++ b/src/distributed_planner/distributed_config.rs
@@ -1,5 +1,6 @@
 use crate::TaskEstimator;
 use crate::distributed_planner::task_estimator::CombinedTaskEstimator;
+use crate::execution_plans::per_task_plan_transformer::PerTaskPlanTransformerExtension;
 use crate::networking::{ChannelResolverExtension, WorkerResolverExtension};
 use datafusion::common::utils::get_available_parallelism;
 use datafusion::common::{DataFusionError, extensions_options, not_impl_err, plan_err};
@@ -61,6 +62,9 @@ extensions_options! {
         /// [WorkerResolver] implementation that tells the distributed planner information about
         /// the available workers ready to execute distributed tasks.
         pub(crate) __private_worker_resolver: WorkerResolverExtension, default = WorkerResolverExtension::not_implemented()
+        /// Optional [PerTaskPlanTransformer] that the coordinator calls before serializing each
+        /// task's plan, allowing per-task plan specialization (e.g., emptying non-owned file groups).
+        pub(crate) __private_per_task_plan_transformer: PerTaskPlanTransformerExtension, default = PerTaskPlanTransformerExtension::default()
     }
 }
 

--- a/src/execution_plans/distributed.rs
+++ b/src/execution_plans/distributed.rs
@@ -1,6 +1,9 @@
 use crate::common::{require_one_child, serialize_uuid};
 use crate::config_extension_ext::get_config_extension_propagation_headers;
 use crate::distributed_planner::NetworkBoundaryExt;
+use crate::execution_plans::per_task_plan_transformer::{
+    PerTaskPlanTransformer, get_per_task_plan_transformer,
+};
 use crate::networking::get_distributed_worker_resolver;
 use crate::passthrough_headers::get_passthrough_headers;
 use crate::protobuf::{DistributedCodec, tonic_status_to_datafusion_error};
@@ -106,6 +109,8 @@ impl DistributedExec {
             )),
         };
 
+        let transformer = get_per_task_plan_transformer(ctx.session_config().options());
+
         let mut join_set = JoinSet::new();
         let prepared = Arc::clone(&self.plan).transform_up(|plan| {
             // The following logic is just applied on network boundaries.
@@ -115,8 +120,13 @@ impl DistributedExec {
 
             let stage = plan.input_stage();
 
-            let mut spawner =
-                CoordinatorToWorkerTaskSpawner::new(stage, &metrics, &codec, &mut join_set)?;
+            let mut spawner = CoordinatorToWorkerTaskSpawner::new(
+                stage,
+                &metrics,
+                &codec,
+                transformer.as_deref(),
+                &mut join_set,
+            )?;
 
             // Right now, we assign random workers to tasks. This might change in the future.
             let start_idx = rand::rng().random_range(0..urls.len());
@@ -244,8 +254,18 @@ struct CoordinatorToWorkerMetrics {
 ///
 /// This struct is responsible for building tasks that communicate a serialized plan to multiple
 /// workers for further execution.
+///
+/// When a [`PerTaskPlanTransformer`] is registered, each task receives a distinct serialized
+/// plan produced by calling `transform_for_task(plan, task_i, task_count)`. Otherwise all tasks
+/// share the same pre-serialized bytes as before.
 struct CoordinatorToWorkerTaskSpawner<'a> {
-    plan_proto: Vec<u8>,
+    /// The stage plan, kept for per-task transformation when a transformer is registered.
+    /// When no transformer is present, `shared_plan_proto` holds the pre-serialized bytes.
+    plan: Arc<dyn ExecutionPlan>,
+    /// Pre-serialized plan bytes shared across all tasks (used when no transformer is set).
+    shared_plan_proto: Option<Vec<u8>>,
+    codec: &'a dyn PhysicalExtensionCodec,
+    transformer: Option<&'a dyn PerTaskPlanTransformer>,
     query_id: Uuid,
     stage_id: usize,
     task_count: usize,
@@ -260,17 +280,29 @@ impl<'a> CoordinatorToWorkerTaskSpawner<'a> {
         stage: &'a Stage,
         metrics: &'a CoordinatorToWorkerMetrics,
         codec: &'a dyn PhysicalExtensionCodec,
+        transformer: Option<&'a dyn PerTaskPlanTransformer>,
         join_set: &'a mut JoinSet<Result<()>>,
     ) -> Result<Self> {
         let Some(plan) = &stage.plan else {
             return internal_err!("Plan is not set for stage {}", stage.num);
         };
+        let plan = Arc::clone(plan);
 
-        let plan_proto =
-            PhysicalPlanNode::try_from_physical_plan(Arc::clone(plan), codec)?.encode_to_vec();
+        // Pre-serialize once when no transformer is registered, to avoid redundant encoding.
+        let shared_plan_proto = if transformer.is_none() {
+            Some(
+                PhysicalPlanNode::try_from_physical_plan(Arc::clone(&plan), codec)?
+                    .encode_to_vec(),
+            )
+        } else {
+            None
+        };
 
         Ok(Self {
-            plan_proto,
+            plan,
+            shared_plan_proto,
+            codec,
+            transformer,
             query_id: stage.query_id,
             stage_id: stage.num,
             task_count: stage.tasks.len(),
@@ -287,9 +319,21 @@ impl<'a> CoordinatorToWorkerTaskSpawner<'a> {
         let mut headers = get_config_extension_propagation_headers(ctx.session_config())?;
         headers.extend(get_passthrough_headers(ctx.session_config()));
 
+        let plan_proto = match self.transformer {
+            Some(transformer) => {
+                let task_plan =
+                    transformer.transform_for_task(Arc::clone(&self.plan), task_i, self.task_count)?;
+                PhysicalPlanNode::try_from_physical_plan(task_plan, self.codec)?.encode_to_vec()
+            }
+            None => self
+                .shared_plan_proto
+                .clone()
+                .expect("shared_plan_proto is set when no transformer is registered"),
+        };
+
         let msg = CoordinatorToWorkerMsg {
             inner: Some(Inner::SetPlanRequest(SetPlanRequest {
-                plan_proto: self.plan_proto.clone(),
+                plan_proto: plan_proto.clone(),
                 task_count: self.task_count as u64,
                 task_key: Some(TaskKey {
                     query_id: serialize_uuid(&self.query_id),
@@ -298,7 +342,7 @@ impl<'a> CoordinatorToWorkerTaskSpawner<'a> {
                 }),
             })),
         };
-        let plan_size = self.plan_proto.len();
+        let plan_size = plan_proto.len();
 
         let request = Request::from_parts(
             MetadataMap::from_headers(headers),

--- a/src/execution_plans/mod.rs
+++ b/src/execution_plans/mod.rs
@@ -7,6 +7,7 @@ mod network_broadcast;
 mod network_coalesce;
 mod network_shuffle;
 mod partition_isolator;
+pub(crate) mod per_task_plan_transformer;
 
 #[cfg(any(test, feature = "integration"))]
 pub mod benchmarks;

--- a/src/execution_plans/per_task_plan_transformer.rs
+++ b/src/execution_plans/per_task_plan_transformer.rs
@@ -1,0 +1,174 @@
+use crate::DistributedConfig;
+use crate::config_extension_ext::set_distributed_option_extension;
+use datafusion::common::{Result, not_impl_err};
+use datafusion::config::{ConfigField, ConfigOptions, Visit};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::prelude::SessionConfig;
+use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
+
+/// Transforms a physical plan on a per-task basis at the coordinator before serialization.
+///
+/// When the coordinator distributes a stage to multiple workers, it normally serializes
+/// the same plan bytes for every task. Implementing this trait allows the coordinator to
+/// produce a distinct serialized plan per task — for example, by emptying file groups that
+/// a given task will not process, reducing unnecessary disk-cache population on workers.
+///
+/// # Example
+///
+/// ```rust
+/// use std::sync::Arc;
+/// use datafusion::physical_plan::ExecutionPlan;
+/// use datafusion_distributed::{DistributedExt, PerTaskPlanTransformer};
+/// use datafusion::execution::SessionStateBuilder;
+///
+/// #[derive(Debug)]
+/// struct MyTransformer;
+///
+/// impl PerTaskPlanTransformer for MyTransformer {
+///     fn transform_for_task(
+///         &self,
+///         plan: Arc<dyn ExecutionPlan>,
+///         _task_index: usize,
+///         _task_count: usize,
+///     ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+///         // Return a (possibly modified) plan for this task.
+///         Ok(plan)
+///     }
+/// }
+///
+/// let _state = SessionStateBuilder::new()
+///     .with_distributed_per_task_plan_transformer(MyTransformer)
+///     .build();
+/// ```
+pub trait PerTaskPlanTransformer: Debug + Send + Sync {
+    /// Returns a plan specialized for `task_index` out of `task_count` total tasks.
+    ///
+    /// Called once per task by the coordinator before serializing the plan for that task.
+    /// The returned plan replaces the original in the bytes sent to the worker.
+    fn transform_for_task(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        task_index: usize,
+        task_count: usize,
+    ) -> Result<Arc<dyn ExecutionPlan>>;
+}
+
+/// Wrapper stored in [`DistributedConfig`] that holds an optional [`PerTaskPlanTransformer`].
+#[derive(Clone, Default)]
+pub(crate) struct PerTaskPlanTransformerExtension(
+    pub(crate) Option<Arc<dyn PerTaskPlanTransformer>>,
+);
+
+impl PerTaskPlanTransformerExtension {
+    pub(crate) fn get(&self) -> Option<&Arc<dyn PerTaskPlanTransformer>> {
+        self.0.as_ref()
+    }
+}
+
+impl ConfigField for PerTaskPlanTransformerExtension {
+    fn visit<V: Visit>(&self, _: &mut V, _: &str, _: &'static str) {}
+
+    fn set(&mut self, _: &str, _: &str) -> Result<()> {
+        not_impl_err!("PerTaskPlanTransformerExtension cannot be set via string config")
+    }
+}
+
+impl Debug for PerTaskPlanTransformerExtension {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "PerTaskPlanTransformerExtension")
+    }
+}
+
+/// Reads the registered [`PerTaskPlanTransformer`] from [`ConfigOptions`], if any.
+pub(crate) fn get_per_task_plan_transformer(
+    cfg: &ConfigOptions,
+) -> Option<Arc<dyn PerTaskPlanTransformer>> {
+    cfg.extensions
+        .get::<DistributedConfig>()?
+        .__private_per_task_plan_transformer
+        .get()
+        .map(Arc::clone)
+}
+
+/// Registers a [`PerTaskPlanTransformer`] in the [`SessionConfig`].
+pub fn set_distributed_per_task_plan_transformer(
+    cfg: &mut SessionConfig,
+    transformer: impl PerTaskPlanTransformer + 'static,
+) {
+    let opts = cfg.options_mut();
+    if let Some(distributed_cfg) = opts.extensions.get_mut::<DistributedConfig>() {
+        distributed_cfg.__private_per_task_plan_transformer =
+            PerTaskPlanTransformerExtension(Some(Arc::new(transformer)));
+    } else {
+        set_distributed_option_extension(
+            cfg,
+            DistributedConfig {
+                __private_per_task_plan_transformer: PerTaskPlanTransformerExtension(Some(
+                    Arc::new(transformer),
+                )),
+                ..Default::default()
+            },
+        )
+    }
+}
+
+/// Registers a [`PerTaskPlanTransformer`] (already wrapped in [`Arc`]) in the [`SessionConfig`].
+pub fn set_distributed_per_task_plan_transformer_arc(
+    cfg: &mut SessionConfig,
+    transformer: Arc<dyn PerTaskPlanTransformer>,
+) {
+    let opts = cfg.options_mut();
+    if let Some(distributed_cfg) = opts.extensions.get_mut::<DistributedConfig>() {
+        distributed_cfg.__private_per_task_plan_transformer =
+            PerTaskPlanTransformerExtension(Some(transformer));
+    } else {
+        set_distributed_option_extension(
+            cfg,
+            DistributedConfig {
+                __private_per_task_plan_transformer: PerTaskPlanTransformerExtension(Some(
+                    transformer,
+                )),
+                ..Default::default()
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DistributedExt;
+    use datafusion::execution::SessionStateBuilder;
+
+    #[derive(Debug)]
+    struct NoOpTransformer;
+
+    impl PerTaskPlanTransformer for NoOpTransformer {
+        fn transform_for_task(
+            &self,
+            plan: Arc<dyn ExecutionPlan>,
+            _task_index: usize,
+            _task_count: usize,
+        ) -> Result<Arc<dyn ExecutionPlan>> {
+            Ok(plan)
+        }
+    }
+
+    #[test]
+    fn test_set_and_get_transformer() {
+        let state = SessionStateBuilder::new()
+            .with_distributed_per_task_plan_transformer(NoOpTransformer)
+            .build();
+
+        let transformer = get_per_task_plan_transformer(state.config().options());
+        assert!(transformer.is_some());
+    }
+
+    #[test]
+    fn test_no_transformer_by_default() {
+        let state = SessionStateBuilder::new().build();
+        let transformer = get_per_task_plan_transformer(state.config().options());
+        assert!(transformer.is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub use execution_plans::{
     BroadcastExec, DistributedExec, NetworkBroadcastExec, NetworkCoalesceExec, NetworkShuffleExec,
     PartitionIsolatorExec,
 };
+pub use execution_plans::per_task_plan_transformer::PerTaskPlanTransformer;
 pub use metrics::{
     AvgLatencyMetric, BytesCounterMetric, BytesMetricExt, DISTRIBUTED_DATAFUSION_TASK_ID_LABEL,
     DistributedMetricsFormat, FirstLatencyMetric, LatencyMetricExt, MaxLatencyMetric,


### PR DESCRIPTION
## Description

Previously, the coordinator serialized the same plan bytes and sent them to every worker task. This PR introduces a hook that allows the coordinator to produce distinct serialized plan bytes per task before sending.

The problem with creating the same serialized plan for all tasks is that each task ends up receiving all the file groups in the query even the ones it is not assigned to execute on causing unnecessary network calls & memory usage for each task.

This provides the infrastructure that makes coordinator-side per-task plan specialization possible. It doesn't implement any file group logic itself; it just creates the hook.

## Motivation 

If you have 1000 file groups across 10 tasks, each worker previously received metadata for all 1000 files — now it receives ~100. For large scans with many small files (the common metrics query pattern), that's a meaningful reduction in both wire bytes and worker memory.

## Changes

Before: the coordinator serialized the plan once into a single Vec<u8> and sent the same bytes to every worker. There was no way to intercept that serialization to customize the plan per task.

After: the coordinator checks if a PerTaskPlanTransformer is registered. If one is, instead of serializing once and cloning, it calls transform_for_task(plan, task_index, task_count) for each task and serializes the result independently. Each worker gets its own distinct plan bytes.

### New trait: `PerTaskPlanTransformer`  (`src/execution_plans/per_task_plan_transformer.rs`)

A trait that the coordinator calls once per task before serialization:
```rust
fn transform_for_task(plan, task_index, task_count) -> Result<Arc<dyn ExecutionPlan>>
```
Stored in `DistributedConfig` via a `PerTaskPlanTransformerExtension` wrapper.

### Refactor `CoordinatorToWorkerTaskSpawner`  (`src/execution_plans/distributed.rs`)

The spawner now holds the original stage plan alongside a `transformer: Option<&dyn PerTaskPlanTransformer>`:
- **No transformer registered**: pre-serializes plan bytes once and clones them to every task (zero behavior change).
- **Transformer registered**: calls `transform_for_task(plan, i, task_count)` per task and serializes the result, and each worker receives its own specialized plan bytes.


## Follow Up

https://github.com/DataDog/dd-source/pull/416389

After this is merged, I will update the distribution manager and task estimator in dd-source to use the new `PerTaskPlanTransformer` which would help us build the optimization per plan that would lead to savings on:

* Network bandwidth: Each worker receives a smaller plan proto. A FileGroup contains per-file metadata (paths, sizes, partition values, statistics). With N tasks, each worker's plan carries roughly 1/N of that metadata instead of all of it.

* Worker memory: Workers don't hold file metadata for partitions they'll never read.

* Disk cache:. Workers won't issue reads that populate cache entries for files they don't own, which was the original motivation.

* Worker startup latency: Without coordinator specialization, LazyFileGroupSpecializerExec would do a downcast + plan rebuild on the first execute() call. With the coordinator handling it upfront, that work is gone.

Note: we don't save on
* Number of network calls (No change): Still one plan serialization + send per worker.
* Coordinator memory : Previously one Vec<u8> was cloned to every task. Now the coordinator serializes per-task, but send_plan_task produces and sends one plan at a time, so peak memory is roughly one serialized plan, not N.

