### PR TITLE
Cherry pick LocalWorkerContext

### DIFF
--- a/src/execution_plans/distributed.rs
+++ b/src/execution_plans/distributed.rs
@@ -438,6 +438,7 @@ impl<'a> CoordinatorToWorkerTaskSpawner<'a> {
                 task_count: self.task_count as u64,
                 task_key: Some(task_key.clone()),
                 work_unit_feed_declarations,
+                target_worker_url: url.to_string(),
             })),
         };
         let plan_size = self.plan_proto.len();

--- a/src/worker/generated/worker.rs
+++ b/src/worker/generated/worker.rs
@@ -70,6 +70,10 @@ pub struct SetPlanRequest {
     #[prost(message, repeated, tag = "4")]
     pub work_unit_feed_declarations:
         ::prost::alloc::vec::Vec<set_plan_request::WorkUnitFeedDeclaration>,
+    /// The worker URL to which this message will go. The receiving worker will use this information to identify
+    /// itself, and avoid further gRPC calls in case it needs to call itself for executing remote tasks.
+    #[prost(string, tag = "5")]
+    pub target_worker_url: ::prost::alloc::string::String,
 }
 /// Nested message and enum types in `SetPlanRequest`.
 pub mod set_plan_request {

--- a/src/worker/impl_set_plan.rs
+++ b/src/worker/impl_set_plan.rs
@@ -4,6 +4,7 @@ use crate::protobuf::DistributedCodec;
 use crate::work_unit_feed::{RemoteWorkUnitFeedRegistry, RemoteWorkUnitFeedTxs};
 use crate::worker::generated::worker::set_plan_request::WorkUnitFeedDeclaration;
 use crate::worker::generated::worker::{PreOrderTaskMetrics, SetPlanRequest};
+use crate::worker::worker_connection_pool::LocalWorkerContext;
 use crate::{DistributedConfig, DistributedTaskContext, Worker, WorkerQueryContext};
 use datafusion::error::DataFusionError;
 use datafusion::execution::{SessionStateBuilder, TaskContext};
@@ -16,6 +17,7 @@ use std::sync::atomic::AtomicUsize;
 use tokio::sync::oneshot;
 use tonic::Status;
 use tonic::metadata::MetadataMap;
+use url::Url;
 
 #[derive(Clone, Debug)]
 /// TaskData stores state for a single task being executed by this Endpoint. It may be shared
@@ -88,6 +90,10 @@ impl Worker {
                 .with_extension(Arc::new(DistributedTaskContext {
                     task_index: key.task_number as usize,
                     task_count: request.task_count as usize,
+                }))
+                .with_extension(Arc::new(LocalWorkerContext {
+                    self_url: Url::parse(&request.target_worker_url)
+                        .map_err(|e| DataFusionError::External(Box::new(e)))?,
                 }));
             set_distributed_option_extension_from_headers::<DistributedConfig>(&mut cfg, &headers)?;
 

--- a/src/worker/worker.proto
+++ b/src/worker/worker.proto
@@ -67,6 +67,9 @@ message SetPlanRequest {
   //
   // If no WorkUnitFeedExec nodes are present in the plan, this should be empty.
   repeated WorkUnitFeedDeclaration work_unit_feed_declarations = 4;
+  // The worker URL to which this message will go. The receiving worker will use this information to identify
+  // itself, and avoid further gRPC calls in case it needs to call itself for executing remote tasks.
+  string target_worker_url = 5;
 }
 
 message WorkUnit {

--- a/src/worker/worker_connection_pool.rs
+++ b/src/worker/worker_connection_pool.rs
@@ -37,6 +37,20 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::CancellationToken;
 use tonic::metadata::MetadataMap;
 use tonic::{Request, Status};
+use url::Url;
+
+/// Context set by [crate::Worker::coordinator_channel] in DataFusion's
+/// [datafusion::prelude::SessionConfig] that contains information about the local tasks the current
+/// [crate::Worker] owns.
+///
+/// This information can be used for executing tasks locally bypassing gRPC comms if the tasks that
+/// needs to be remotely executed happens to be owned by this same worker.
+pub(crate) struct LocalWorkerContext {
+    /// The URL of the [crate::Worker] in scope. When trying to reach to a target URL that happens
+    /// to be the same as this one, local comms are preferred instead.
+    #[allow(dead_code)]
+    pub(crate) self_url: Url,
+}
 
 /// Holds a list of lazily initialized [WorkerConnection]s. Each position in the underlying
 /// `connections` vector corresponds to the connection to one worker. It assumes a 1:1 mapping
@@ -78,6 +92,7 @@ impl WorkerConnectionPool {
                 self.connections.len()
             );
         };
+        ctx.session_config().get_extension::<LocalWorkerContext>();
 
         let conn = worker_connection.get_or_init(|| {
             WorkerConnection::init(


### PR DESCRIPTION
Cherry picks the `LocalWorkerContext` struct propagation from:
- https://github.com/datafusion-contrib/datafusion-distributed/pull/427