### PR TITLE
Use in-memory comms if both workers involved in an exchange happen to be the same 

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,11 +1,13 @@
 mod children_helpers;
 mod map_last_stream;
 mod on_drop_stream;
+mod once_lock;
 mod task_context_helpers;
 mod uuid;
 
 pub(crate) use children_helpers::require_one_child;
 pub(crate) use map_last_stream::map_last_stream;
 pub(crate) use on_drop_stream::on_drop_stream;
+pub(crate) use once_lock::OnceLockResult;
 pub(crate) use task_context_helpers::task_ctx_with_extension;
 pub(crate) use uuid::{deserialize_uuid, serialize_uuid};

--- a/src/common/once_lock.rs
+++ b/src/common/once_lock.rs
@@ -1,0 +1,5 @@
+use datafusion::error::DataFusionError;
+use std::sync::{Arc, OnceLock};
+
+/// A [OnceLock] that holds a clonable result.
+pub(crate) type OnceLockResult<T> = OnceLock<Result<T, Arc<DataFusionError>>>;

--- a/src/execution_plans/broadcast.rs
+++ b/src/execution_plans/broadcast.rs
@@ -1,4 +1,4 @@
-use crate::common::require_one_child;
+use crate::common::{OnceLockResult, require_one_child};
 use crossbeam_queue::SegQueue;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::common::runtime::SpawnedTask;
@@ -73,7 +73,7 @@ pub struct BroadcastExec {
     input: Arc<dyn ExecutionPlan>,
     consumer_task_count: usize,
     properties: Arc<PlanProperties>,
-    queues: Vec<OnceLock<Result<StreamAndTask, Arc<DataFusionError>>>>,
+    queues: Vec<OnceLockResult<StreamAndTask>>,
 }
 
 type StreamAndTask = (SegQueue<SendableRecordBatchStream>, Arc<SpawnedTask<()>>);

--- a/src/execution_plans/network_broadcast.rs
+++ b/src/execution_plans/network_broadcast.rs
@@ -259,7 +259,7 @@ impl ExecutionPlan for NetworkBroadcastExec {
                 &context,
             )?;
 
-            let stream = worker_connection.stream_partition(off + partition, |_meta| {})?;
+            let stream = worker_connection.execute(off + partition)?;
             streams.push(stream);
         }
 

--- a/src/execution_plans/network_coalesce.rs
+++ b/src/execution_plans/network_coalesce.rs
@@ -301,7 +301,7 @@ impl ExecutionPlan for NetworkCoalesceExec {
             &context,
         )?;
 
-        let stream = worker_connection.stream_partition(target_partition, |_meta| {})?;
+        let stream = worker_connection.execute(target_partition)?;
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             self.schema(),

--- a/src/execution_plans/network_shuffle.rs
+++ b/src/execution_plans/network_shuffle.rs
@@ -237,7 +237,7 @@ impl ExecutionPlan for NetworkShuffleExec {
                 &context,
             )?;
 
-            let stream = worker_connection.stream_partition(off + partition, |_meta| {})?;
+            let stream = worker_connection.execute(off + partition)?;
             streams.push(stream);
         }
 

--- a/src/worker/impl_coordinator_channel.rs
+++ b/src/worker/impl_coordinator_channel.rs
@@ -65,6 +65,7 @@ impl Worker {
                     task_count: request.task_count as usize,
                 }))
                 .with_extension(Arc::new(LocalWorkerContext {
+                    task_data_entries: Arc::clone(&self.task_data_entries),
                     self_url: Url::parse(&request.target_worker_url)
                         .map_err(|e| DataFusionError::External(Box::new(e)))?,
                 }))

--- a/src/worker/impl_execute_task.rs
+++ b/src/worker/impl_execute_task.rs
@@ -3,12 +3,13 @@ use crate::common::{map_last_stream, on_drop_stream};
 use crate::metrics::proto::df_metrics_set_to_proto;
 use crate::protobuf::datafusion_error_to_tonic_status;
 use crate::worker::generated::worker::{FlightAppMetadata, PreOrderTaskMetrics};
-use crate::worker::worker_service::Worker;
+use crate::worker::worker_service::{TaskDataEntries, Worker};
 use arrow_flight::encode::{DictionaryHandling, FlightDataEncoder, FlightDataEncoderBuilder};
 use arrow_flight::error::FlightError;
 use arrow_select::dictionary::garbage_collect_any_dictionary;
 use datafusion::arrow::array::{Array, AsArray, RecordBatch, RecordBatchOptions};
 use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
+use datafusion::common::{Result, exec_err, internal_err};
 
 use crate::worker::generated::worker::ExecuteTaskRequest;
 use crate::worker::generated::worker::worker_service_server::WorkerService;
@@ -17,8 +18,9 @@ use datafusion::arrow::ipc::CompressionType;
 use datafusion::arrow::ipc::writer::IpcWriteOptions;
 use datafusion::common::exec_datafusion_err;
 use datafusion::error::DataFusionError;
-use datafusion::execution::SendableRecordBatchStream;
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::TryStreamExt;
 use prost::Message;
 use std::sync::Arc;
@@ -26,148 +28,178 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::oneshot::Sender;
+use tokio_stream::StreamExt;
 use tonic::{Request, Response, Status};
 
 /// How many record batches to buffer from the plan execution.
 const RECORD_BATCH_BUFFER_SIZE: usize = 2;
 const WAIT_PLAN_TIMEOUT_SECS: u64 = 10;
 
-impl Worker {
-    pub(crate) async fn impl_execute_task(
-        &self,
-        request: Request<ExecuteTaskRequest>,
-    ) -> Result<Response<<Worker as WorkerService>::ExecuteTaskStream>, Status> {
-        let body = request.into_inner();
+/// Builds several per-partition streams by retrieving the appropriate entry from [TaskDataEntries]
+/// based on the task key extracted from [ExecuteTaskRequest].
+///
+/// This method is async mainly for the key retrieval operation from [TaskDataEntries], but it does
+/// not start polling any stream, it just instantiates them.
+pub(crate) async fn execute_local_task(
+    task_data_entries: &Arc<TaskDataEntries>,
+    body: ExecuteTaskRequest,
+) -> Result<(Vec<SendableRecordBatchStream>, Arc<TaskContext>)> {
+    let Some(key) = body.task_key.as_ref().cloned() else {
+        return internal_err!("Missing task_key in LocalWorkerConnection");
+    };
+    let entry = task_data_entries
+        .get_with(key.clone(), async { Default::default() })
+        .await;
 
-        let key = body.task_key.ok_or_else(missing("task_key"))?;
-        let entry = self
-            .task_data_entries
-            .get_with(key.clone(), async { Default::default() })
-            .await;
+    // Other request is responsible for writing the plan that belongs to this TaskKey, so
+    // we'll resolve immediately if it was already there, or wait until it's ready.
+    let task_data = entry
+        .read(Duration::from_secs(WAIT_PLAN_TIMEOUT_SECS))
+        .await
+        .map_err(|e| exec_datafusion_err!("Worker::execute_task timed-out while waiting for the plan to be set by the coordinator. ({e})"))?
+        .map_err(DataFusionError::Shared)?;
 
-        // Other request is responsible for writing the plan that belongs to this TaskKey, so
-        // we'll resolve immediately if it was already there, or wait until it's ready.
-        let task_data = entry
-            .read(Duration::from_secs(WAIT_PLAN_TIMEOUT_SECS))
-            .await
-            .map_err(|e| Status::internal(e.to_string()))?
-            .map_err(datafusion_error_to_tonic_status)?;
+    let plan = task_data.plan;
+    let task_ctx = task_data.task_ctx;
+    let d_cfg = DistributedConfig::from_config_options(task_ctx.session_config().options())?;
 
-        let plan = task_data.plan;
-        let task_ctx = task_data.task_ctx;
-        let d_cfg = DistributedConfig::from_config_options(task_ctx.session_config().options())
-            .map_err(datafusion_error_to_tonic_status)?;
+    let send_metrics = d_cfg.collect_metrics;
+    let partition_count = plan.properties().partitioning.partition_count();
+    let plan_name = plan.name();
 
-        let compression = match d_cfg.compression.as_str() {
-            "lz4" => Some(CompressionType::LZ4_FRAME),
-            "zstd" => Some(CompressionType::ZSTD),
-            "none" => None,
-            v => Err(Status::invalid_argument(format!(
-                "Unknown compression type {v}"
-            )))?,
-        };
-        let send_metrics = d_cfg.collect_metrics;
-        let partition_count = plan.properties().partitioning.partition_count();
-        let plan_name = plan.name();
-
-        // Execute all the requested partitions at once, and collect all the streams so that they
-        // can be merged into a single one at the end of this function.
-        let n_streams = body.target_partition_end - body.target_partition_start;
-        let mut streams = Vec::with_capacity(n_streams as usize);
-        for partition in body.target_partition_start..body.target_partition_end {
-            if partition >= partition_count as u64 {
-                return Err(datafusion_error_to_tonic_status(exec_datafusion_err!(
-                    "partition {partition} not available. The head plan {plan_name} of the stage just has {partition_count} partitions"
-                )));
-            }
-
-            let stream = plan
-                .execute(partition as usize, Arc::clone(&task_ctx))
-                .map_err(|err| Status::internal(format!("Error executing stage plan: {err:#?}")))?;
-
-            let stream = build_flight_data_stream(stream, compression)?;
-
-            let task_data_entries = Arc::clone(&self.task_data_entries);
-            let num_partitions_remaining = Arc::clone(&task_data.num_partitions_remaining);
-            let metrics_tx = Arc::clone(&task_data.metrics_tx);
-
-            let key = key.clone();
-            let key_clone = key.clone();
-            let plan = Arc::clone(&plan);
-            let plan_for_drop = Arc::clone(&plan);
-            let fully_finished = Arc::new(AtomicBool::new(false));
-            let fully_finished_cloned = Arc::clone(&fully_finished);
-            let stream = map_last_stream(stream, move |msg, last_msg_in_stream| {
-                // For each FlightData produced by this stream, mark it with the appropriate
-                // partition. This stream will be merged with several others from other partitions,
-                // so marking it with the original partition allows it to be deconstructed into
-                // the original per-partition streams in later steps.
-                let flight_data = FlightAppMetadata {
-                    partition,
-                    created_timestamp_unix_nanos: SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .map(|duration| duration.as_nanos() as u64)
-                        .unwrap_or(0),
-                };
-
-                if last_msg_in_stream {
-                    // If it's the last message from the last partition, clean up the entry from
-                    // the cache and send the collected metrics back via the coordinator channel.
-                    if num_partitions_remaining.fetch_sub(1, Ordering::SeqCst) == 1 {
-                        let entries = Arc::clone(&task_data_entries);
-                        let k = key.clone();
-                        #[allow(clippy::disallowed_methods)]
-                        tokio::spawn(async move {
-                            entries.invalidate(&k).await;
-                        });
-                        if send_metrics {
-                            // Last message of the last partition. This is the moment to send
-                            // the metrics back.
-                            send_metrics_via_channel(&metrics_tx, &plan);
-                        }
-                    }
-                    fully_finished.store(true, Ordering::SeqCst);
-                }
-
-                msg.map(|v| v.with_app_metadata(flight_data.encode_to_vec()))
-            });
-
-            let num_partitions_remaining = Arc::clone(&task_data.num_partitions_remaining);
-            let task_data_entries = Arc::clone(&self.task_data_entries);
-            let metrics_tx = Arc::clone(&task_data.metrics_tx);
-            let key_for_drop = key_clone.clone();
-            let stream = on_drop_stream(stream, move || {
-                if !fully_finished_cloned.load(Ordering::SeqCst) {
-                    // Stream was dropped before fully consumed -- see https://github.com/datafusion-contrib/datafusion-distributed/issues/412
-                    // Send metrics via the coordinator channel so they are not lost.
-                    if num_partitions_remaining.fetch_sub(1, Ordering::SeqCst) == 1 {
-                        let entries = Arc::clone(&task_data_entries);
-                        let k = key_for_drop.clone();
-                        // Fire-and-forget background tokio task to handle async
-                        // invalidate() within synchronous on_drop_stream.
-                        #[allow(clippy::disallowed_methods)]
-                        tokio::spawn(async move {
-                            entries.invalidate(&k).await;
-                        });
-                        if send_metrics {
-                            send_metrics_via_channel(&metrics_tx, &plan_for_drop);
-                        }
-                    }
-                }
-            });
-            streams.push(stream)
+    // Execute all the requested partitions at once, and collect all the streams so that they
+    // can be merged into a single one at the end of this function.
+    let n_streams = body.target_partition_end - body.target_partition_start;
+    let mut streams = Vec::with_capacity(n_streams as usize);
+    for partition in body.target_partition_start..body.target_partition_end {
+        if partition >= partition_count as u64 {
+            return exec_err!(
+                "partition {partition} not available. The head plan {plan_name} of the stage just has {partition_count} partitions"
+            );
         }
 
-        // Merge all the per-partition streams into one. Each message in the stream is marked with
-        // the original partition, so they can be reconstructed at the other side of the boundary.
-        let memory_pool = Arc::clone(&task_ctx.runtime_env().memory_pool);
-        let stream = spawn_select_all(streams, memory_pool, RECORD_BATCH_BUFFER_SIZE);
+        let stream = plan.execute(partition as usize, Arc::clone(&task_ctx))?;
+        let stream_schema = plan.schema();
 
-        Ok(Response::new(Box::pin(stream.map_err(|err| match err {
-            FlightError::Tonic(status) => *status,
-            _ => Status::internal(format!("Error during flight stream: {err}")),
-        }))))
+        let task_data_entries_for_map = Arc::clone(task_data_entries);
+        let num_partitions_remaining = Arc::clone(&task_data.num_partitions_remaining);
+        let metrics_tx = Arc::clone(&task_data.metrics_tx);
+
+        let key_clone = key.clone();
+        let plan = Arc::clone(&plan);
+        let plan_for_drop = Arc::clone(&plan);
+        let fully_finished = Arc::new(AtomicBool::new(false));
+        let fully_finished_cloned = Arc::clone(&fully_finished);
+        let stream = map_last_stream(stream, move |msg, last_msg_in_stream| {
+            if !last_msg_in_stream {
+                return msg;
+            }
+
+            // this is the last message in the stream.
+
+            // If it's the last message from the last partition, clean up the entry from
+            // the cache and send the collected metrics back via the coordinator channel.
+            if num_partitions_remaining.fetch_sub(1, Ordering::SeqCst) == 1 {
+                let entries = Arc::clone(&task_data_entries_for_map);
+                let k = key_clone.clone();
+                #[allow(clippy::disallowed_methods)]
+                tokio::spawn(async move {
+                    entries.invalidate(&k).await;
+                });
+                if send_metrics {
+                    // Last message of the last partition. This is the moment to send
+                    // the metrics back.
+                    send_metrics_via_channel(&metrics_tx, &plan);
+                }
+            }
+            fully_finished.store(true, Ordering::SeqCst);
+            msg
+        });
+
+        let num_partitions_remaining = Arc::clone(&task_data.num_partitions_remaining);
+        let task_data_entries_for_drop = Arc::clone(task_data_entries);
+        let metrics_tx = Arc::clone(&task_data.metrics_tx);
+        let key_for_drop = key.clone();
+        let stream = on_drop_stream(stream, move || {
+            if !fully_finished_cloned.load(Ordering::SeqCst) {
+                // Stream was dropped before fully consumed -- see https://github.com/datafusion-contrib/datafusion-distributed/issues/412
+                // Send metrics via the coordinator channel so they are not lost.
+                if num_partitions_remaining.fetch_sub(1, Ordering::SeqCst) == 1 {
+                    let entries = Arc::clone(&task_data_entries_for_drop);
+                    let k = key_for_drop.clone();
+                    // Fire-and-forget background tokio task to handle async
+                    // invalidate() within synchronous on_drop_stream.
+                    #[allow(clippy::disallowed_methods)]
+                    tokio::spawn(async move {
+                        entries.invalidate(&k).await;
+                    });
+                    if send_metrics {
+                        send_metrics_via_channel(&metrics_tx, &plan_for_drop);
+                    }
+                }
+            }
+        });
+        streams.push(Box::pin(RecordBatchStreamAdapter::new(stream_schema, stream)) as _);
     }
+    Ok((streams, task_ctx))
+}
+
+/// Builds several per-partition streams by retrieving the appropriate entry from [TaskDataEntries]
+/// based on the task key extracted from the gRPC request.
+///
+/// This method eagerly starts streaming data from the task, and communicates via channels the
+/// produced [RecordBatch]s already encoded as Arrow Flight data.
+pub(crate) async fn execute_remote_task(
+    task_data_entries: &Arc<TaskDataEntries>,
+    request: Request<ExecuteTaskRequest>,
+) -> Result<Response<<Worker as WorkerService>::ExecuteTaskStream>, Status> {
+    let body = request.into_inner();
+    let partition_range = body.target_partition_start..body.target_partition_end;
+
+    let (arrow_streams, task_ctx) = execute_local_task(task_data_entries, body)
+        .await
+        .map_err(datafusion_error_to_tonic_status)?;
+
+    let d_cfg = DistributedConfig::from_config_options(task_ctx.session_config().options())
+        .map_err(datafusion_error_to_tonic_status)?;
+
+    let compression = match d_cfg.compression.as_str() {
+        "lz4" => Some(CompressionType::LZ4_FRAME),
+        "zstd" => Some(CompressionType::ZSTD),
+        "none" => None,
+        v => Err(Status::invalid_argument(format!(
+            "Unknown compression type {v}"
+        )))?,
+    };
+    let mut flight_streams = Vec::with_capacity(arrow_streams.len());
+    for (partition, arrow_stream) in partition_range.zip(arrow_streams) {
+        let flight_stream = build_flight_data_stream(arrow_stream, compression)?.map(move |msg| {
+            // For each FlightData produced by this stream, mark it with the appropriate
+            // partition. This stream will be merged with several others from other partitions,
+            // so marking it with the original partition allows it to be deconstructed into
+            // the original per-partition streams in later steps.
+            let flight_data = FlightAppMetadata {
+                partition,
+                created_timestamp_unix_nanos: SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|duration| duration.as_nanos() as u64)
+                    .unwrap_or(0),
+            };
+            msg.map(|v| v.with_app_metadata(flight_data.encode_to_vec()))
+        });
+
+        flight_streams.push(flight_stream);
+    }
+
+    // Merge all the per-partition streams into one. Each message in the stream is marked with
+    // the original partition, so they can be reconstructed at the other side of the boundary.
+    let memory_pool = Arc::clone(&task_ctx.runtime_env().memory_pool);
+    let stream = spawn_select_all(flight_streams, memory_pool, RECORD_BATCH_BUFFER_SIZE);
+
+    Ok(Response::new(Box::pin(stream.map_err(|err| match err {
+        FlightError::Tonic(status) => *status,
+        _ => Status::internal(format!("Error during flight stream: {err}")),
+    }))))
 }
 
 fn build_flight_data_stream(
@@ -206,10 +238,6 @@ fn build_flight_data_stream(
                 .map_err(|err| FlightError::Tonic(Box::new(datafusion_error_to_tonic_status(err)))),
         );
     Ok(stream)
-}
-
-fn missing(field: &'static str) -> impl FnOnce() -> Status {
-    move || Status::invalid_argument(format!("Missing field '{field}'"))
 }
 
 /// Collects metrics from the plan in pre-order traversal order and sends them via the

--- a/src/worker/worker_connection_pool.rs
+++ b/src/worker/worker_connection_pool.rs
@@ -1,4 +1,4 @@
-use crate::common::{on_drop_stream, serialize_uuid};
+use crate::common::{OnceLockResult, on_drop_stream, serialize_uuid};
 use crate::metrics::LatencyMetricExt;
 use crate::networking::get_distributed_channel_resolver;
 use crate::passthrough_headers::get_passthrough_headers;
@@ -6,6 +6,8 @@ use crate::protobuf::{datafusion_error_to_tonic_status, map_flight_to_datafusion
 use crate::stage::RemoteStage;
 use crate::worker::generated::worker::FlightAppMetadata;
 use crate::worker::generated::worker::{ExecuteTaskRequest, TaskKey};
+use crate::worker::impl_execute_task::execute_local_task;
+use crate::worker::worker_service::TaskDataEntries;
 use crate::{BytesMetricExt, ChannelResolver, DistributedConfig};
 use arrow_flight::FlightData;
 use arrow_flight::decode::FlightRecordBatchStream;
@@ -14,12 +16,13 @@ use dashmap::DashMap;
 use datafusion::arrow::array::RecordBatch;
 use datafusion::common::instant::Instant;
 use datafusion::common::runtime::SpawnedTask;
-use datafusion::common::{DataFusionError, Result, internal_err};
+use datafusion::common::{DataFusionError, Result, internal_datafusion_err, internal_err};
 use datafusion::execution::TaskContext;
 use datafusion::execution::memory_pool::{MemoryConsumer, MemoryReservation};
 use datafusion::physical_expr_common::metrics::{ExecutionPlanMetricsSet, MetricValue};
 use datafusion::physical_plan::metrics::{MetricBuilder, Time};
-use futures::{Stream, TryStreamExt};
+use futures::stream::BoxStream;
+use futures::{Stream, StreamExt, TryFutureExt, TryStreamExt};
 use http::Extensions;
 use pin_project::{pin_project, pinned_drop};
 use prost::Message;
@@ -33,7 +36,6 @@ use std::task::{Context, Poll};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::Notify;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
-use tokio_stream::StreamExt;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::CancellationToken;
 use tonic::metadata::MetadataMap;
@@ -47,9 +49,10 @@ use url::Url;
 /// This information can be used for executing tasks locally bypassing gRPC comms if the tasks that
 /// needs to be remotely executed happens to be owned by this same worker.
 pub(crate) struct LocalWorkerContext {
+    /// The registry of in-flight tasks the [crate::Worker] in the current scope owns.
+    pub(crate) task_data_entries: Arc<TaskDataEntries>,
     /// The URL of the [crate::Worker] in scope. When trying to reach to a target URL that happens
     /// to be the same as this one, local comms are preferred instead.
-    #[allow(dead_code)]
     pub(crate) self_url: Url,
 }
 
@@ -59,7 +62,7 @@ pub(crate) struct LocalWorkerContext {
 /// it will initialize the corresponding position in the vector matching the provided `target_task`
 /// index.
 pub(crate) struct WorkerConnectionPool {
-    connections: Vec<OnceLock<Result<WorkerConnection, Arc<DataFusionError>>>>,
+    connections: Vec<OnceLockResult<Box<dyn WorkerConnection + Sync + Send>>>,
     pub(crate) metrics: ExecutionPlanMetricsSet,
 }
 
@@ -86,7 +89,7 @@ impl WorkerConnectionPool {
         target_partitions: Range<usize>,
         target_task: usize,
         ctx: &Arc<TaskContext>,
-    ) -> Result<&WorkerConnection> {
+    ) -> Result<&(dyn WorkerConnection + Sync + Send)> {
         let Some(worker_connection) = self.connections.get(target_task) else {
             return internal_err!(
                 "WorkerConnections: Task index {target_task} not found, only have {} tasks",
@@ -96,24 +99,50 @@ impl WorkerConnectionPool {
         ctx.session_config().get_extension::<LocalWorkerContext>();
 
         let conn = worker_connection.get_or_init(|| {
-            WorkerConnection::init(
-                input_stage,
-                target_partitions,
-                target_task,
-                ctx,
-                &self.metrics,
-            )
-            .map_err(Arc::new)
+            let Some(target_url) = input_stage.workers.get(target_task) else {
+                internal_err!("input_stage.workers[{target_task}] out of range.")?
+            };
+            if let Some(lw_ctx) = ctx.session_config().get_extension::<LocalWorkerContext>()
+                && &lw_ctx.self_url == target_url
+            {
+                // Instead of making a gRPC call to ourselves, better to just use local comms.
+                Ok(Box::new(LocalWorkerConnection::init(
+                    input_stage,
+                    target_partitions,
+                    target_task,
+                    lw_ctx,
+                    &self.metrics,
+                )) as Box<_>)
+            } else {
+                // We are trying to reach a URL different from ours, so use normal gRPC streams.
+                RemoteWorkerConnection::init(
+                    input_stage,
+                    target_partitions,
+                    target_task,
+                    ctx,
+                    &self.metrics,
+                )
+                .map(|v| Box::new(v) as Box<_>)
+                .map_err(Arc::new)
+            }
         });
 
         match conn {
-            Ok(v) => Ok(v),
+            Ok(v) => Ok(v.as_ref()),
             Err(err) => Err(DataFusionError::Shared(Arc::clone(err))),
         }
     }
 }
 
 type WorkerMsg = Result<(FlightData, FlightAppMetadata), Status>;
+
+/// Abstraction that allows treating remote and local comms as equal. Network boundaries do not
+/// care if the stream comes over the wire or locally.
+pub(crate) trait WorkerConnection {
+    /// Streams the specified partition. Consumers do not care if the implementation pulls data
+    /// from in-memory or from local comms.
+    fn execute(&self, partition: usize) -> Result<BoxStream<'static, Result<RecordBatch>>>;
+}
 
 /// Represents a connection to one [Worker]. Network boundaries will use this for streaming
 /// data from single partitions while the actual network communication is handling all the partitions
@@ -126,7 +155,7 @@ type WorkerMsg = Result<(FlightData, FlightAppMetadata), Status>;
 /// the same underlying TCP connection, there do is some overhead in having one gRPC stream per
 /// partition VS a single gRPC stream interleaving multiple partitions. The whole serialized plan
 /// needs to be sent over the wire on every gRPC call, so the less gRPC calls we do the better.
-pub(crate) struct WorkerConnection {
+struct RemoteWorkerConnection {
     task: Arc<SpawnedTask<()>>,
     not_consumed_streams: Arc<AtomicUsize>,
     cancel_token: CancellationToken,
@@ -140,7 +169,7 @@ pub(crate) struct WorkerConnection {
     elapsed_compute: Time,
 }
 
-impl WorkerConnection {
+impl RemoteWorkerConnection {
     fn init(
         input_stage: &RemoteStage,
         target_partition_range: Range<usize>,
@@ -337,7 +366,9 @@ impl WorkerConnection {
             elapsed_compute: elapsed_compute_clone,
         })
     }
+}
 
+impl WorkerConnection for RemoteWorkerConnection {
     /// Streams the provided `partition` from the remote worker.
     ///
     /// Note that this does not issue a network request, the actual network request happened before
@@ -348,11 +379,7 @@ impl WorkerConnection {
     ///
     /// When the returned stream is dropped (e.g., due to query cancellation), the background task
     /// pulling from the Flight stream will be cancelled promptly.
-    pub(crate) fn stream_partition(
-        &self,
-        partition: usize,
-        on_metadata: impl Fn(FlightAppMetadata) + Send + Sync + 'static,
-    ) -> Result<impl Stream<Item = Result<RecordBatch>> + 'static> {
+    fn execute(&self, partition: usize) -> Result<BoxStream<'static, Result<RecordBatch>>> {
         let Some((_, partition_receiver)) = self.per_partition_rx.remove(&partition) else {
             return internal_err!(
                 "WorkerConnection has no stream for target partition {partition}. Was it already consumed?"
@@ -365,12 +392,11 @@ impl WorkerConnection {
         let stream = stream.map_err(|err| FlightError::Tonic(Box::new(err)));
         let reservation = Arc::clone(&self.memory_reservation);
         let mem_available_notify = Arc::clone(&self.mem_available_notify);
-        let stream = stream.map_ok(move |(data, meta)| {
+        let stream = stream.map_ok(move |(data, _meta)| {
             reservation.shrink(data.encoded_len());
             // Wake the demux task in case it is blocked on the byte budget.
             mem_available_notify.notify_one();
             let _ = &task; // <- keep the task that polls data from the network alive.
-            on_metadata(meta);
             data
         });
         let stream = FlightRecordBatchStream::new_from_flight_data(stream);
@@ -384,7 +410,71 @@ impl WorkerConnection {
             if remaining_streams == 0 {
                 cancel_token.cancel();
             }
-        }))
+        })
+        .boxed())
+    }
+}
+
+/// Equivalent to [RemoteWorkerConnection], but that pulls data from the local registry of tasks
+/// rather than doing it across a gRPC interface.
+pub(crate) struct LocalWorkerConnection {
+    lw_ctx: Arc<LocalWorkerContext>,
+    request_template: ExecuteTaskRequest,
+}
+
+impl LocalWorkerConnection {
+    fn init(
+        input_stage: &RemoteStage,
+        target_partition_range: Range<usize>,
+        target_task: usize,
+        lw_ctx: Arc<LocalWorkerContext>,
+        metrics: &ExecutionPlanMetricsSet,
+    ) -> Self {
+        MetricBuilder::new(metrics)
+            .global_counter("local_connections_used")
+            .add(1);
+        Self {
+            lw_ctx,
+            request_template: ExecuteTaskRequest {
+                task_key: Some(TaskKey {
+                    query_id: serialize_uuid(&input_stage.query_id),
+                    stage_id: input_stage.num as u64,
+                    task_number: target_task as u64,
+                }),
+                target_partition_start: target_partition_range.start as u64,
+                target_partition_end: target_partition_range.end as u64,
+            },
+        }
+    }
+}
+
+impl WorkerConnection for LocalWorkerConnection {
+    fn execute(&self, partition: usize) -> Result<BoxStream<'static, Result<RecordBatch>>> {
+        let mut request = self.request_template.clone();
+        request.target_partition_start = partition as u64;
+        request.target_partition_end = (partition + 1) as u64;
+        let task_data_entries = Arc::clone(&self.lw_ctx.task_data_entries);
+        // The relevant entry from `task_data_entries` needs to be eagerly retrieved, it cannot be
+        // left for until someone decides to start polling the returned `BoxStream`, otherwise,
+        // there's risk that the entry is evicted by Moka's TTL, and by the time the returned stream
+        // is polled, the entry might not be there.
+        //
+        // Note that this does not start polling the returned streams, it just instantiates them.
+        let streams_future = SpawnedTask::spawn(async move {
+            let (streams, _) = execute_local_task(&task_data_entries, request).await?;
+            Ok::<_, DataFusionError>(streams)
+        });
+        Ok(async move {
+            let mut streams = streams_future
+                .await
+                .map_err(|err| internal_datafusion_err!("{err}"))??;
+            if streams.len() != 1 {
+                return internal_err!("Expected exactly 1 local stream");
+            }
+            Ok(streams.swap_remove(0))
+        }
+        .try_flatten_stream()
+        .boxed())
     }
 }
 
@@ -408,7 +498,7 @@ impl Clone for WorkerConnectionPool {
     }
 }
 
-impl Debug for WorkerConnection {
+impl Debug for RemoteWorkerConnection {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WorkerConnection").finish()
     }

--- a/src/worker/worker_connection_pool.rs
+++ b/src/worker/worker_connection_pool.rs
@@ -485,7 +485,12 @@ impl LocalWorkerConnection {
 
 impl WorkerConnection for LocalWorkerConnection {
     fn execute(&self, partition: usize) -> Result<BoxStream<'static, Result<RecordBatch>>> {
-        let relative_i = partition - self.partition_start;
+        let Some(relative_i) = partition.checked_sub(self.partition_start) else {
+            return internal_err!(
+                "LocalWorkerConnection received an invalid partition {partition}, the starting partition is {}",
+                self.partition_start
+            );
+        };
         let Some(slot) = self.local_streams.get(relative_i) else {
             return internal_err!(
                 "LocalWorkerConnection has no stream for partition {partition}. Was it already consumed?"

--- a/src/worker/worker_connection_pool.rs
+++ b/src/worker/worker_connection_pool.rs
@@ -31,7 +31,7 @@ use std::fmt::{Debug, Formatter};
 use std::ops::Range;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::task::{Context, Poll};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::Notify;
@@ -96,7 +96,6 @@ impl WorkerConnectionPool {
                 self.connections.len()
             );
         };
-        ctx.session_config().get_extension::<LocalWorkerContext>();
 
         let conn = worker_connection.get_or_init(|| {
             let Some(target_url) = input_stage.workers.get(target_task) else {
@@ -418,8 +417,8 @@ impl WorkerConnection for RemoteWorkerConnection {
 /// Equivalent to [RemoteWorkerConnection], but that pulls data from the local registry of tasks
 /// rather than doing it across a gRPC interface.
 pub(crate) struct LocalWorkerConnection {
-    lw_ctx: Arc<LocalWorkerContext>,
-    request_template: ExecuteTaskRequest,
+    partition_start: usize,
+    local_streams: Vec<Mutex<Option<BoxStream<'static, Result<RecordBatch>>>>>,
 }
 
 impl LocalWorkerConnection {
@@ -433,48 +432,70 @@ impl LocalWorkerConnection {
         MetricBuilder::new(metrics)
             .global_counter("local_connections_used")
             .add(1);
+
+        let task_key = TaskKey {
+            query_id: serialize_uuid(&input_stage.query_id),
+            stage_id: input_stage.num as u64,
+            task_number: target_task as u64,
+        };
+
+        let partition_start = target_partition_range.start;
+        let mut local_streams = Vec::with_capacity(target_partition_range.len());
+        for partition_i in target_partition_range {
+            let request = ExecuteTaskRequest {
+                task_key: Some(task_key.clone()),
+                target_partition_start: partition_i as u64,
+                target_partition_end: (partition_i + 1) as u64,
+            };
+
+            let task_data_entries = Arc::clone(&lw_ctx.task_data_entries);
+
+            // The relevant entry from `task_data_entries` needs to be eagerly retrieved, it cannot be
+            // left for until someone decides to start polling the returned `BoxStream`, otherwise,
+            // there's risk that the entry is evicted by Moka's TTL, and by the time the returned stream
+            // is polled, the entry might not be there.
+            //
+            // Note that this does not start polling the returned streams, it just instantiates them.
+            let streams_future = SpawnedTask::spawn(async move {
+                let (streams, _) = execute_local_task(&task_data_entries, request).await?;
+                Ok::<_, DataFusionError>(streams)
+            });
+
+            let stream = async move {
+                let mut streams = streams_future
+                    .await
+                    .map_err(|err| internal_datafusion_err!("{err}"))??;
+                if streams.len() != 1 {
+                    return internal_err!("Expected exactly 1 local stream");
+                }
+                Ok(streams.swap_remove(0))
+            }
+            .try_flatten_stream()
+            .boxed();
+
+            local_streams.push(Mutex::new(Some(stream)));
+        }
+
         Self {
-            lw_ctx,
-            request_template: ExecuteTaskRequest {
-                task_key: Some(TaskKey {
-                    query_id: serialize_uuid(&input_stage.query_id),
-                    stage_id: input_stage.num as u64,
-                    task_number: target_task as u64,
-                }),
-                target_partition_start: target_partition_range.start as u64,
-                target_partition_end: target_partition_range.end as u64,
-            },
+            partition_start,
+            local_streams,
         }
     }
 }
 
 impl WorkerConnection for LocalWorkerConnection {
     fn execute(&self, partition: usize) -> Result<BoxStream<'static, Result<RecordBatch>>> {
-        let mut request = self.request_template.clone();
-        request.target_partition_start = partition as u64;
-        request.target_partition_end = (partition + 1) as u64;
-        let task_data_entries = Arc::clone(&self.lw_ctx.task_data_entries);
-        // The relevant entry from `task_data_entries` needs to be eagerly retrieved, it cannot be
-        // left for until someone decides to start polling the returned `BoxStream`, otherwise,
-        // there's risk that the entry is evicted by Moka's TTL, and by the time the returned stream
-        // is polled, the entry might not be there.
-        //
-        // Note that this does not start polling the returned streams, it just instantiates them.
-        let streams_future = SpawnedTask::spawn(async move {
-            let (streams, _) = execute_local_task(&task_data_entries, request).await?;
-            Ok::<_, DataFusionError>(streams)
-        });
-        Ok(async move {
-            let mut streams = streams_future
-                .await
-                .map_err(|err| internal_datafusion_err!("{err}"))??;
-            if streams.len() != 1 {
-                return internal_err!("Expected exactly 1 local stream");
-            }
-            Ok(streams.swap_remove(0))
-        }
-        .try_flatten_stream()
-        .boxed())
+        let relative_i = partition - self.partition_start;
+        let Some(slot) = self.local_streams.get(relative_i) else {
+            return internal_err!(
+                "LocalWorkerConnection has no stream for partition {partition}. Was it already consumed?"
+            );
+        };
+        slot.lock().unwrap().take().ok_or_else(|| {
+            internal_datafusion_err!(
+                "LocalWorkerConnection stream for partition {partition} was already consumed"
+            )
+        })
     }
 }
 

--- a/src/worker/worker_service.rs
+++ b/src/worker/worker_service.rs
@@ -1,8 +1,10 @@
+use super::generated::worker::{GetWorkerInfoRequest, GetWorkerInfoResponse};
 use crate::worker::WorkerSessionBuilder;
 use crate::worker::generated::worker::worker_service_server::{WorkerService, WorkerServiceServer};
 use crate::worker::generated::worker::{
     CoordinatorToWorkerMsg, ExecuteTaskRequest, TaskKey, WorkerToCoordinatorMsg,
 };
+use crate::worker::impl_execute_task::execute_remote_task;
 use crate::worker::single_write_multi_read::SingleWriteMultiRead;
 use crate::worker::task_data::TaskData;
 use crate::{
@@ -20,8 +22,6 @@ use std::time::Duration;
 use tonic::codegen::BoxStream;
 use tonic::{Request, Response, Status, Streaming};
 
-use super::generated::worker::{GetWorkerInfoRequest, GetWorkerInfoResponse};
-
 #[allow(clippy::type_complexity)]
 #[derive(Clone, Default)]
 pub(super) struct WorkerHooks {
@@ -29,7 +29,8 @@ pub(super) struct WorkerHooks {
         Vec<Arc<dyn Fn(Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> + Sync + Send>>,
 }
 
-type ResultTaskData = Result<TaskData, Arc<DataFusionError>>;
+pub(crate) type ResultTaskData = Result<TaskData, Arc<DataFusionError>>;
+pub(crate) type TaskDataEntries = Cache<TaskKey, Arc<SingleWriteMultiRead<ResultTaskData>>>;
 
 #[derive(Clone)]
 pub struct Worker {
@@ -37,7 +38,7 @@ pub struct Worker {
     /// TTL-based cache for task execution data. Entries are automatically evicted after 60 seconds.
     /// This prevents memory leaks from abandoned or incomplete queries while allowing concurrent
     /// access to task results across multiple partition requests.
-    pub(super) task_data_entries: Arc<Cache<TaskKey, Arc<SingleWriteMultiRead<ResultTaskData>>>>,
+    pub(super) task_data_entries: Arc<TaskDataEntries>,
     pub(super) session_builder: Arc<dyn WorkerSessionBuilder + Send + Sync>,
     pub(super) hooks: WorkerHooks,
     pub(super) max_message_size: Option<usize>,
@@ -191,7 +192,7 @@ impl WorkerService for Worker {
         &self,
         request: Request<ExecuteTaskRequest>,
     ) -> Result<Response<Self::ExecuteTaskStream>, Status> {
-        self.impl_execute_task(request).await
+        execute_remote_task(&self.task_data_entries, request).await
     }
 
     async fn get_worker_info(


### PR DESCRIPTION
This is one PR from the following stack of PRs:
- https://github.com/datafusion-contrib/datafusion-distributed/pull/427 <- you are here
- https://github.com/datafusion-contrib/datafusion-distributed/pull/469
- https://github.com/datafusion-contrib/datafusion-distributed/pull/461
- https://github.com/datafusion-contrib/datafusion-distributed/pull/462
- https://github.com/datafusion-contrib/datafusion-distributed/pull/463
- https://github.com/datafusion-contrib/datafusion-distributed/pull/464
- https://github.com/datafusion-contrib/datafusion-distributed/pull/432

This is a preparatory step towards:
- https://github.com/datafusion-contrib/datafusion-distributed/issues/377

This is an optimization that allows workers to communicate in-memory avoiding network calls and serialization in case it needs to communicate to itself.

This optimization shows good improvements if using a small number of workers, and fades away as more workers are used.

Even if this shows improvements today, it will become very meaningful in adaptative query execution: there will be times when two consecutive stages are assigned 1 task each, and as that was done dynamically, we cannot eagerly do the optimization that collapses those two stages into one, so instead, we assigned both stages to the same worker, and the optimization in this PR kicks in, executing the plan fully locally.