### PR TITLE
Add per-task specialized plans

### DIFF
--- a/src/distributed_planner/mod.rs
+++ b/src/distributed_planner/mod.rs
@@ -5,10 +5,12 @@ mod network_boundary;
 mod partial_reduce_below_network_shuffles;
 mod plan_annotator;
 mod session_state_builder_ext;
+mod specialize_plan;
 mod task_estimator;
 
 pub use distributed_config::DistributedConfig;
 pub use network_boundary::{NetworkBoundary, NetworkBoundaryExt};
 pub use session_state_builder_ext::SessionStateBuilderExt;
 pub use task_estimator::{TaskCountAnnotation, TaskEstimation, TaskEstimator, TaskRoutingContext};
+pub(crate) use specialize_plan::specialize_plan_for_task;
 pub(crate) use task_estimator::{get_distributed_task_estimator, set_distributed_task_estimator};

--- a/src/distributed_planner/specialize_plan.rs
+++ b/src/distributed_planner/specialize_plan.rs
@@ -1,0 +1,218 @@
+use crate::PartitionIsolatorExec;
+use crate::distributed_planner::TaskEstimator;
+use datafusion::common::Result;
+use datafusion::common::tree_node::{Transformed, TreeNode};
+use datafusion::config::ConfigOptions;
+use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
+use std::sync::Arc;
+
+/// Returns a per-task specialization of `plan`. Walks the plan top-down and, for every
+/// [PartitionIsolatorExec] found, asks the registered [TaskEstimator]s to specialize the
+/// wrapped leaf so it only carries the per-partition state assigned to
+/// `(task_index, task_count)`. The [PartitionIsolatorExec] wrapper is preserved (so plan
+/// shape across coordinator and worker stays in sync — important for metrics rewriting)
+/// and the runtime skipping path keeps working: skipped partitions just yield empty
+/// streams now that their state has been dropped from the payload.
+///
+/// When no estimator handles a particular [PartitionIsolatorExec], the original leaf is
+/// left in place and the runtime skipping behavior is preserved as a safe fallback.
+pub(crate) fn specialize_plan_for_task(
+    plan: &Arc<dyn ExecutionPlan>,
+    task_index: usize,
+    task_count: usize,
+    estimator: &dyn TaskEstimator,
+    cfg: &ConfigOptions,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    if task_count <= 1 {
+        return Ok(Arc::clone(plan));
+    }
+    let result = Arc::clone(plan).transform_down(|node| {
+        let Some(isolator) = node.as_any().downcast_ref::<PartitionIsolatorExec>() else {
+            return Ok(Transformed::no(node));
+        };
+        let input_partitions = isolator.input.output_partitioning().partition_count();
+        let partition_group =
+            PartitionIsolatorExec::partition_group(input_partitions, task_index, task_count);
+        match estimator.specialize_leaf(&isolator.input, &partition_group, cfg) {
+            Some(specialized_child) => {
+                let new_isolator = Arc::new(PartitionIsolatorExec::new(
+                    specialized_child,
+                    isolator.n_tasks,
+                ));
+                Ok(Transformed::yes(new_isolator as Arc<dyn ExecutionPlan>))
+            }
+            None => Ok(Transformed::no(node)),
+        }
+    })?;
+    Ok(result.data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::distributed_planner::{TaskEstimation, TaskRoutingContext};
+    use crate::test_utils::mock_exec::MockExec;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::common::tree_node::TreeNodeRecursion;
+    use datafusion::error::DataFusionError;
+    use std::sync::Mutex;
+
+    fn build_mock_leaf(partitions: usize) -> Arc<dyn ExecutionPlan> {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+        let data = (0..partitions).map(|_| vec![]).collect();
+        Arc::new(MockExec::new_partitioned(data, schema))
+    }
+
+    fn build_isolated(partitions: usize, n_tasks: usize) -> Arc<dyn ExecutionPlan> {
+        let leaf = build_mock_leaf(partitions);
+        Arc::new(PartitionIsolatorExec::new(leaf, n_tasks))
+    }
+
+    fn count_isolators(plan: &Arc<dyn ExecutionPlan>) -> usize {
+        let mut count = 0;
+        let _ = plan.apply(|node| {
+            if node.as_any().is::<PartitionIsolatorExec>() {
+                count += 1;
+            }
+            Ok(TreeNodeRecursion::Continue)
+        });
+        count
+    }
+
+    /// A test estimator whose `specialize_leaf` returns a smaller [MockExec] sized to the
+    /// passed-in partition group. Records the partition groups it received per task.
+    struct RecordingEstimator {
+        seen: Mutex<Vec<Vec<usize>>>,
+    }
+
+    impl RecordingEstimator {
+        fn new() -> Self {
+            Self {
+                seen: Mutex::new(Vec::new()),
+            }
+        }
+        fn calls(&self) -> Vec<Vec<usize>> {
+            self.seen.lock().unwrap().clone()
+        }
+    }
+
+    impl TaskEstimator for RecordingEstimator {
+        fn task_estimation(
+            &self,
+            _plan: &Arc<dyn ExecutionPlan>,
+            _cfg: &ConfigOptions,
+        ) -> Option<TaskEstimation> {
+            None
+        }
+        fn scale_up_leaf_node(
+            &self,
+            _plan: &Arc<dyn ExecutionPlan>,
+            _task_count: usize,
+            _cfg: &ConfigOptions,
+        ) -> Option<Arc<dyn ExecutionPlan>> {
+            None
+        }
+        fn specialize_leaf(
+            &self,
+            plan: &Arc<dyn ExecutionPlan>,
+            partition_group: &[usize],
+            _cfg: &ConfigOptions,
+        ) -> Option<Arc<dyn ExecutionPlan>> {
+            self.seen.lock().unwrap().push(partition_group.to_vec());
+            // Preserve the input partition count; just return a same-shape mock leaf.
+            Some(build_mock_leaf(
+                plan.output_partitioning().partition_count(),
+            ))
+        }
+        fn route_tasks(
+            &self,
+            _routing_ctx: &TaskRoutingContext<'_>,
+        ) -> Result<Option<Vec<url::Url>>> {
+            Ok(None)
+        }
+    }
+
+    /// An estimator that never specializes — used to verify the safe fallback.
+    struct NoopEstimator;
+    impl TaskEstimator for NoopEstimator {
+        fn task_estimation(
+            &self,
+            _plan: &Arc<dyn ExecutionPlan>,
+            _cfg: &ConfigOptions,
+        ) -> Option<TaskEstimation> {
+            None
+        }
+        fn scale_up_leaf_node(
+            &self,
+            _plan: &Arc<dyn ExecutionPlan>,
+            _task_count: usize,
+            _cfg: &ConfigOptions,
+        ) -> Option<Arc<dyn ExecutionPlan>> {
+            None
+        }
+    }
+
+    #[test]
+    fn test_preserves_isolator_when_estimator_specializes() -> Result<(), DataFusionError> {
+        // 6 partitions, 3 tasks → each task should see partitions [0,1], [2,3], [4,5].
+        let plan = build_isolated(6, 3);
+        assert_eq!(count_isolators(&plan), 1);
+
+        let estimator = RecordingEstimator::new();
+        let cfg = ConfigOptions::default();
+
+        for task_i in 0..3 {
+            let specialized = specialize_plan_for_task(&plan, task_i, 3, &estimator, &cfg)?;
+            assert_eq!(
+                count_isolators(&specialized),
+                1,
+                "task {task_i}: PartitionIsolatorExec wrapper should be preserved \
+                 so plan shape stays in sync with the coordinator's view"
+            );
+            // Output partition count from the isolator wrapper is the task's group size.
+            assert_eq!(
+                specialized.output_partitioning().partition_count(),
+                2,
+                "task {task_i}: isolator should expose the task's 2 partitions"
+            );
+        }
+
+        // Each task saw exactly its own partition group.
+        assert_eq!(
+            estimator.calls(),
+            vec![vec![0, 1], vec![2, 3], vec![4, 5]],
+            "specialize_leaf must receive disjoint, ordered partition groups"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_preserves_isolator_when_estimator_returns_none() -> Result<(), DataFusionError> {
+        // Without a specializer, the isolator must remain so the runtime fallback handles it.
+        let plan = build_isolated(6, 3);
+        assert_eq!(count_isolators(&plan), 1);
+
+        let estimator = NoopEstimator;
+        let cfg = ConfigOptions::default();
+
+        for task_i in 0..3 {
+            let specialized = specialize_plan_for_task(&plan, task_i, 3, &estimator, &cfg)?;
+            assert_eq!(count_isolators(&specialized), 1, "task {task_i}");
+            // PartitionIsolatorExec exposes partition_group.len() partitions to upper nodes.
+            assert_eq!(specialized.output_partitioning().partition_count(), 2);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_noop_for_single_task() -> Result<(), DataFusionError> {
+        // task_count <= 1: bypass entirely, return the input as-is.
+        let plan = build_isolated(6, 3);
+        let estimator = RecordingEstimator::new();
+        let cfg = ConfigOptions::default();
+        let specialized = specialize_plan_for_task(&plan, 0, 1, &estimator, &cfg)?;
+        assert_eq!(count_isolators(&specialized), 1);
+        assert!(estimator.calls().is_empty(), "estimator should not be invoked");
+        Ok(())
+    }
+}

--- a/src/distributed_planner/task_estimator.rs
+++ b/src/distributed_planner/task_estimator.rs
@@ -3,12 +3,13 @@ use crate::{DistributedConfig, PartitionIsolatorExec};
 use datafusion::catalog::memory::DataSourceExec;
 use datafusion::common::exec_err;
 use datafusion::config::ConfigOptions;
-use datafusion::datasource::physical_plan::FileScanConfig;
+use datafusion::datasource::physical_plan::{FileGroup, FileScanConfig};
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionConfig;
 use delegate::delegate;
+use std::collections::HashSet;
 use std::fmt::Debug;
 use std::sync::Arc;
 use url::Url;
@@ -126,6 +127,25 @@ pub trait TaskEstimator {
         cfg: &ConfigOptions,
     ) -> Option<Arc<dyn ExecutionPlan>>;
 
+    /// Specializes a leaf node for the given task by trimming the per-partition state
+    /// (e.g. file groups, ranges) for partitions outside `partition_group`. When this
+    /// returns `Some`, the leaf inside the surrounding [crate::PartitionIsolatorExec]
+    /// is replaced by the returned plan in the per-task payload sent to the worker, so
+    /// the per-task payload no longer carries data for partitions this task will not
+    /// execute. When this returns `None`, the original leaf is shipped as-is.
+    ///
+    /// Implementations MUST preserve the input partition count so the surrounding
+    /// [crate::PartitionIsolatorExec] dispatch math remains valid at runtime. The
+    /// returned plan should yield empty streams for partitions not in `partition_group`.
+    fn specialize_leaf(
+        &self,
+        _plan: &Arc<dyn ExecutionPlan>,
+        _partition_group: &[usize],
+        _cfg: &ConfigOptions,
+    ) -> Option<Arc<dyn ExecutionPlan>> {
+        None
+    }
+
     /// Optionally defines a custom protocol for routing tasks to specific worker URLs. Receives
     /// routing context including task count and a list of available URLs, and returns a vector
     /// of routed URLs, in order of task assignment.
@@ -180,6 +200,7 @@ impl TaskEstimator for Arc<dyn TaskEstimator> {
         to self.as_ref() {
             fn task_estimation(&self, plan: &Arc<dyn ExecutionPlan>, cfg: &ConfigOptions) -> Option<TaskEstimation>;
             fn scale_up_leaf_node(&self, plan: &Arc<dyn ExecutionPlan>, task_count: usize, cfg: &ConfigOptions) -> Option<Arc<dyn ExecutionPlan>>;
+            fn specialize_leaf(&self, plan: &Arc<dyn ExecutionPlan>, partition_group: &[usize], cfg: &ConfigOptions) -> Option<Arc<dyn ExecutionPlan>>;
             fn route_tasks(&self, routing_ctx: &TaskRoutingContext<'_>) -> Result<Option<Vec<Url>>>;
         }
     }
@@ -190,6 +211,7 @@ impl TaskEstimator for Arc<dyn TaskEstimator + Send + Sync> {
         to self.as_ref() {
             fn task_estimation(&self, plan: &Arc<dyn ExecutionPlan>, cfg: &ConfigOptions) -> Option<TaskEstimation>;
             fn scale_up_leaf_node(&self, plan: &Arc<dyn ExecutionPlan>, task_count: usize, cfg: &ConfigOptions) -> Option<Arc<dyn ExecutionPlan>>;
+            fn specialize_leaf(&self, plan: &Arc<dyn ExecutionPlan>, partition_group: &[usize], cfg: &ConfigOptions) -> Option<Arc<dyn ExecutionPlan>>;
             fn route_tasks(&self, routing_ctx: &TaskRoutingContext<'_>) -> Result<Option<Vec<Url>>>;
         }
     }
@@ -288,6 +310,37 @@ impl TaskEstimator for FileScanConfigTaskEstimator {
         let plan = DataSourceExec::from_data_source(new_file_scan);
         Some(Arc::new(PartitionIsolatorExec::new(plan, task_count)))
     }
+
+    fn specialize_leaf(
+        &self,
+        plan: &Arc<dyn ExecutionPlan>,
+        partition_group: &[usize],
+        _cfg: &ConfigOptions,
+    ) -> Option<Arc<dyn ExecutionPlan>> {
+        // Empty out the file groups for partitions this task will not execute, while
+        // preserving the overall file_groups vector length so the partition count is
+        // unchanged. This drops the unused file metadata from the per-task payload
+        // shipped over the wire, while keeping the plan structure (and the surrounding
+        // [PartitionIsolatorExec]) intact so the runtime skipping path still works.
+        let dse: &DataSourceExec = plan.as_any().downcast_ref()?;
+        let file_scan: &FileScanConfig = dse.data_source().as_any().downcast_ref()?;
+
+        let in_group: HashSet<usize> = partition_group.iter().copied().collect();
+        let mut new_file_scan = file_scan.clone();
+        new_file_scan.file_groups = file_scan
+            .file_groups
+            .iter()
+            .enumerate()
+            .map(|(i, g)| {
+                if in_group.contains(&i) {
+                    g.clone()
+                } else {
+                    FileGroup::new(vec![])
+                }
+            })
+            .collect();
+        Some(DataSourceExec::from_data_source(new_file_scan))
+    }
 }
 
 /// Tries multiple user-provided [TaskEstimator]s until one returns an estimation. If none
@@ -336,6 +389,25 @@ impl TaskEstimator for CombinedTaskEstimator {
         // If none of the user-provided returned an estimation, the default ones are used.
         for default_estimator in [&FileScanConfigTaskEstimator as &dyn TaskEstimator] {
             if let Some(result) = default_estimator.scale_up_leaf_node(plan, task_count, cfg) {
+                return Some(result);
+            }
+        }
+        None
+    }
+
+    fn specialize_leaf(
+        &self,
+        plan: &Arc<dyn ExecutionPlan>,
+        partition_group: &[usize],
+        cfg: &ConfigOptions,
+    ) -> Option<Arc<dyn ExecutionPlan>> {
+        for estimator in &self.user_provided {
+            if let Some(result) = estimator.specialize_leaf(plan, partition_group, cfg) {
+                return Some(result);
+            }
+        }
+        for default_estimator in [&FileScanConfigTaskEstimator as &dyn TaskEstimator] {
+            if let Some(result) = default_estimator.specialize_leaf(plan, partition_group, cfg) {
                 return Some(result);
             }
         }

--- a/src/execution_plans/distributed.rs
+++ b/src/execution_plans/distributed.rs
@@ -1,6 +1,8 @@
 use crate::common::{require_one_child, serialize_uuid, task_ctx_with_extension};
 use crate::config_extension_ext::get_config_extension_propagation_headers;
-use crate::distributed_planner::{NetworkBoundaryExt, get_distributed_task_estimator};
+use crate::distributed_planner::{
+    NetworkBoundaryExt, get_distributed_task_estimator, specialize_plan_for_task,
+};
 use crate::execution_plans::ChildrenIsolatorUnionExec;
 use crate::networking::get_distributed_worker_resolver;
 use crate::passthrough_headers::get_passthrough_headers;
@@ -31,6 +33,7 @@ use datafusion::physical_plan::metrics::{
 };
 use datafusion::physical_plan::stream::RecordBatchReceiverStreamBuilder;
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use crate::TaskEstimator;
 use datafusion_proto::physical_plan::{AsExecutionPlan, PhysicalExtensionCodec};
 use datafusion_proto::protobuf::PhysicalPlanNode;
 use futures::StreamExt;
@@ -197,8 +200,13 @@ impl DistributedExec {
 
             let stage = plan.input_stage();
 
-            let mut spawner =
-                CoordinatorToWorkerTaskSpawner::new(stage, &metrics, &codec, &mut join_set)?;
+            let mut spawner = CoordinatorToWorkerTaskSpawner::new(
+                stage,
+                &metrics,
+                &codec,
+                Arc::clone(&task_estimator),
+                &mut join_set,
+            )?;
 
             let routed_urls = match task_estimator.route_tasks(&TaskRoutingContext {
                 task_ctx: Arc::clone(ctx),
@@ -362,7 +370,8 @@ type WorkerResponseRx =
 
 struct CoordinatorToWorkerTaskSpawner<'a> {
     plan: &'a Arc<dyn ExecutionPlan>,
-    plan_proto: Vec<u8>,
+    codec: &'a dyn PhysicalExtensionCodec,
+    estimator: Arc<dyn TaskEstimator>,
     query_id: Uuid,
     stage_id: usize,
     task_count: usize,
@@ -377,18 +386,17 @@ impl<'a> CoordinatorToWorkerTaskSpawner<'a> {
         stage: &'a Stage,
         metrics: &'a CoordinatorToWorkerMetrics,
         codec: &'a dyn PhysicalExtensionCodec,
+        estimator: Arc<dyn TaskEstimator>,
         join_set: &'a mut JoinSet<Result<()>>,
     ) -> Result<Self> {
         let Some(plan) = &stage.plan else {
             return internal_err!("Plan is not set for stage {}", stage.num);
         };
 
-        let plan_proto =
-            PhysicalPlanNode::try_from_physical_plan(Arc::clone(plan), codec)?.encode_to_vec();
-
         Ok(Self {
             plan,
-            plan_proto,
+            codec,
+            estimator,
             query_id: stage.query_id,
             stage_id: stage.num,
             task_count: stage.tasks.len(),
@@ -457,21 +465,36 @@ impl<'a> CoordinatorToWorkerTaskSpawner<'a> {
             &mut work_unit_feed_declarations,
         );
 
+        // Specialize the stage plan for this specific task. This drops state (e.g. file
+        // groups) for partitions the task will not execute, so the per-task payload only
+        // carries what this worker actually needs. When no [TaskEstimator] handles a given
+        // [PartitionIsolatorExec], the isolator is preserved and the runtime skipping path
+        // is used as a safe fallback.
+        let specialized_plan = specialize_plan_for_task(
+            self.plan,
+            task_i,
+            self.task_count,
+            self.estimator.as_ref(),
+            ctx.session_config().options(),
+        )?;
+        let plan_proto =
+            PhysicalPlanNode::try_from_physical_plan(specialized_plan, self.codec)?.encode_to_vec();
+
         let task_key = TaskKey {
             query_id: serialize_uuid(&self.query_id),
             stage_id: self.stage_id as u64,
             task_number: task_i as u64,
         };
+        let plan_size = plan_proto.len();
         let msg = CoordinatorToWorkerMsg {
             inner: Some(Inner::SetPlanRequest(SetPlanRequest {
-                plan_proto: self.plan_proto.clone(),
+                plan_proto,
                 task_count: self.task_count as u64,
                 task_key: Some(task_key.clone()),
                 work_unit_feed_declarations,
                 target_worker_url: url.to_string(),
             })),
         };
-        let plan_size = self.plan_proto.len();
 
         let (coordinator_to_worker_tx, coordinator_to_worker_rx) =
             tokio::sync::mpsc::unbounded_channel();


### PR DESCRIPTION
## Summary

Specialize each task's plan at the sender side so per-task `SetPlanRequest` payloads no longer carry file groups for partitions the task will not execute. Previously, every task received the full leaf with all file groups and relied on `PartitionIsolatorExec` to skip the unassigned ones at runtime.

## Wins
1. Wire bytes per SetPlanRequest shrink ~linearly with task count.
For N files distributed across N tasks (default files_per_task=1), each worker receives roughly 1/N of the file-list bytes vs. the full list before. A PartitionedFile carries: path string, size, optional last-modified, partition values (each an Arrow ScalarValue), optional statistics, byte range, extensions. For S3-style URIs and plans with hundreds-to-thousands of files, that's the dominant chunk of the encoded plan proto.
Concretely: a stage with 1,000 files split across 100 tasks shipped ~1,000 × PartitionedFile worth of bytes per task before; now ~10 per task. Total bytes-on-the-wire across the whole stage drops from tasks × files to roughly files.

2. Worker-side decode work drops correspondingly.
`PhysicalPlanNode::try_decode` and the `FileScanConfig` round-trip allocate `Vec<PartitionedFile>` and inner ScalarValues for every file in the proto. Smaller proto → fewer allocations and less protobuf parsing work on every worker, on every stage.

3. Worker-side memory for plan structures drops.
The decoded `FileScanConfig` lives for the lifetime of the task. Trimming removes per-PartitionedFile heap state from the worker's working set. Per-task savings are small in absolute terms, but multiplied by concurrent tasks per worker it adds up.

4. Skipped-partition setup work disappears.
Today, for partitions not in this task's group, PartitionIsolatorExec::execute returns an empty stream — but only after FileScanConfig has built the partition's stream-creation infra. After this change, those partitions have empty FileGroups, so there's nothing to set up. Marginal CPU win per skipped partition.
## What changed

- **New `trim_files_for_task` walker** (`src/distributed_planner/specialize_plan.rs`). Given `(plan, task_index, task_count)`, walks the plan and for every `PartitionIsolatorExec` whose child is a `DataSourceExec`/`FileScanConfig`, replaces file groups outside the task's partition group with empty `FileGroup`s. Partition count is preserved so the surrounding `PartitionIsolatorExec`'s runtime dispatch math is unchanged. Leaves of other shapes are left untouched. The runtime skip path remains the safe fallback.
- **Sender path now encodes per-task** (`CoordinatorToWorkerTaskSpawner::send_plan_task` in `src/execution_plans/distributed.rs`). Replaced the eagerly-encoded `plan_proto: Vec<u8>` with per-task specialization + encoding, so each worker receives a payload trimmed to only the files it will read.

## Design notes

The `PartitionIsolatorExec` wrapper is **kept** in the per-task plan rather than elided. Eliding it would have:

1. broken plan-shape parity with the coordinator's `stage.plan` (the metrics rewriter asserts node-count equality across both sides);
2. required teaching the isolator's runtime dispatch (which uses `task_context.task_count`, not `self.n_tasks`) to handle a pre-trimmed leaf.

Keeping the wrapper around an internally-trimmed leaf gets the network-payload win; drop unused file groups from the wire while leaving the runtime skipping path as a safe, structurally-identical fallback.

The walker is intentionally closed over `DataSourceExec`/`FileScanConfig` rather than introduced as a new `TaskEstimator` trait method. In practice user pipelines bottom out in `DataSourceExec` (the standard `scale_up_leaf_node` pattern emits exactly that shape), so this covers the realistic user population without introducing speculative trait surface. Additional leaf shapes can be added as concrete needs surface — purely additive, no public API impact.

## Test plan

- [x] New unit tests for `trim_files_for_task`: preserves wrapper, no-ops when no isolator is present, no-ops for `task_count <= 1`, file groups outside the task's group are emptied while partition count is preserved.
