### PR TITLE
Harden work unit tests

### DIFF
--- a/src/test_utils/test_work_unit_feed.rs
+++ b/src/test_utils/test_work_unit_feed.rs
@@ -12,6 +12,7 @@ use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::common::{Result, ScalarValue, Statistics, internal_err, plan_err};
 use datafusion::config::ConfigOptions;
 use datafusion::datasource::{TableProvider, TableType};
+use datafusion::error::DataFusionError;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::logical_expr::Expr;
 use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
@@ -26,8 +27,9 @@ use futures::StreamExt;
 use futures::stream::BoxStream;
 use prost::Message;
 use std::any::Any;
-use std::fmt::Formatter;
+use std::fmt::{Display, Formatter};
 use std::sync::Arc;
+use std::time::Duration;
 
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RowGeneratorWorkUnit {
@@ -35,30 +37,89 @@ pub struct RowGeneratorWorkUnit {
     n_rows: u64,
 }
 
+/// A scripted operation that the [`RowGeneratorFeedProvider`] performs on the
+/// coordinator side while producing its per-partition work unit stream.
+///
+/// `WorkUnitOp` is a tiny DSL used by the test harness to drive specific
+/// timing and error scenarios through the feed pipeline. Ops are written as
+/// comma-separated strings in the `test_work_unit` table function:
+///
+/// - `rows(N)` — emit a [`RowGeneratorWorkUnit`] that produces N rows.
+/// - `wait(MS)` — sleep for MS milliseconds before the next op.
+/// - `err(MSG)` — yield a [`DataFusionError::Execution`] with the given
+///   message and terminate the stream.
+#[derive(Debug, Clone)]
+pub enum WorkUnitOp {
+    Rows(u64),
+    Wait(Duration),
+    Err(String),
+}
+
+impl Display for WorkUnitOp {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            WorkUnitOp::Rows(n) => write!(f, "rows({n})"),
+            WorkUnitOp::Wait(d) => write!(f, "wait({})", d.as_millis()),
+            WorkUnitOp::Err(msg) => write!(f, "err({msg})"),
+        }
+    }
+}
+
+fn parse_partition_ops(s: &str) -> Result<Vec<WorkUnitOp>> {
+    if s.trim().is_empty() {
+        return Ok(vec![]);
+    }
+    s.split(',').map(|item| parse_op(item.trim())).collect()
+}
+
+fn parse_op(s: &str) -> Result<WorkUnitOp> {
+    let Some(open) = s.find('(') else {
+        return plan_err!("expected `name(arg)` op, got {s:?}");
+    };
+    if !s.ends_with(')') {
+        return plan_err!("expected closing `)` in op {s:?}");
+    }
+    let name = &s[..open];
+    let arg = &s[open + 1..s.len() - 1];
+    match name {
+        "rows" => {
+            let n: u64 = arg
+                .parse()
+                .map_err(|e| DataFusionError::Plan(format!("invalid rows arg in {s:?}: {e}")))?;
+            Ok(WorkUnitOp::Rows(n))
+        }
+        "wait" => {
+            let n: u64 = arg
+                .parse()
+                .map_err(|e| DataFusionError::Plan(format!("invalid wait arg in {s:?}: {e}")))?;
+            Ok(WorkUnitOp::Wait(Duration::from_millis(n)))
+        }
+        "err" => Ok(WorkUnitOp::Err(arg.to_string())),
+        other => plan_err!("unknown op {other:?} in {s:?}"),
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct RowGeneratorFeedProvider {
-    per_partition_work_units: Vec<Vec<RowGeneratorWorkUnit>>,
+    per_partition_ops: Vec<Vec<WorkUnitOp>>,
     task_count: usize,
     metrics: ExecutionPlanMetricsSet,
 }
 
 impl RowGeneratorFeedProvider {
-    pub fn new(task_count: usize, row_count_per_partition: Vec<Vec<usize>>) -> Self {
+    pub fn new(task_count: usize, per_partition_ops: Vec<Vec<WorkUnitOp>>) -> Self {
         Self {
-            per_partition_work_units: row_count_per_partition
-                .into_iter()
-                .map(|msgs| {
-                    msgs.into_iter()
-                        .map(|n_rows| RowGeneratorWorkUnit {
-                            n_rows: n_rows as u64,
-                        })
-                        .collect()
-                })
-                .collect(),
+            per_partition_ops,
             task_count,
             metrics: ExecutionPlanMetricsSet::new(),
         }
     }
+}
+
+struct FeedStreamState {
+    iter: std::vec::IntoIter<WorkUnitOp>,
+    counter: Count,
+    done: bool,
 }
 
 impl WorkUnitFeedProvider for RowGeneratorFeedProvider {
@@ -69,18 +130,41 @@ impl WorkUnitFeedProvider for RowGeneratorFeedProvider {
         partition: usize,
         _ctx: Arc<TaskContext>,
     ) -> Result<BoxStream<'static, Result<Self::WorkUnit>>> {
-        let work_units_sent: Count =
+        let counter: Count =
             MetricBuilder::new(&self.metrics).counter("work_units_sent", partition);
-        let units = self
-            .per_partition_work_units
+        let ops = self
+            .per_partition_ops
             .get(partition)
             .cloned()
             .unwrap_or_default();
-        Ok(futures::stream::iter(units.into_iter().map(move |unit| {
-            work_units_sent.add(1);
-            Ok(unit)
-        }))
-        .boxed())
+        let state = FeedStreamState {
+            iter: ops.into_iter(),
+            counter,
+            done: false,
+        };
+        let stream = futures::stream::unfold(state, |mut state| async move {
+            if state.done {
+                return None;
+            }
+            loop {
+                let op = state.iter.next()?;
+                match op {
+                    WorkUnitOp::Rows(n) => {
+                        state.counter.add(1);
+                        return Some((Ok(RowGeneratorWorkUnit { n_rows: n }), state));
+                    }
+                    WorkUnitOp::Wait(d) => {
+                        tokio::time::sleep(d).await;
+                        continue;
+                    }
+                    WorkUnitOp::Err(msg) => {
+                        state.done = true;
+                        return Some((Err(DataFusionError::Execution(msg)), state));
+                    }
+                }
+            }
+        });
+        Ok(stream.boxed())
     }
 }
 
@@ -135,12 +219,17 @@ fn row_generator_schema() -> SchemaRef {
 
 /// Table function that creates a [`RowGeneratorExec`].
 ///
-/// Called in SQL as: `SELECT * FROM test_work_unit('my_tag', 2, '3,1', '5', '2')`
+/// Called in SQL as:
+/// `SELECT * FROM test_work_unit('my_tag', 2, 'rows(3),rows(1)', 'rows(5)', 'rows(2)')`
 /// where the first argument is a tag string, the second is the task count (integer),
-/// and the remaining arguments are comma-separated row counts for each partition's feed
-/// messages. An empty string means an empty partition (no messages). The number of
-/// partition arguments must be divisible by the task count — they are distributed evenly
-/// across tasks.
+/// and the remaining arguments are comma-separated [`WorkUnitOp`]s describing what
+/// each partition's feed should do at runtime.
+///
+/// Available ops: `rows(N)` emits a work unit that generates N rows, `wait(MS)`
+/// sleeps the producer for MS milliseconds, `err(MSG)` yields an error and ends
+/// the stream. An empty string means an empty partition (no ops). The number of
+/// partition arguments must be divisible by the task count — they are distributed
+/// evenly across tasks.
 ///
 /// String encoding is used for partitions because DataFusion 52.x has a bug where array
 /// literal arguments are silently dropped by the table-function SQL planner.
@@ -163,36 +252,23 @@ impl TableFunctionImpl for TestWorkUnitFeedFunction {
             Expr::Literal(ScalarValue::Int32(Some(v)), _) => *v as usize,
             v => return plan_err!("task_count must be an integer literal, got {v:?}"),
         };
-        let row_counts = exprs[2..]
+        let partition_ops = exprs[2..]
             .iter()
             .map(|expr| match expr {
-                Expr::Literal(ScalarValue::Utf8(Some(s)), _) => {
-                    if s.is_empty() {
-                        return Ok(vec![]);
-                    }
-                    s.split(',')
-                        .map(|v| {
-                            v.trim().parse::<usize>().map_err(|e| {
-                                datafusion::error::DataFusionError::Plan(format!(
-                                    "Invalid integer in test_work_unit_feed(): {e}"
-                                ))
-                            })
-                        })
-                        .collect::<Result<Vec<_>>>()
-                }
+                Expr::Literal(ScalarValue::Utf8(Some(s)), _) => parse_partition_ops(s),
                 v => plan_err!("partition args must be string literals, got {v:?}"),
             })
             .collect::<Result<Vec<_>>>()?;
-        if row_counts.len() % task_count != 0 {
+        if partition_ops.len() % task_count != 0 {
             return plan_err!(
                 "number of partitions ({}) must be divisible by task_count ({task_count})",
-                row_counts.len()
+                partition_ops.len()
             );
         }
         Ok(Arc::new(TestWorkUnitFeedTableProvider {
             tag,
             task_count,
-            row_counts,
+            partition_ops,
         }))
     }
 }
@@ -202,7 +278,7 @@ impl TableFunctionImpl for TestWorkUnitFeedFunction {
 struct TestWorkUnitFeedTableProvider {
     tag: String,
     task_count: usize,
-    row_counts: Vec<Vec<usize>>,
+    partition_ops: Vec<Vec<WorkUnitOp>>,
 }
 
 #[async_trait]
@@ -227,17 +303,21 @@ impl TableProvider for TestWorkUnitFeedTableProvider {
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let total_rows: usize = self
-            .row_counts
+            .partition_ops
             .iter()
-            .flat_map(|msgs| msgs.iter().copied())
+            .flat_map(|ops| ops.iter())
+            .map(|op| match op {
+                WorkUnitOp::Rows(n) => *n as usize,
+                _ => 0,
+            })
             .sum();
         Ok(Arc::new(RowGeneratorExec::new(
             WorkUnitFeed::new(RowGeneratorFeedProvider::new(
                 self.task_count,
-                self.row_counts.clone(),
+                self.partition_ops.clone(),
             )),
             self.tag.clone(),
-            self.row_counts.len(),
+            self.partition_ops.len(),
             projection.cloned(),
             total_rows,
         )))
@@ -265,7 +345,7 @@ impl TaskEstimator for TestWorkUnitFeedTaskEstimator {
     ) -> Option<Arc<dyn ExecutionPlan>> {
         let exec = plan.as_any().downcast_ref::<RowGeneratorExec>()?;
         let provider = exec.feed.clone().try_into_inner().ok()?;
-        let partitions_per_task = provider.per_partition_work_units.len() / task_count;
+        let partitions_per_task = provider.per_partition_ops.len() / task_count;
 
         // Rebuild the exec with the decided task count so its partition count matches.
         let transformed = Arc::clone(plan).transform_down(|plan| {
@@ -291,17 +371,17 @@ impl DisplayAs for RowGeneratorExec {
         let Some(provider) = self.feed.inner() else {
             return Ok(());
         };
-        write!(f, ", tasks={}, rows_per_partition=[", provider.task_count)?;
-        for (i, msgs) in provider.per_partition_work_units.iter().enumerate() {
+        write!(f, ", tasks={}, partition_ops=[", provider.task_count)?;
+        for (i, ops) in provider.per_partition_ops.iter().enumerate() {
             if i > 0 {
                 write!(f, ", ")?;
             }
             write!(f, "[")?;
-            for (j, msg) in msgs.iter().enumerate() {
+            for (j, op) in ops.iter().enumerate() {
                 if j > 0 {
                     write!(f, ", ")?;
                 }
-                write!(f, "{}", msg.n_rows)?;
+                write!(f, "{op}")?;
             }
             write!(f, "]")?;
         }

--- a/tests/metrics_collection.rs
+++ b/tests/metrics_collection.rs
@@ -240,7 +240,7 @@ mod tests {
         // Two tasks × two partitions × comma-separated row counts. Total work units sent:
         // 2 (t0/p0) + 1 (t0/p1) + 1 (t1/p0) + 2 (t1/p1) = 6.
         let df = ctx
-            .sql("SELECT * FROM test_work_unit('t', 2, '3,4', '1', '1', '2,5')")
+            .sql("SELECT * FROM test_work_unit('t', 2, 'rows(3),rows(4)', 'rows(1)', 'rows(1)', 'rows(2),rows(5)')")
             .await?;
         let plan = df.create_physical_plan().await?;
         execute_stream(plan.clone(), ctx.task_ctx())?

--- a/tests/work_unit_feed.rs
+++ b/tests/work_unit_feed.rs
@@ -14,12 +14,13 @@ mod tests {
     };
     use futures::TryStreamExt;
     use std::sync::Arc;
+    use std::time::{Duration, Instant};
 
     #[tokio::test]
     async fn single_task_no_distribution() -> Result<(), Box<dyn std::error::Error>> {
         let (plan, results) = run_query(
             r#"
-            SELECT * FROM test_work_unit('source', 1, '1,1', '2')
+            SELECT * FROM test_work_unit('source', 1, 'rows(1),rows(1)', 'rows(2)')
             ORDER BY task, partition, letter
         "#,
         )
@@ -29,7 +30,7 @@ mod tests {
             @r"
         SortPreservingMergeExec: [task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST]
           SortExec: expr=[task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
-            RowGeneratorExec: tag=source, tasks=1, rows_per_partition=[[1, 1], [2]]
+            RowGeneratorExec: tag=source, tasks=1, partition_ops=[[rows(1), rows(1)], [rows(2)]]
         +--------+------+-----------+--------+
         | tag    | task | partition | letter |
         +--------+------+-----------+--------+
@@ -47,7 +48,7 @@ mod tests {
     async fn two_tasks() -> Result<(), Box<dyn std::error::Error>> {
         let (plan, results) = run_query(
             r#"
-            SELECT * FROM test_work_unit('source', 2, '1,1', '2', '1', '2,1')
+            SELECT * FROM test_work_unit('source', 2, 'rows(1),rows(1)', 'rows(2)', 'rows(1)', 'rows(2),rows(1)')
             ORDER BY task, partition, letter
         "#,
         )
@@ -61,7 +62,7 @@ mod tests {
         └──────────────────────────────────────────────────
           ┌───── Stage 1 ── Tasks: t0:[p0..p1] t1:[p2..p3] 
           │ SortExec: expr=[task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
-          │   RowGeneratorExec: tag=source, tasks=2, rows_per_partition=[[1, 1], [2], [1], [2, 1]]
+          │   RowGeneratorExec: tag=source, tasks=2, partition_ops=[[rows(1), rows(1)], [rows(2)], [rows(1)], [rows(2), rows(1)]]
           └──────────────────────────────────────────────────
         +--------+------+-----------+--------+
         | tag    | task | partition | letter |
@@ -86,7 +87,7 @@ mod tests {
     async fn empty_work_unit_feeds() -> Result<(), Box<dyn std::error::Error>> {
         let (plan, results) = run_query(
             r#"
-            SELECT * FROM test_work_unit('source', 2, '3', '', '', '1')
+            SELECT * FROM test_work_unit('source', 2, 'rows(3)', '', '', 'rows(1)')
             ORDER BY task, partition, letter
         "#,
         )
@@ -100,7 +101,7 @@ mod tests {
         └──────────────────────────────────────────────────
           ┌───── Stage 1 ── Tasks: t0:[p0..p1] t1:[p2..p3] 
           │ SortExec: expr=[task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
-          │   RowGeneratorExec: tag=source, tasks=2, rows_per_partition=[[3], [], [], [1]]
+          │   RowGeneratorExec: tag=source, tasks=2, partition_ops=[[rows(3)], [], [], [rows(1)]]
           └──────────────────────────────────────────────────
         +--------+------+-----------+--------+
         | tag    | task | partition | letter |
@@ -120,7 +121,7 @@ mod tests {
     async fn three_tasks() -> Result<(), Box<dyn std::error::Error>> {
         let (plan, results) = run_query(
             r#"
-            SELECT * FROM test_work_unit('source', 3, '2', '1', '3', '1', '2', '1')
+            SELECT * FROM test_work_unit('source', 3, 'rows(2)', 'rows(1)', 'rows(3)', 'rows(1)', 'rows(2)', 'rows(1)')
             ORDER BY task, partition, letter
         "#,
         )
@@ -134,7 +135,7 @@ mod tests {
         └──────────────────────────────────────────────────
           ┌───── Stage 1 ── Tasks: t0:[p0..p1] t1:[p2..p3] t2:[p4..p5] 
           │ SortExec: expr=[task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
-          │   RowGeneratorExec: tag=source, tasks=3, rows_per_partition=[[2], [1], [3], [1], [2], [1]]
+          │   RowGeneratorExec: tag=source, tasks=3, partition_ops=[[rows(2)], [rows(1)], [rows(3)], [rows(1)], [rows(2)], [rows(1)]]
           └──────────────────────────────────────────────────
         +--------+------+-----------+--------+
         | tag    | task | partition | letter |
@@ -161,9 +162,9 @@ mod tests {
     async fn union_of_two_feeds() -> Result<(), Box<dyn std::error::Error>> {
         let (plan, results) = run_query(
             r#"
-            SELECT * FROM test_work_unit('left', 2, '2', '1', '3', '1')
+            SELECT * FROM test_work_unit('left', 2, 'rows(2)', 'rows(1)', 'rows(3)', 'rows(1)')
             UNION ALL
-            SELECT * FROM test_work_unit('right', 2, '1', '2', '1', '1')
+            SELECT * FROM test_work_unit('right', 2, 'rows(1)', 'rows(2)', 'rows(1)', 'rows(1)')
             ORDER BY tag, task, partition, letter
         "#,
         )
@@ -178,9 +179,9 @@ mod tests {
           ┌───── Stage 1 ── Tasks: t0:[p0..p3] t1:[p4..p7] t2:[p8..p11] 
           │ DistributedUnionExec: t0:[c0] t1:[c1(0/2)] t2:[c1(1/2)]
           │   SortExec: expr=[tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
-          │     RowGeneratorExec: tag=left, tasks=2, rows_per_partition=[[2], [1], [3], [1]]
+          │     RowGeneratorExec: tag=left, tasks=2, partition_ops=[[rows(2)], [rows(1)], [rows(3)], [rows(1)]]
           │   SortExec: expr=[tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
-          │     RowGeneratorExec: tag=right, tasks=2, rows_per_partition=[[1], [2], [1], [1]]
+          │     RowGeneratorExec: tag=right, tasks=2, partition_ops=[[rows(1)], [rows(2)], [rows(1)], [rows(1)]]
           └──────────────────────────────────────────────────
         +-------+------+-----------+--------+
         | tag   | task | partition | letter |
@@ -210,7 +211,7 @@ mod tests {
         let (plan, results) = run_query(
             r#"
             SELECT COUNT(*) as cnt, letter
-            FROM test_work_unit('source', 2, '3', '2', '1', '4')
+            FROM test_work_unit('source', 2, 'rows(3)', 'rows(2)', 'rows(1)', 'rows(4)')
             GROUP BY letter
             ORDER BY letter
         "#,
@@ -232,7 +233,7 @@ mod tests {
             ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p0..p5] 
             │ RepartitionExec: partitioning=Hash([letter@0], 6), input_partitions=2
             │   AggregateExec: mode=Partial, gby=[letter@0 as letter], aggr=[count(Int64(1))]
-            │     RowGeneratorExec: tag=source, tasks=2, rows_per_partition=[[3], [2], [1], [4]]
+            │     RowGeneratorExec: tag=source, tasks=2, partition_ops=[[rows(3)], [rows(2)], [rows(1)], [rows(4)]]
             └──────────────────────────────────────────────────
         +-----+--------+
         | cnt | letter |
@@ -256,8 +257,8 @@ mod tests {
             SET datafusion.optimizer.hash_join_single_partition_threshold = 0;
             SET datafusion.optimizer.hash_join_single_partition_threshold_rows = 0;
             SELECT a.task as a_task, a.letter as a_letter, b.task as b_task, b.letter as b_letter
-            FROM test_work_unit('orders', 2, '2', '1', '1', '2') a
-            INNER JOIN test_work_unit('customers', 2, '1', '1', '2', '1') b
+            FROM test_work_unit('orders', 2, 'rows(2)', 'rows(1)', 'rows(1)', 'rows(2)') a
+            INNER JOIN test_work_unit('customers', 2, 'rows(1)', 'rows(1)', 'rows(2)', 'rows(1)') b
             ON a.letter = b.letter
             ORDER BY a_task, a_letter, b_task, b_letter
         "#,
@@ -279,11 +280,11 @@ mod tests {
           └──────────────────────────────────────────────────
             ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p0..p5] 
             │ RepartitionExec: partitioning=Hash([letter@1], 6), input_partitions=2
-            │   RowGeneratorExec: tag=customers, tasks=2, rows_per_partition=[[1], [1], [2], [1]]
+            │   RowGeneratorExec: tag=customers, tasks=2, partition_ops=[[rows(1)], [rows(1)], [rows(2)], [rows(1)]]
             └──────────────────────────────────────────────────
             ┌───── Stage 2 ── Tasks: t0:[p0..p5] t1:[p0..p5] 
             │ RepartitionExec: partitioning=Hash([letter@1], 6), input_partitions=2
-            │   RowGeneratorExec: tag=orders, tasks=2, rows_per_partition=[[2], [1], [1], [2]]
+            │   RowGeneratorExec: tag=orders, tasks=2, partition_ops=[[rows(2)], [rows(1)], [rows(1)], [rows(2)]]
             └──────────────────────────────────────────────────
         +--------+----------+--------+----------+
         | a_task | a_letter | b_task | b_letter |
@@ -318,11 +319,11 @@ mod tests {
     async fn triple_union() -> Result<(), Box<dyn std::error::Error>> {
         let (plan, results) = run_query(
             r#"
-            SELECT * FROM test_work_unit('x', 2, '2', '1')
+            SELECT * FROM test_work_unit('x', 2, 'rows(2)', 'rows(1)')
             UNION ALL
-            SELECT * FROM test_work_unit('y', 2, '1', '3')
+            SELECT * FROM test_work_unit('y', 2, 'rows(1)', 'rows(3)')
             UNION ALL
-            SELECT * FROM test_work_unit('z', 2, '1', '1')
+            SELECT * FROM test_work_unit('z', 2, 'rows(1)', 'rows(1)')
             ORDER BY tag, task, partition, letter
         "#,
         )
@@ -336,11 +337,11 @@ mod tests {
           ┌───── Stage 1 ── Tasks: t0:[p0..p1] t1:[p2..p3] t2:[p4..p5] 
           │ DistributedUnionExec: t0:[c0] t1:[c1] t2:[c2]
           │   SortExec: expr=[tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
-          │     RowGeneratorExec: tag=x, tasks=2, rows_per_partition=[[2], [1]]
+          │     RowGeneratorExec: tag=x, tasks=2, partition_ops=[[rows(2)], [rows(1)]]
           │   SortExec: expr=[tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
-          │     RowGeneratorExec: tag=y, tasks=2, rows_per_partition=[[1], [3]]
+          │     RowGeneratorExec: tag=y, tasks=2, partition_ops=[[rows(1)], [rows(3)]]
           │   SortExec: expr=[tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
-          │     RowGeneratorExec: tag=z, tasks=2, rows_per_partition=[[1], [1]]
+          │     RowGeneratorExec: tag=z, tasks=2, partition_ops=[[rows(1)], [rows(1)]]
           └──────────────────────────────────────────────────
         +-----+------+-----------+--------+
         | tag | task | partition | letter |
@@ -365,7 +366,7 @@ mod tests {
     async fn union_feed_with_non_feed() -> Result<(), Box<dyn std::error::Error>> {
         let (plan, results) = run_query(
             r#"
-            SELECT * FROM test_work_unit('feed', 2, '2', '1', '1', '2')
+            SELECT * FROM test_work_unit('feed', 2, 'rows(2)', 'rows(1)', 'rows(1)', 'rows(2)')
             UNION ALL
             SELECT 'static' as tag, 0 as task, 0 as partition, 'x' as letter
             ORDER BY tag, task, partition, letter
@@ -381,7 +382,7 @@ mod tests {
           ┌───── Stage 1 ── Tasks: t0:[p0..p3] t1:[p4..p7] t2:[p8..p11] 
           │ DistributedUnionExec: t0:[c0(0/2)] t1:[c0(1/2)] t2:[c1]
           │   SortExec: expr=[tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
-          │     RowGeneratorExec: tag=feed, tasks=2, rows_per_partition=[[2], [1], [1], [2]]
+          │     RowGeneratorExec: tag=feed, tasks=2, partition_ops=[[rows(2)], [rows(1)], [rows(1)], [rows(2)]]
           │   ProjectionExec: expr=[static as tag, 0 as task, 0 as partition, x as letter]
           │     PlaceholderRowExec
           └──────────────────────────────────────────────────
@@ -408,9 +409,9 @@ mod tests {
             r#"
             SELECT tag, letter, COUNT(*) as cnt
             FROM (
-                SELECT * FROM test_work_unit('left', 2, '3', '2', '1', '2')
+                SELECT * FROM test_work_unit('left', 2, 'rows(3)', 'rows(2)', 'rows(1)', 'rows(2)')
                 UNION ALL
-                SELECT * FROM test_work_unit('right', 2, '2', '1', '1', '3')
+                SELECT * FROM test_work_unit('right', 2, 'rows(2)', 'rows(1)', 'rows(1)', 'rows(3)')
             )
             GROUP BY tag, letter
             ORDER BY tag, letter
@@ -433,8 +434,8 @@ mod tests {
             │ RepartitionExec: partitioning=Hash([tag@0, letter@1], 6), input_partitions=4
             │   AggregateExec: mode=Partial, gby=[tag@0 as tag, letter@1 as letter], aggr=[count(Int64(1))]
             │     DistributedUnionExec: t0:[c0] t1:[c1(0/2)] t2:[c1(1/2)]
-            │       RowGeneratorExec: tag=left, tasks=2, rows_per_partition=[[3], [2], [1], [2]]
-            │       RowGeneratorExec: tag=right, tasks=2, rows_per_partition=[[2], [1], [1], [3]]
+            │       RowGeneratorExec: tag=left, tasks=2, partition_ops=[[rows(3)], [rows(2)], [rows(1)], [rows(2)]]
+            │       RowGeneratorExec: tag=right, tasks=2, partition_ops=[[rows(2)], [rows(1)], [rows(1)], [rows(3)]]
             └──────────────────────────────────────────────────
         +-------+--------+-----+
         | tag   | letter | cnt |
@@ -459,10 +460,10 @@ mod tests {
             SET datafusion.optimizer.hash_join_single_partition_threshold = 0;
             SET datafusion.optimizer.hash_join_single_partition_threshold_rows = 0;
             SELECT a.tag as a_tag, a.letter, b.cnt
-            FROM test_work_unit('detail', 2, '2', '1', '1', '2') a
+            FROM test_work_unit('detail', 2, 'rows(2)', 'rows(1)', 'rows(1)', 'rows(2)') a
             INNER JOIN (
                 SELECT letter, COUNT(*) as cnt
-                FROM test_work_unit('summary', 2, '3', '2', '1', '4')
+                FROM test_work_unit('summary', 2, 'rows(3)', 'rows(2)', 'rows(1)', 'rows(4)')
                 GROUP BY letter
             ) b ON a.letter = b.letter
             ORDER BY a_tag, a.letter, b.cnt
@@ -486,12 +487,12 @@ mod tests {
           └──────────────────────────────────────────────────
             ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p0..p5] 
             │ RepartitionExec: partitioning=Hash([letter@1], 6), input_partitions=2
-            │   RowGeneratorExec: tag=detail, tasks=2, rows_per_partition=[[2], [1], [1], [2]]
+            │   RowGeneratorExec: tag=detail, tasks=2, partition_ops=[[rows(2)], [rows(1)], [rows(1)], [rows(2)]]
             └──────────────────────────────────────────────────
             ┌───── Stage 2 ── Tasks: t0:[p0..p5] t1:[p0..p5] 
             │ RepartitionExec: partitioning=Hash([letter@0], 6), input_partitions=2
             │   AggregateExec: mode=Partial, gby=[letter@0 as letter], aggr=[count(Int64(1))]
-            │     RowGeneratorExec: tag=summary, tasks=2, rows_per_partition=[[3], [2], [1], [4]]
+            │     RowGeneratorExec: tag=summary, tasks=2, partition_ops=[[rows(3)], [rows(2)], [rows(1)], [rows(4)]]
             └──────────────────────────────────────────────────
         +--------+--------+-----+
         | a_tag  | letter | cnt |
@@ -515,8 +516,8 @@ mod tests {
             SELECT
                 a.tag as a_tag, a.task as a_task, a.partition as a_partition, a.letter,
                 b.tag as b_tag, b.task as b_task, b.partition as b_partition
-            FROM test_work_unit('probe', 2, '3', '1', '2', '1') a
-            INNER JOIN test_work_unit('build', 2, '1', '2', '1', '3') b
+            FROM test_work_unit('probe', 2, 'rows(3)', 'rows(1)', 'rows(2)', 'rows(1)') a
+            INNER JOIN test_work_unit('build', 2, 'rows(1)', 'rows(2)', 'rows(1)', 'rows(3)') b
             ON a.letter = b.letter
             ORDER BY a_task, a_partition, a.letter, b_task, b_partition
         "#,
@@ -534,11 +535,11 @@ mod tests {
           │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(letter@3, letter@3)], projection=[tag@0, task@1, partition@2, letter@3, tag@4, task@5, partition@6]
           │       CoalescePartitionsExec
           │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
-          │       RowGeneratorExec: tag=build, tasks=2, rows_per_partition=[[1], [2], [1], [3]]
+          │       RowGeneratorExec: tag=build, tasks=2, partition_ops=[[rows(1)], [rows(2)], [rows(1)], [rows(3)]]
           └──────────────────────────────────────────────────
             ┌───── Stage 1 ── Tasks: t0:[p0..p3] t1:[p4..p7] 
             │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
-            │   RowGeneratorExec: tag=probe, tasks=2, rows_per_partition=[[3], [1], [2], [1]]
+            │   RowGeneratorExec: tag=probe, tasks=2, partition_ops=[[rows(3)], [rows(1)], [rows(2)], [rows(1)]]
             └──────────────────────────────────────────────────
         +-------+--------+-------------+--------+-------+--------+-------------+
         | a_tag | a_task | a_partition | letter | b_tag | b_task | b_partition |
@@ -566,6 +567,117 @@ mod tests {
         | probe | 1      | 1           | a      | build | 1      | 1           |
         +-------+--------+-------------+--------+-------+--------+-------------+
         ");
+        Ok(())
+    }
+
+    /// `wait()` ops in a feed must actually delay the producing stream.
+    /// Verifies the [`crate::test_utils::test_work_unit_feed::WorkUnitOp::Wait`]
+    /// op is wired into the producer's stream.
+    #[tokio::test]
+    async fn wait_op_delays_query() -> Result<(), Box<dyn std::error::Error>> {
+        let start = Instant::now();
+        let (_, results) =
+            run_query(r#"SELECT * FROM test_work_unit('a', 1, 'rows(1), wait(800), rows(1)')"#)
+                .await?;
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(800),
+            "expected query to take at least 800ms (the wait), but took {elapsed:?}"
+        );
+        // Sanity check that both rows came through after the wait.
+        let data_rows = results.lines().filter(|l| l.starts_with("| a ")).count();
+        assert_eq!(
+            data_rows, 2,
+            "expected 2 rows from feed 'a', got:\n{results}"
+        );
+        Ok(())
+    }
+
+    /// An `err()` op in the feed must surface as a query-level error.
+    /// This exercises error propagation from a coordinator-side
+    /// [`WorkUnitFeedProvider`] through the local + remote feed pipeline up
+    /// to the user calling `try_collect` on the result stream.
+    #[tokio::test]
+    async fn err_op_in_single_task_propagates() -> Result<(), Box<dyn std::error::Error>> {
+        let res =
+            run_query(r#"SELECT * FROM test_work_unit('a', 1, 'rows(1), err(boom_single)')"#).await;
+        let err = res.expect_err("query should have failed");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("boom_single"),
+            "expected error to mention 'boom_single', got: {msg}"
+        );
+        Ok(())
+    }
+
+    /// Same as [`err_op_in_single_task_propagates`] but with two tasks, so the
+    /// erroring feed actually goes through the coordinator → worker gRPC path.
+    /// Guards against errors being silently swallowed as EOF on the worker side.
+    #[tokio::test]
+    async fn err_op_in_distributed_feed_propagates() -> Result<(), Box<dyn std::error::Error>> {
+        let res = run_query(
+            r#"
+            SELECT * FROM test_work_unit('a', 2, 'rows(1)', 'rows(1), err(boom_distributed)')
+            "#,
+        )
+        .await;
+        let err = res.expect_err("distributed query should have failed");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("boom_distributed"),
+            "expected error to mention 'boom_distributed', got: {msg}"
+        );
+        Ok(())
+    }
+
+    /// An `err()` op in one of two independent feeds in the same query must still
+    /// surface. The other feed is otherwise valid — we want to make sure the
+    /// failing feed taints the whole query rather than the result silently
+    /// missing the rows from the failing side.
+    #[tokio::test]
+    async fn err_in_one_of_two_feeds_propagates() -> Result<(), Box<dyn std::error::Error>> {
+        let res = run_query(
+            r#"
+            SELECT * FROM test_work_unit('left', 2, 'rows(1)', 'rows(1)', 'rows(1)', 'rows(1)')
+            UNION ALL
+            SELECT * FROM test_work_unit('right', 2, 'rows(1)', 'err(boom_union)', 'rows(1)', 'rows(1)')
+            "#,
+        )
+        .await;
+        let err = res.expect_err("query should have failed because of the right feed");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("boom_union"),
+            "expected error to mention 'boom_union', got: {msg}"
+        );
+        Ok(())
+    }
+
+    /// A `wait()` op in one feed should not stop another, independent feed in the
+    /// same query from making progress, and the final result should still be
+    /// correct. Acts as a regression guard against the producer side blocking
+    /// other feeds while sleeping on a single partition.
+    #[tokio::test]
+    async fn wait_in_one_feed_does_not_corrupt_other_feed_results()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (_, results) = run_query(
+            r#"
+            SELECT * FROM test_work_unit('fast', 2, 'rows(1)', 'rows(1)', 'rows(1)', 'rows(1)')
+            UNION ALL
+            SELECT * FROM test_work_unit('slow', 2, 'wait(500), rows(1)', 'rows(1)', 'rows(1)', 'rows(1)')
+            ORDER BY tag, task, partition, letter
+            "#,
+        )
+        .await?;
+        // 4 rows from `fast` + 4 rows from `slow` = 8 data rows.
+        let data_rows = results
+            .lines()
+            .filter(|l| l.starts_with("| fast ") || l.starts_with("| slow "))
+            .count();
+        assert_eq!(
+            data_rows, 8,
+            "expected 8 data rows across both feeds, got:\n{results}"
+        );
         Ok(())
     }
 

--- a/tests/work_unit_feed.rs
+++ b/tests/work_unit_feed.rs
@@ -14,12 +14,13 @@ mod tests {
     };
     use futures::TryStreamExt;
     use std::sync::Arc;
+    use std::time::{Duration, Instant};
 
     #[tokio::test]
     async fn single_task_no_distribution() -> Result<(), Box<dyn std::error::Error>> {
         let (plan, results) = run_query(
             r#"
-            SELECT * FROM test_work_unit('source', 1, '1,1', '2')
+            SELECT * FROM test_work_unit('source', 1, 'rows(1),rows(1)', 'rows(2)')
             ORDER BY task, partition, letter
         "#,
         )
@@ -29,7 +30,7 @@ mod tests {
             @r"
         SortPreservingMergeExec: [task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST]
           SortExec: expr=[task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
-            RowGeneratorExec: tag=source, tasks=1, rows_per_partition=[[1, 1], [2]]
+            RowGeneratorExec: tag=source, tasks=1, partition_ops=[[rows(1), rows(1)], [rows(2)]]
         +--------+------+-----------+--------+
         | tag    | task | partition | letter |
         +--------+------+-----------+--------+
@@ -47,7 +48,7 @@ mod tests {
     async fn two_tasks() -> Result<(), Box<dyn std::error::Error>> {
         let (plan, results) = run_query(
             r#"
-            SELECT * FROM test_work_unit('source', 2, '1,1', '2', '1', '2,1')
+            SELECT * FROM test_work_unit('source', 2, 'rows(1),rows(1)', 'rows(2)', 'rows(1)', 'rows(2),rows(1)')
             ORDER BY task, partition, letter
         "#,
         )
@@ -61,7 +62,7 @@ mod tests {
         └──────────────────────────────────────────────────
           ┌───── Stage 1 ── Tasks: t0:[p0..p1] t1:[p2..p3]
           │ SortExec: expr=[task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
-          │   RowGeneratorExec: tag=source, tasks=2, rows_per_partition=[[1, 1], [2], [1], [2, 1]]
+          │   RowGeneratorExec: tag=source, tasks=2, partition_ops=[[rows(1), rows(1)], [rows(2)], [rows(1)], [rows(2), rows(1)]]
           └──────────────────────────────────────────────────
         +--------+------+-----------+--------+
         | tag    | task | partition | letter |
@@ -86,7 +87,7 @@ mod tests {
     async fn empty_work_unit_feeds() -> Result<(), Box<dyn std::error::Error>> {
         let (plan, results) = run_query(
             r#"
-            SELECT * FROM test_work_unit('source', 2, '3', '', '', '1')
+            SELECT * FROM test_work_unit('source', 2, 'rows(3)', '', '', 'rows(1)')
             ORDER BY task, partition, letter
         "#,
         )
@@ -100,7 +101,7 @@ mod tests {
         └──────────────────────────────────────────────────
           ┌───── Stage 1 ── Tasks: t0:[p0..p1] t1:[p2..p3]
           │ SortExec: expr=[task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
-          │   RowGeneratorExec: tag=source, tasks=2, rows_per_partition=[[3], [], [], [1]]
+          │   RowGeneratorExec: tag=source, tasks=2, partition_ops=[[rows(3)], [], [], [rows(1)]]
           └──────────────────────────────────────────────────
         +--------+------+-----------+--------+
         | tag    | task | partition | letter |
@@ -120,7 +121,7 @@ mod tests {
     async fn three_tasks() -> Result<(), Box<dyn std::error::Error>> {
         let (plan, results) = run_query(
             r#"
-            SELECT * FROM test_work_unit('source', 3, '2', '1', '3', '1', '2', '1')
+            SELECT * FROM test_work_unit('source', 3, 'rows(2)', 'rows(1)', 'rows(3)', 'rows(1)', 'rows(2)', 'rows(1)')
             ORDER BY task, partition, letter
         "#,
         )
@@ -134,7 +135,7 @@ mod tests {
         └──────────────────────────────────────────────────
           ┌───── Stage 1 ── Tasks: t0:[p0..p1] t1:[p2..p3] t2:[p4..p5]
           │ SortExec: expr=[task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
-          │   RowGeneratorExec: tag=source, tasks=3, rows_per_partition=[[2], [1], [3], [1], [2], [1]]
+          │   RowGeneratorExec: tag=source, tasks=3, partition_ops=[[rows(2)], [rows(1)], [rows(3)], [rows(1)], [rows(2)], [rows(1)]]
           └──────────────────────────────────────────────────
         +--------+------+-----------+--------+
         | tag    | task | partition | letter |
@@ -161,9 +162,9 @@ mod tests {
     async fn union_of_two_feeds() -> Result<(), Box<dyn std::error::Error>> {
         let (plan, results) = run_query(
             r#"
-            SELECT * FROM test_work_unit('left', 2, '2', '1', '3', '1')
+            SELECT * FROM test_work_unit('left', 2, 'rows(2)', 'rows(1)', 'rows(3)', 'rows(1)')
             UNION ALL
-            SELECT * FROM test_work_unit('right', 2, '1', '2', '1', '1')
+            SELECT * FROM test_work_unit('right', 2, 'rows(1)', 'rows(2)', 'rows(1)', 'rows(1)')
             ORDER BY tag, task, partition, letter
         "#,
         )
@@ -178,9 +179,9 @@ mod tests {
           ┌───── Stage 1 ── Tasks: t0:[p0..p3] t1:[p4..p7] t2:[p8..p11]
           │ DistributedUnionExec: t0:[c0] t1:[c1(0/2)] t2:[c1(1/2)]
           │   SortExec: expr=[tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
-          │     RowGeneratorExec: tag=left, tasks=2, rows_per_partition=[[2], [1], [3], [1]]
+          │     RowGeneratorExec: tag=left, tasks=2, partition_ops=[[rows(2)], [rows(1)], [rows(3)], [rows(1)]]
           │   SortExec: expr=[tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
-          │     RowGeneratorExec: tag=right, tasks=2, rows_per_partition=[[1], [2], [1], [1]]
+          │     RowGeneratorExec: tag=right, tasks=2, partition_ops=[[rows(1)], [rows(2)], [rows(1)], [rows(1)]]
           └──────────────────────────────────────────────────
         +-------+------+-----------+--------+
         | tag   | task | partition | letter |
@@ -210,7 +211,7 @@ mod tests {
         let (plan, results) = run_query(
             r#"
             SELECT COUNT(*) as cnt, letter
-            FROM test_work_unit('source', 2, '3', '2', '1', '4')
+            FROM test_work_unit('source', 2, 'rows(3)', 'rows(2)', 'rows(1)', 'rows(4)')
             GROUP BY letter
             ORDER BY letter
         "#,
@@ -232,7 +233,7 @@ mod tests {
             ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p0..p5]
             │ RepartitionExec: partitioning=Hash([letter@0], 6), input_partitions=2
             │   AggregateExec: mode=Partial, gby=[letter@0 as letter], aggr=[count(Int64(1))]
-            │     RowGeneratorExec: tag=source, tasks=2, rows_per_partition=[[3], [2], [1], [4]]
+            │     RowGeneratorExec: tag=source, tasks=2, partition_ops=[[rows(3)], [rows(2)], [rows(1)], [rows(4)]]
             └──────────────────────────────────────────────────
         +-----+--------+
         | cnt | letter |
@@ -256,8 +257,8 @@ mod tests {
             SET datafusion.optimizer.hash_join_single_partition_threshold = 0;
             SET datafusion.optimizer.hash_join_single_partition_threshold_rows = 0;
             SELECT a.task as a_task, a.letter as a_letter, b.task as b_task, b.letter as b_letter
-            FROM test_work_unit('orders', 2, '2', '1', '1', '2') a
-            INNER JOIN test_work_unit('customers', 2, '1', '1', '2', '1') b
+            FROM test_work_unit('orders', 2, 'rows(2)', 'rows(1)', 'rows(1)', 'rows(2)') a
+            INNER JOIN test_work_unit('customers', 2, 'rows(1)', 'rows(1)', 'rows(2)', 'rows(1)') b
             ON a.letter = b.letter
             ORDER BY a_task, a_letter, b_task, b_letter
         "#,
@@ -279,11 +280,11 @@ mod tests {
           └──────────────────────────────────────────────────
             ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p0..p5]
             │ RepartitionExec: partitioning=Hash([letter@1], 6), input_partitions=2
-            │   RowGeneratorExec: tag=customers, tasks=2, rows_per_partition=[[1], [1], [2], [1]]
+            │   RowGeneratorExec: tag=customers, tasks=2, partition_ops=[[rows(1)], [rows(1)], [rows(2)], [rows(1)]]
             └──────────────────────────────────────────────────
             ┌───── Stage 2 ── Tasks: t0:[p0..p5] t1:[p0..p5]
             │ RepartitionExec: partitioning=Hash([letter@1], 6), input_partitions=2
-            │   RowGeneratorExec: tag=orders, tasks=2, rows_per_partition=[[2], [1], [1], [2]]
+            │   RowGeneratorExec: tag=orders, tasks=2, partition_ops=[[rows(2)], [rows(1)], [rows(1)], [rows(2)]]
             └──────────────────────────────────────────────────
         +--------+----------+--------+----------+
         | a_task | a_letter | b_task | b_letter |
@@ -318,11 +319,11 @@ mod tests {
     async fn triple_union() -> Result<(), Box<dyn std::error::Error>> {
         let (plan, results) = run_query(
             r#"
-            SELECT * FROM test_work_unit('x', 2, '2', '1')
+            SELECT * FROM test_work_unit('x', 2, 'rows(2)', 'rows(1)')
             UNION ALL
-            SELECT * FROM test_work_unit('y', 2, '1', '3')
+            SELECT * FROM test_work_unit('y', 2, 'rows(1)', 'rows(3)')
             UNION ALL
-            SELECT * FROM test_work_unit('z', 2, '1', '1')
+            SELECT * FROM test_work_unit('z', 2, 'rows(1)', 'rows(1)')
             ORDER BY tag, task, partition, letter
         "#,
         )
@@ -336,11 +337,11 @@ mod tests {
           ┌───── Stage 1 ── Tasks: t0:[p0..p1] t1:[p2..p3] t2:[p4..p5]
           │ DistributedUnionExec: t0:[c0] t1:[c1] t2:[c2]
           │   SortExec: expr=[tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
-          │     RowGeneratorExec: tag=x, tasks=2, rows_per_partition=[[2], [1]]
+          │     RowGeneratorExec: tag=x, tasks=2, partition_ops=[[rows(2)], [rows(1)]]
           │   SortExec: expr=[tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
-          │     RowGeneratorExec: tag=y, tasks=2, rows_per_partition=[[1], [3]]
+          │     RowGeneratorExec: tag=y, tasks=2, partition_ops=[[rows(1)], [rows(3)]]
           │   SortExec: expr=[tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
-          │     RowGeneratorExec: tag=z, tasks=2, rows_per_partition=[[1], [1]]
+          │     RowGeneratorExec: tag=z, tasks=2, partition_ops=[[rows(1)], [rows(1)]]
           └──────────────────────────────────────────────────
         +-----+------+-----------+--------+
         | tag | task | partition | letter |
@@ -365,7 +366,7 @@ mod tests {
     async fn union_feed_with_non_feed() -> Result<(), Box<dyn std::error::Error>> {
         let (plan, results) = run_query(
             r#"
-            SELECT * FROM test_work_unit('feed', 2, '2', '1', '1', '2')
+            SELECT * FROM test_work_unit('feed', 2, 'rows(2)', 'rows(1)', 'rows(1)', 'rows(2)')
             UNION ALL
             SELECT 'static' as tag, 0 as task, 0 as partition, 'x' as letter
             ORDER BY tag, task, partition, letter
@@ -381,7 +382,7 @@ mod tests {
           ┌───── Stage 1 ── Tasks: t0:[p0..p1] t1:[p2..p3] t2:[p4..p5]
           │ DistributedUnionExec: t0:[c0(0/2)] t1:[c0(1/2)] t2:[c1]
           │   SortExec: expr=[tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
-          │     RowGeneratorExec: tag=feed, tasks=2, rows_per_partition=[[2], [1], [1], [2]]
+          │     RowGeneratorExec: tag=feed, tasks=2, partition_ops=[[rows(2)], [rows(1)], [rows(1)], [rows(2)]]
           │   ProjectionExec: expr=[static as tag, 0 as task, 0 as partition, x as letter]
           │     PlaceholderRowExec
           └──────────────────────────────────────────────────
@@ -408,9 +409,9 @@ mod tests {
             r#"
             SELECT tag, letter, COUNT(*) as cnt
             FROM (
-                SELECT * FROM test_work_unit('left', 2, '3', '2', '1', '2')
+                SELECT * FROM test_work_unit('left', 2, 'rows(3)', 'rows(2)', 'rows(1)', 'rows(2)')
                 UNION ALL
-                SELECT * FROM test_work_unit('right', 2, '2', '1', '1', '3')
+                SELECT * FROM test_work_unit('right', 2, 'rows(2)', 'rows(1)', 'rows(1)', 'rows(3)')
             )
             GROUP BY tag, letter
             ORDER BY tag, letter
@@ -433,8 +434,8 @@ mod tests {
             │ RepartitionExec: partitioning=Hash([tag@0, letter@1], 6), input_partitions=4
             │   AggregateExec: mode=Partial, gby=[tag@0 as tag, letter@1 as letter], aggr=[count(Int64(1))]
             │     DistributedUnionExec: t0:[c0] t1:[c1(0/2)] t2:[c1(1/2)]
-            │       RowGeneratorExec: tag=left, tasks=2, rows_per_partition=[[3], [2], [1], [2]]
-            │       RowGeneratorExec: tag=right, tasks=2, rows_per_partition=[[2], [1], [1], [3]]
+            │       RowGeneratorExec: tag=left, tasks=2, partition_ops=[[rows(3)], [rows(2)], [rows(1)], [rows(2)]]
+            │       RowGeneratorExec: tag=right, tasks=2, partition_ops=[[rows(2)], [rows(1)], [rows(1)], [rows(3)]]
             └──────────────────────────────────────────────────
         +-------+--------+-----+
         | tag   | letter | cnt |
@@ -459,10 +460,10 @@ mod tests {
             SET datafusion.optimizer.hash_join_single_partition_threshold = 0;
             SET datafusion.optimizer.hash_join_single_partition_threshold_rows = 0;
             SELECT a.tag as a_tag, a.letter, b.cnt
-            FROM test_work_unit('detail', 2, '2', '1', '1', '2') a
+            FROM test_work_unit('detail', 2, 'rows(2)', 'rows(1)', 'rows(1)', 'rows(2)') a
             INNER JOIN (
                 SELECT letter, COUNT(*) as cnt
-                FROM test_work_unit('summary', 2, '3', '2', '1', '4')
+                FROM test_work_unit('summary', 2, 'rows(3)', 'rows(2)', 'rows(1)', 'rows(4)')
                 GROUP BY letter
             ) b ON a.letter = b.letter
             ORDER BY a_tag, a.letter, b.cnt
@@ -486,12 +487,12 @@ mod tests {
           └──────────────────────────────────────────────────
             ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p0..p5]
             │ RepartitionExec: partitioning=Hash([letter@1], 6), input_partitions=2
-            │   RowGeneratorExec: tag=detail, tasks=2, rows_per_partition=[[2], [1], [1], [2]]
+            │   RowGeneratorExec: tag=detail, tasks=2, partition_ops=[[rows(2)], [rows(1)], [rows(1)], [rows(2)]]
             └──────────────────────────────────────────────────
             ┌───── Stage 2 ── Tasks: t0:[p0..p5] t1:[p0..p5]
             │ RepartitionExec: partitioning=Hash([letter@0], 6), input_partitions=2
             │   AggregateExec: mode=Partial, gby=[letter@0 as letter], aggr=[count(Int64(1))]
-            │     RowGeneratorExec: tag=summary, tasks=2, rows_per_partition=[[3], [2], [1], [4]]
+            │     RowGeneratorExec: tag=summary, tasks=2, partition_ops=[[rows(3)], [rows(2)], [rows(1)], [rows(4)]]
             └──────────────────────────────────────────────────
         +--------+--------+-----+
         | a_tag  | letter | cnt |
@@ -515,8 +516,8 @@ mod tests {
             SELECT
                 a.tag as a_tag, a.task as a_task, a.partition as a_partition, a.letter,
                 b.tag as b_tag, b.task as b_task, b.partition as b_partition
-            FROM test_work_unit('probe', 2, '3', '1', '2', '1') a
-            INNER JOIN test_work_unit('build', 2, '1', '2', '1', '3') b
+            FROM test_work_unit('probe', 2, 'rows(3)', 'rows(1)', 'rows(2)', 'rows(1)') a
+            INNER JOIN test_work_unit('build', 2, 'rows(1)', 'rows(2)', 'rows(1)', 'rows(3)') b
             ON a.letter = b.letter
             ORDER BY a_task, a_partition, a.letter, b_task, b_partition
         "#,
@@ -534,11 +535,11 @@ mod tests {
           │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(letter@3, letter@3)], projection=[tag@0, task@1, partition@2, letter@3, tag@4, task@5, partition@6]
           │       CoalescePartitionsExec
           │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
-          │       RowGeneratorExec: tag=build, tasks=2, rows_per_partition=[[1], [2], [1], [3]]
+          │       RowGeneratorExec: tag=build, tasks=2, partition_ops=[[rows(1)], [rows(2)], [rows(1)], [rows(3)]]
           └──────────────────────────────────────────────────
             ┌───── Stage 1 ── Tasks: t0:[p0..p3] t1:[p4..p7]
             │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
-            │   RowGeneratorExec: tag=probe, tasks=2, rows_per_partition=[[3], [1], [2], [1]]
+            │   RowGeneratorExec: tag=probe, tasks=2, partition_ops=[[rows(3)], [rows(1)], [rows(2)], [rows(1)]]
             └──────────────────────────────────────────────────
         +-------+--------+-------------+--------+-------+--------+-------------+
         | a_tag | a_task | a_partition | letter | b_tag | b_task | b_partition |
@@ -566,6 +567,135 @@ mod tests {
         | probe | 1      | 1           | a      | build | 1      | 1           |
         +-------+--------+-------------+--------+-------+--------+-------------+
         ");
+        Ok(())
+    }
+
+    /// `wait()` ops in a feed must actually delay the producing stream.
+    /// Verifies the [`crate::test_utils::test_work_unit_feed::WorkUnitOp::Wait`]
+    /// op is wired into the producer's stream.
+    #[tokio::test]
+    async fn wait_op_delays_query() -> Result<(), Box<dyn std::error::Error>> {
+        let start = Instant::now();
+        let (_, results) =
+            run_query(r#"SELECT * FROM test_work_unit('a', 1, 'rows(1), wait(800), rows(1)')"#)
+                .await?;
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(800),
+            "expected query to take at least 800ms (the wait), but took {elapsed:?}"
+        );
+        // Sanity check that both rows came through after the wait.
+        let data_rows = results.lines().filter(|l| l.starts_with("| a ")).count();
+        assert_eq!(
+            data_rows, 2,
+            "expected 2 rows from feed 'a', got:\n{results}"
+        );
+        Ok(())
+    }
+
+    /// An `err()` op in the feed must surface as a query-level error.
+    /// This exercises error propagation from a coordinator-side
+    /// [`WorkUnitFeedProvider`] through the local + remote feed pipeline up
+    /// to the user calling `try_collect` on the result stream.
+    #[tokio::test]
+    async fn err_op_in_single_task_propagates() -> Result<(), Box<dyn std::error::Error>> {
+        let res =
+            run_query(r#"SELECT * FROM test_work_unit('a', 1, 'rows(1), err(boom_single)')"#).await;
+        let err = res.expect_err("query should have failed");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("boom_single"),
+            "expected error to mention 'boom_single', got: {msg}"
+        );
+        Ok(())
+    }
+
+    /// Same as [`err_op_in_single_task_propagates`] but with two tasks, so the
+    /// erroring feed actually goes through the coordinator → worker gRPC path.
+    /// Guards against errors being silently swallowed as EOF on the worker side.
+    #[tokio::test]
+    async fn err_op_in_distributed_feed_propagates() -> Result<(), Box<dyn std::error::Error>> {
+        let res = run_query(
+            r#"
+            SELECT * FROM test_work_unit('a', 2, 'rows(1)', 'rows(1), err(boom_distributed)')
+            "#,
+        )
+        .await;
+        let err = res.expect_err("distributed query should have failed");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("boom_distributed"),
+            "expected error to mention 'boom_distributed', got: {msg}"
+        );
+        Ok(())
+    }
+
+    /// An `err()` op in one of two independent feeds in the same query must still
+    /// surface. The other feed is otherwise valid — we want to make sure the
+    /// failing feed taints the whole query rather than the result silently
+    /// missing the rows from the failing side.
+    #[tokio::test]
+    async fn err_in_one_of_two_feeds_propagates() -> Result<(), Box<dyn std::error::Error>> {
+        let res = run_query(
+            r#"
+            SELECT * FROM test_work_unit('left', 2, 'rows(1)', 'rows(1)', 'rows(1)', 'rows(1)')
+            UNION ALL
+            SELECT * FROM test_work_unit('right', 2, 'rows(1)', 'err(boom_union)', 'rows(1)', 'rows(1)')
+            "#,
+        )
+        .await;
+        let err = res.expect_err("query should have failed because of the right feed");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("boom_union"),
+            "expected error to mention 'boom_union', got: {msg}"
+        );
+        Ok(())
+    }
+
+    /// A `wait()` op in one feed should not stop another, independent feed in the
+    /// same query from making progress, and the final result should still be
+    /// correct. Acts as a regression guard against the producer side blocking
+    /// other feeds while sleeping on a single partition.
+    #[tokio::test]
+    async fn wait_in_one_feed_does_not_corrupt_other_feed_results()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (plan, results) = run_query(
+            r#"
+            SELECT * FROM test_work_unit('fast', 2, 'rows(1)', 'rows(1)', 'rows(1)', 'rows(1)')
+            UNION ALL
+            SELECT * FROM test_work_unit('slow', 2, 'wait(500), rows(1)', 'rows(1)', 'rows(1)', 'rows(1)')
+            ORDER BY tag, task, partition, letter
+            "#,
+        )
+        .await?;
+
+        assert_snapshot!(plan + &results, @r"
+        ┌───── DistributedExec ── Tasks: t0:[p0]
+        │ SortPreservingMergeExec: [tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST]
+        │   [Stage 1] => NetworkCoalesceExec: output_partitions=12, input_tasks=3
+        └──────────────────────────────────────────────────
+          ┌───── Stage 1 ── Tasks: t0:[p0..p3] t1:[p4..p7] t2:[p8..p11]
+          │ DistributedUnionExec: t0:[c0] t1:[c1(0/2)] t2:[c1(1/2)]
+          │   SortExec: expr=[tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
+          │     RowGeneratorExec: tag=fast, tasks=2, partition_ops=[[rows(1)], [rows(1)], [rows(1)], [rows(1)]]
+          │   SortExec: expr=[tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
+          │     RowGeneratorExec: tag=slow, tasks=2, partition_ops=[[wait(500), rows(1)], [rows(1)], [rows(1)], [rows(1)]]
+          └──────────────────────────────────────────────────
+        +------+------+-----------+--------+
+        | tag  | task | partition | letter |
+        +------+------+-----------+--------+
+        | fast | 0    | 0         | a      |
+        | fast | 0    | 1         | a      |
+        | fast | 0    | 2         | a      |
+        | fast | 0    | 3         | a      |
+        | slow | 0    | 0         | a      |
+        | slow | 0    | 1         | a      |
+        | slow | 1    | 0         | a      |
+        | slow | 1    | 1         | a      |
+        +------+------+-----------+--------+
+        "
+        );
         Ok(())
     }
 


### PR DESCRIPTION
This is one PR from a stack of PRs:
- https://github.com/datafusion-contrib/datafusion-distributed/pull/418 <- you are here
- https://github.com/datafusion-contrib/datafusion-distributed/pull/448

---

Just some extra test to the WorkUnitFeed machinery.

Extends the work unit testing tooling to support statements like this:

```sql
SELECT * FROM test_work_unit('a', 1, 'rows(1), err(boom_single)')
```

or

```sql
SELECT * FROM test_work_unit('a', 1, 'rows(1), wait(800), rows(1)')
```

Replicating weird behaviors in `WorkUnitFeedProvider` implementations.

---

Additionally, ships a testing `WorkUnitFileScanConfig` implementation that replicates a `FileScanConfig` but streaming the `FileGroup`s as work units instead of baking them in the plan. Suitable for benchmarking and ensuring that the `WorkUnitFeed` machinery meets performance expectations