### PR TITLE
Buffering improvements to inter-worker communication

### DIFF
--- a/src/distributed_ext.rs
+++ b/src/distributed_ext.rs
@@ -541,6 +541,22 @@ pub trait DistributedExt: Sized {
     /// Same as [DistributedExt::with_distributed_partial_reduce] but with an in-place mutation.
     fn set_distributed_partial_reduce(&mut self, enabled: bool) -> Result<(), DataFusionError>;
 
+    /// Sets the soft byte budget that each per-worker connection will buffer in memory before
+    /// pausing the gRPC pull from that worker. Per-partition channels are unbounded (to avoid
+    /// head-of-line blocking between sibling partitions), so backpressure is enforced globally
+    /// per worker connection using this budget.
+    fn with_distributed_worker_connection_buffer_budget_bytes(
+        self,
+        budget_bytes: usize,
+    ) -> Result<Self, DataFusionError>;
+
+    /// Same as [DistributedExt::with_distributed_worker_connection_buffer_budget_bytes] but with
+    /// an in-place mutation.
+    fn set_distributed_worker_connection_buffer_budget_bytes(
+        &mut self,
+        budget_bytes: usize,
+    ) -> Result<(), DataFusionError>;
+
     /// Registers a [WorkUnitFeed] so that Distributed DataFusion can discover it while traversing
     /// plans. For more info, refer to [WorkUnitFeed] docs.
     ///
@@ -693,6 +709,15 @@ impl DistributedExt for SessionConfig {
         Ok(())
     }
 
+    fn set_distributed_worker_connection_buffer_budget_bytes(
+        &mut self,
+        budget_bytes: usize,
+    ) -> Result<(), DataFusionError> {
+        let d_cfg = DistributedConfig::from_config_options_mut(self.options_mut())?;
+        d_cfg.worker_connection_buffer_budget_bytes = budget_bytes;
+        Ok(())
+    }
+
     fn set_distributed_work_unit_feed<T, P, F>(&mut self, getter: F)
     where
         T: ExecutionPlan + 'static,
@@ -774,6 +799,10 @@ impl DistributedExt for SessionConfig {
             #[call(set_distributed_partial_reduce)]
             #[expr($?;Ok(self))]
             fn with_distributed_partial_reduce(mut self, enabled: bool) -> Result<Self, DataFusionError>;
+
+            #[call(set_distributed_worker_connection_buffer_budget_bytes)]
+            #[expr($?;Ok(self))]
+            fn with_distributed_worker_connection_buffer_budget_bytes(mut self, budget_bytes: usize) -> Result<Self, DataFusionError>;
 
             #[call(set_distributed_work_unit_feed)]
             #[expr($;self)]
@@ -874,6 +903,11 @@ impl DistributedExt for SessionStateBuilder {
             #[call(set_distributed_partial_reduce)]
             #[expr($?;Ok(self))]
             fn with_distributed_partial_reduce(mut self, enabled: bool) -> Result<Self, DataFusionError>;
+
+            fn set_distributed_worker_connection_buffer_budget_bytes(&mut self, budget_bytes: usize) -> Result<(), DataFusionError>;
+            #[call(set_distributed_worker_connection_buffer_budget_bytes)]
+            #[expr($?;Ok(self))]
+            fn with_distributed_worker_connection_buffer_budget_bytes(mut self, budget_bytes: usize) -> Result<Self, DataFusionError>;
 
             fn set_distributed_work_unit_feed<T, P, F>(&mut self, getter: F)
             where
@@ -981,6 +1015,11 @@ impl DistributedExt for SessionState {
             #[expr($?;Ok(self))]
             fn with_distributed_partial_reduce(mut self, enabled: bool) -> Result<Self, DataFusionError>;
 
+            fn set_distributed_worker_connection_buffer_budget_bytes(&mut self, budget_bytes: usize) -> Result<(), DataFusionError>;
+            #[call(set_distributed_worker_connection_buffer_budget_bytes)]
+            #[expr($?;Ok(self))]
+            fn with_distributed_worker_connection_buffer_budget_bytes(mut self, budget_bytes: usize) -> Result<Self, DataFusionError>;
+
             fn set_distributed_work_unit_feed<T, P, F>(&mut self, getter: F)
             where
                 T: ExecutionPlan + 'static,
@@ -1086,6 +1125,11 @@ impl DistributedExt for SessionContext {
             #[call(set_distributed_partial_reduce)]
             #[expr($?;Ok(self))]
             fn with_distributed_partial_reduce(self, enabled: bool) -> Result<Self, DataFusionError>;
+
+            fn set_distributed_worker_connection_buffer_budget_bytes(&mut self, budget_bytes: usize) -> Result<(), DataFusionError>;
+            #[call(set_distributed_worker_connection_buffer_budget_bytes)]
+            #[expr($?;Ok(self))]
+            fn with_distributed_worker_connection_buffer_budget_bytes(self, budget_bytes: usize) -> Result<Self, DataFusionError>;
 
             fn set_distributed_work_unit_feed<T, P, F>(&mut self, getter: F)
             where

--- a/src/distributed_planner/distributed_config.rs
+++ b/src/distributed_planner/distributed_config.rs
@@ -58,6 +58,13 @@ extensions_options! {
         /// Disabled by default because its effectiveness is workload-dependent: it helps when
         /// aggregation significantly reduces cardinality, but adds overhead when it does not.
         pub partial_reduce: bool, default = false
+        /// Soft byte budget that each per-worker connection will buffer in memory before pausing
+        /// the gRPC pull from that worker. Per-partition channels are unbounded (to avoid
+        /// head-of-line blocking between sibling partitions), so backpressure is enforced
+        /// globally per [WorkerConnection] using this budget. A single message larger than this
+        /// budget will still be admitted (otherwise we would livelock), so the actual peak per
+        /// connection is `worker_connection_buffer_budget_bytes + max_message_size`.
+        pub worker_connection_buffer_budget_bytes: usize, default = 64 * 1024 * 1024
         /// Collection of [TaskEstimator]s that will be applied to leaf nodes in order to
         /// estimate how many tasks should be spawned for the [Stage] containing the leaf node.
         pub(crate) __private_task_estimator: CombinedTaskEstimator, default = CombinedTaskEstimator::default()

--- a/src/worker/spawn_select_all.rs
+++ b/src/worker/spawn_select_all.rs
@@ -21,13 +21,14 @@ where
     El: MemoryFootPrint + Send + 'static,
     Err: Send + 'static,
 {
-    let (tx, rx) = tokio::sync::mpsc::channel(queue_size);
+    let reservation = Arc::new(MemoryConsumer::new("NetworkBoundary").register(&pool));
 
-    let mut tasks = vec![];
+    let mut tasks = Vec::with_capacity(inner.len());
+    let mut in_rxs = Vec::with_capacity(inner.len());
     for mut t in inner {
-        let tx = tx.clone();
-        let pool = Arc::clone(&pool);
-        let consumer = MemoryConsumer::new("NetworkBoundary");
+        let (in_tx, in_rx) = tokio::sync::mpsc::channel(queue_size);
+        in_rxs.push(ReceiverStream::new(in_rx));
+        let reservation = Arc::clone(&reservation);
 
         tasks.push(SpawnedTask::spawn(async move {
             loop {
@@ -35,24 +36,26 @@ where
                 // extra work if we know nobody is going to listen to it.
                 let msg = tokio::select! {
                     biased;
-                    _ = tx.closed() => return,
+                    _ = in_tx.closed() => return,
                     msg = t.next() => msg
                 };
                 let Some(msg) = msg else { return };
 
-                let reservation = consumer.clone_with_new_id().register(&pool);
                 if let Ok(msg) = &msg {
                     reservation.grow(msg.get_memory_size());
                 }
 
-                if tx.send((msg, reservation)).await.is_err() {
+                if in_tx.send(msg).await.is_err() {
                     return;
                 };
             }
         }))
     }
 
-    ReceiverStream::new(rx).map(move |(msg, _reservation)| {
+    futures::stream::select_all(in_rxs).map(move |msg| {
+        if let Ok(msg) = &msg {
+            reservation.shrink(msg.get_memory_size());
+        }
         // keep the tasks alive as long as the stream lives
         let _ = &tasks;
         msg
@@ -99,13 +102,13 @@ mod tests {
         let reserved = pool.reserved();
         assert_eq!(reserved, 15);
 
-        for i in [1, 2, 3] {
-            let n = stream.next().await.unwrap()?;
-            assert_eq!(i, n)
+        let mut consumed = 0;
+        for _ in 0..3 {
+            consumed += stream.next().await.unwrap()?;
         }
 
         let reserved = pool.reserved();
-        assert_eq!(reserved, 9);
+        assert_eq!(reserved, 15 - consumed);
 
         drop(stream);
 

--- a/src/worker/worker_connection_pool.rs
+++ b/src/worker/worker_connection_pool.rs
@@ -30,6 +30,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::task::{Context, Poll};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::sync::Notify;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -98,6 +99,11 @@ impl WorkerConnectionPool {
 
 type WorkerMsg = Result<(FlightData, FlightAppMetadata), Status>;
 
+/// Soft byte budget the demux task will buffer in memory before pausing the gRPC
+/// pull. Per-partition channels are unbounded (to avoid head-of-line blocking
+/// between sibling partitions), so backpressure is enforced globally here instead.
+const PER_CONNECTION_BUFFER_BUDGET_BYTES: usize = 64 * 1024 * 1024;
+
 /// Represents a connection to one [Worker]. Network boundaries will use this for streaming
 /// data from single partitions while the actual network communication is handling all the partitions
 /// under the hood.
@@ -114,6 +120,9 @@ pub(crate) struct WorkerConnection {
     not_consumed_streams: Arc<AtomicUsize>,
     cancel_token: CancellationToken,
     per_partition_rx: DashMap<usize, UnboundedReceiver<WorkerMsg>>,
+
+    // Signals the demux task that buffered memory has been freed by a consumer.
+    mem_available_notify: Arc<Notify>,
 
     // Metrics collection stuff.
     memory_reservation: Arc<MemoryReservation>,
@@ -182,9 +191,11 @@ impl WorkerConnection {
         };
 
         // The senders and receivers are unbounded queues used for multiplexing the record
-        // batches sent through the single gRPC stream into one stream per partition.
-        // The received record batches contain information of the partition to which they belong,
-        // so we use that for determining where to put them.
+        // batches sent through the single gRPC stream into one stream per partition. They
+        // are unbounded to avoid head-of-line blocking: a single bounded queue could block
+        // the demux task and starve all sibling partitions even though they have capacity,
+        // which deadlocks queries with cross-partition dependencies.
+        // Total memory is bounded globally below via `mem_available_notify`.
         let mut per_partition_tx = Vec::with_capacity(target_partition_range.len());
         let per_partition_rx = DashMap::with_capacity(target_partition_range.len());
         for partition in target_partition_range.clone() {
@@ -192,6 +203,9 @@ impl WorkerConnection {
             per_partition_tx.push(tx);
             per_partition_rx.insert(partition, rx);
         }
+
+        let mem_available_notify = Arc::new(Notify::new());
+        let mem_available_notify_for_task = Arc::clone(&mem_available_notify);
 
         // Cancellation token allows us to stop the background task promptly when all partition
         // streams are dropped (e.g., when the query is cancelled).
@@ -215,6 +229,20 @@ impl WorkerConnection {
             };
 
             loop {
+                // Backpressure gate. Per-partition channels are unbounded, so we cap
+                // total in-flight buffered bytes here by pausing the gRPC pull when
+                // consumers haven't drained enough. This propagates flow control all
+                // the way back to the worker without coupling sibling partitions.
+                // We always allow a message through when reservation == 0 to avoid
+                // livelock if a single message is larger than the budget.
+                while memory_reservation.size() >= PER_CONNECTION_BUFFER_BUDGET_BYTES {
+                    tokio::select! {
+                        biased;
+                        _ = cancel.cancelled() => return,
+                        _ = mem_available_notify_for_task.notified() => {}
+                    }
+                }
+
                 // Check for cancellation while waiting for the next message.
                 let flight_data = tokio::select! {
                     biased;
@@ -291,6 +319,7 @@ impl WorkerConnection {
             cancel_token,
             not_consumed_streams: Arc::new(AtomicUsize::new(per_partition_rx.len())),
             per_partition_rx,
+            mem_available_notify,
 
             // metrics stuff
             memory_reservation: memory_reservation_clone,
@@ -324,8 +353,11 @@ impl WorkerConnection {
         let stream = UnboundedReceiverStream::new(partition_receiver);
         let stream = stream.map_err(|err| FlightError::Tonic(Box::new(err)));
         let reservation = Arc::clone(&self.memory_reservation);
+        let mem_available_notify = Arc::clone(&self.mem_available_notify);
         let stream = stream.map_ok(move |(data, meta)| {
             reservation.shrink(data.encoded_len());
+            // Wake the demux task in case it is blocked on the byte budget.
+            mem_available_notify.notify_one();
             let _ = &task; // <- keep the task that polls data from the network alive.
             on_metadata(meta);
             data

--- a/src/worker/worker_connection_pool.rs
+++ b/src/worker/worker_connection_pool.rs
@@ -5,7 +5,7 @@ use crate::passthrough_headers::get_passthrough_headers;
 use crate::protobuf::{datafusion_error_to_tonic_status, map_flight_to_datafusion_error};
 use crate::worker::generated::worker::FlightAppMetadata;
 use crate::worker::generated::worker::{ExecuteTaskRequest, TaskKey};
-use crate::{BytesMetricExt, ChannelResolver, Stage};
+use crate::{BytesMetricExt, ChannelResolver, DistributedConfig, Stage};
 use arrow_flight::FlightData;
 use arrow_flight::decode::FlightRecordBatchStream;
 use arrow_flight::error::FlightError;
@@ -99,11 +99,6 @@ impl WorkerConnectionPool {
 
 type WorkerMsg = Result<(FlightData, FlightAppMetadata), Status>;
 
-/// Soft byte budget the demux task will buffer in memory before pausing the gRPC
-/// pull. Per-partition channels are unbounded (to avoid head-of-line blocking
-/// between sibling partitions), so backpressure is enforced globally here instead.
-const PER_CONNECTION_BUFFER_BUDGET_BYTES: usize = 64 * 1024 * 1024;
-
 /// Represents a connection to one [Worker]. Network boundaries will use this for streaming
 /// data from single partitions while the actual network communication is handling all the partitions
 /// under the hood.
@@ -138,6 +133,9 @@ impl WorkerConnection {
         metrics: &ExecutionPlanMetricsSet,
     ) -> Result<Self> {
         let channel_resolver = get_distributed_channel_resolver(ctx.as_ref());
+        let buffer_budget_bytes =
+            DistributedConfig::from_config_options(ctx.session_config().options())?
+                .worker_connection_buffer_budget_bytes;
         // We are retaining record batches in memory until they are consumed, so we need to account
         // for them in the memory pool.
         let memory_reservation =
@@ -235,7 +233,7 @@ impl WorkerConnection {
                 // the way back to the worker without coupling sibling partitions.
                 // We always allow a message through when reservation == 0 to avoid
                 // livelock if a single message is larger than the budget.
-                while memory_reservation.size() >= PER_CONNECTION_BUFFER_BUDGET_BYTES {
+                while memory_reservation.size() >= buffer_budget_bytes {
                     tokio::select! {
                         biased;
                         _ = cancel.cancelled() => return,

--- a/src/worker/worker_connection_pool.rs
+++ b/src/worker/worker_connection_pool.rs
@@ -96,7 +96,7 @@ impl WorkerConnectionPool {
     }
 }
 
-type WorkerMsg = Result<(FlightData, FlightAppMetadata, MemoryReservation), Status>;
+type WorkerMsg = Result<(FlightData, FlightAppMetadata), Status>;
 
 /// Represents a connection to one [Worker]. Network boundaries will use this for streaming
 /// data from single partitions while the actual network communication is handling all the partitions
@@ -116,7 +116,7 @@ pub(crate) struct WorkerConnection {
     per_partition_rx: DashMap<usize, UnboundedReceiver<WorkerMsg>>,
 
     // Metrics collection stuff.
-    curr_mem_used: Arc<AtomicUsize>,
+    memory_reservation: Arc<MemoryReservation>,
     elapsed_compute: Time,
 }
 
@@ -129,10 +129,11 @@ impl WorkerConnection {
         metrics: &ExecutionPlanMetricsSet,
     ) -> Result<Self> {
         let channel_resolver = get_distributed_channel_resolver(ctx.as_ref());
-
-        // Stuff for collecting metrics.
-        let curr_mem_used = Arc::new(AtomicUsize::new(0));
-        let curr_mem_used_clone = Arc::clone(&curr_mem_used);
+        // We are retaining record batches in memory until they are consumed, so we need to account
+        // for them in the memory pool.
+        let memory_reservation =
+            Arc::new(MemoryConsumer::new("WorkerConnection").register(ctx.memory_pool()));
+        let memory_reservation_clone = Arc::clone(&memory_reservation);
 
         // Track the maximum memory used to buffer recieved messages.
         let mut curr_max_mem = 0;
@@ -192,10 +193,6 @@ impl WorkerConnection {
             per_partition_rx.insert(partition, rx);
         }
 
-        // We are retaining record batches in memory until they are consumed, so we need to account
-        // for them in the memory pool.
-        let memory_pool = Arc::clone(ctx.memory_pool());
-
         // Cancellation token allows us to stop the background task promptly when all partition
         // streams are dropped (e.g., when the query is cancelled).
         let cancel_token = CancellationToken::new();
@@ -217,11 +214,9 @@ impl WorkerConnection {
                 Err(err) => return fanout(&per_partition_tx, err),
             };
 
-            let consumer = MemoryConsumer::new("WorkerConnection");
-
             loop {
                 // Check for cancellation while waiting for the next message.
-                let msg = tokio::select! {
+                let flight_data = tokio::select! {
                     biased;
                     _ = cancel.cancelled() => return,
                     msg = interleaved_stream.next() => {
@@ -236,7 +231,7 @@ impl WorkerConnection {
                 // Earliest time at which the msg was received.
                 let msg_received_time = SystemTime::now();
 
-                let flight_metadata = match FlightAppMetadata::decode(msg.app_metadata.as_ref()) {
+                let flight_metadata = match FlightAppMetadata::decode(flight_data.app_metadata.as_ref()) {
                     Ok(v) => v,
                     Err(err) => {
                         return fanout(&per_partition_tx, Status::internal(err.to_string()));
@@ -273,20 +268,19 @@ impl WorkerConnection {
                 // so that it gets dropped as soon as the message leaves the queue. Dropping the
                 // memory reservation means releasing the memory from the pool for that specific
                 // message
-                let reservation = consumer.clone_with_new_id().register(&memory_pool);
-                let size = msg.encoded_len();
+                let size = flight_data.encoded_len();
+                memory_reservation.grow(size);
 
                 // Update memory related metrics.
                 msg_count.add(1);
                 bytes_transferred.add_bytes(size);
-                let curr_mem_used = curr_mem_used.fetch_add(size, Ordering::Relaxed);
-                if curr_mem_used > curr_max_mem {
-                    curr_max_mem = curr_mem_used;
+                let curr_mem = memory_reservation.size();
+                if curr_mem > curr_max_mem {
+                    curr_max_mem = curr_mem;
                     max_mem_used.set(curr_max_mem);
                 }
 
-                reservation.grow(size);
-                if o_tx.send(Ok((msg, flight_metadata, reservation))).is_err() {
+                if o_tx.send(Ok((flight_data, flight_metadata))).is_err() {
                     return; // channel closed
                 };
             }
@@ -299,7 +293,7 @@ impl WorkerConnection {
             per_partition_rx,
 
             // metrics stuff
-            curr_mem_used: curr_mem_used_clone,
+            memory_reservation: memory_reservation_clone,
             elapsed_compute: elapsed_compute_clone,
         })
     }
@@ -326,13 +320,12 @@ impl WorkerConnection {
         };
         let task = Arc::clone(&self.task);
         let cancel_token = self.cancel_token.clone();
-        let curr_mem_used = Arc::clone(&self.curr_mem_used);
 
         let stream = UnboundedReceiverStream::new(partition_receiver);
         let stream = stream.map_err(|err| FlightError::Tonic(Box::new(err)));
-        let stream = stream.map_ok(move |(data, meta, reservation)| {
-            curr_mem_used.fetch_sub(reservation.size(), Ordering::Relaxed);
-            drop(reservation); // <- drop the reservation, freeing memory on the memory pool.
+        let reservation = Arc::clone(&self.memory_reservation);
+        let stream = stream.map_ok(move |(data, meta)| {
+            reservation.shrink(data.encoded_len());
             let _ = &task; // <- keep the task that polls data from the network alive.
             on_metadata(meta);
             data


### PR DESCRIPTION
## Summary
- Replaces the bounded per-partition channels in `WorkerConnection` with unbounded ones to eliminate head-of-line blocking on the demux task. A single bounded queue could block the demux and starve all sibling partitions, deadlocking queries with cross-partition dependencies (e.g. TPC-H Q18).
- Backpressure is now enforced globally per worker connection: the demux loop pauses the gRPC pull while `memory_reservation.size()` is at or above a configurable byte budget, and consumers wake it via `Notify` after each `shrink`. A single oversized message is always admitted to avoid livelock, so the peak per connection is `budget + max_message_size`.
- Adds a new `DistributedConfig::worker_connection_buffer_budget_bytes` knob (default 64 MiB) and the matching `with_distributed_worker_connection_buffer_budget_bytes` / `set_…` builder methods on all `DistributedExt` impls.
- Refactored `spawn_select_all` to use one channel per partition instead of a global channel for all partitions. This makes sure that slow partitions do not delay fast ones.