### PR TITLE
Un-ignore test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ system-metrics = ["sysinfo"]
 tpch = ["integration"]
 tpcds = ["integration"]
 clickbench = ["integration"]
+slow-tests = []
 sysinfo = ["dep:sysinfo"]
 
 [dev-dependencies]

--- a/docs/source/contributor-guide/readme.md
+++ b/docs/source/contributor-guide/readme.md
@@ -1,0 +1,7 @@
+# Index
+
+Welcome to the DataFusion Distributed contributor guide!
+
+- [Setup](setup.md) - Getting started with development
+- [Tests](tests.md) - Running unit and integration tests
+- [Benchmarks](benchmarks.md) - Local and remote performance benchmarks

--- a/docs/source/contributor-guide/readme.md
+++ b/docs/source/contributor-guide/readme.md
@@ -1,7 +1,0 @@
-# Index
-
-Welcome to the DataFusion Distributed contributor guide!
-
-- [Setup](setup.md) - Getting started with development
-- [Tests](tests.md) - Running unit and integration tests
-- [Benchmarks](benchmarks.md) - Local and remote performance benchmarks

--- a/src/test_utils/property_based.rs
+++ b/src/test_utils/property_based.rs
@@ -11,10 +11,24 @@ use datafusion::{
 };
 use std::sync::Arc;
 
+/// Per-test configuration knobs for the property-based comparison helpers.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PerTestConfig {
+    /// If true, skip the set-equality comparison in [`compare_result_set`]. Use for queries
+    /// whose final operator is a non-deterministic LIMIT (no ORDER BY at all), where two
+    /// engines may correctly return different valid 10-row slices.
+    pub uses_undeterministic_limit_operator: bool,
+    /// If true, skip the set-equality comparison in [`compare_result_set`]. Use for queries
+    /// whose ORDER BY does not produce a total ordering (e.g. `ORDER BY c DESC` with ties
+    /// at the LIMIT boundary), where two engines may correctly pick different tied rows.
+    pub non_deterministic_sort: bool,
+}
+
 /// compares the set of record batches for equality
 pub fn compare_result_set(
     actual_result: &Result<Vec<RecordBatch>>,
     expected_result: &Result<Vec<RecordBatch>>,
+    config: &PerTestConfig,
 ) -> Result<()> {
     let test_batches = match actual_result.as_ref() {
         Ok(batches) => batches,
@@ -36,7 +50,7 @@ pub fn compare_result_set(
         }
     };
 
-    records_equal_as_sets(test_batches, compare_batches)
+    records_equal_as_sets(test_batches, compare_batches, config)
         .map_err(|e| internal_datafusion_err!("result sets were not equal: {}", e))
 }
 
@@ -55,7 +69,6 @@ pub fn compare_ordering(
 
     let actual_ordering = actual_physical_plan.properties().output_ordering();
     let expected_ordering = expected_physical_plan.properties().output_ordering();
-
     if actual_ordering != expected_ordering {
         return internal_err!(
             "ordering mismatch: expected ordering: {:?}, actual ordering: {:?}",
@@ -93,6 +106,7 @@ pub fn compare_ordering(
 fn records_equal_as_sets(
     left: &[RecordBatch],
     right: &[RecordBatch],
+    config: &PerTestConfig,
 ) -> Result<(), DataFusionError> {
     // First check if total row counts match
     let left_rows: usize = left.iter().map(|b| b.num_rows()).sum();
@@ -113,6 +127,13 @@ fn records_equal_as_sets(
             left[0].schema(),
             right[0].schema()
         );
+    }
+    // Skip the row-by-row set comparison for queries where SQL semantics allow two engines
+    // to correctly return different result sets (e.g. LIMIT without ORDER BY, or ORDER BY
+    // with unbroken ties at the LIMIT boundary). Running the full comparison on these
+    // queries would surface false positives even though both engines are right.
+    if config.uses_undeterministic_limit_operator || config.non_deterministic_sort {
+        return Ok(());
     }
 
     detailed_batch_comparison(left, right)
@@ -197,11 +218,17 @@ fn batch_rows_to_strings(batches: &[RecordBatch]) -> Vec<String> {
                 if array.is_null(row_idx) {
                     row_values.push("NULL".to_string());
                 } else if let Some(arr) = array.as_any().downcast_ref::<Float16Array>() {
-                    row_values.push(format!("{:.1$}", arr.value(row_idx), 2));
+                    // 14 significant digits — leaves ~1-2 digits of headroom below f64 precision
+                    // to tolerate summation-order drift between single-node and distributed
+                    // aggregation. [15 digits still diverged at the last digit]
+                    // Example values that 15 digits could not reconcile:
+                    //  - Single-node: 2.533767602294735e18  → 2,533,767,602,294,735,000
+                    //  - Distributed: 2.5337676022947354e18 → 2,533,767,602,294,735,400
+                    row_values.push(format!("{:.13e}", arr.value(row_idx).to_f64()));
                 } else if let Some(arr) = array.as_any().downcast_ref::<Float32Array>() {
-                    row_values.push(format!("{:.1$}", arr.value(row_idx), 2));
+                    row_values.push(format!("{:.13e}", arr.value(row_idx) as f64));
                 } else if let Some(arr) = array.as_any().downcast_ref::<Float64Array>() {
-                    row_values.push(format!("{:.1$}", arr.value(row_idx), 2));
+                    row_values.push(format!("{:.13e}", arr.value(row_idx)));
                 } else {
                     // Use Arrow's deterministic string representation
                     let value_str = array_value_to_string(array, row_idx)
@@ -290,7 +317,7 @@ mod tests {
     async fn test_records_equal_as_sets_empty() {
         let left: Vec<RecordBatch> = vec![];
         let right: Vec<RecordBatch> = vec![];
-        assert!(records_equal_as_sets(&left, &right).is_ok());
+        assert!(records_equal_as_sets(&left, &right, &PerTestConfig::default()).is_ok());
     }
 
     #[tokio::test]
@@ -323,7 +350,7 @@ mod tests {
         let right = vec![batch2];
 
         // Should be equal as sets (order independent)
-        assert!(records_equal_as_sets(&left, &right).is_ok());
+        assert!(records_equal_as_sets(&left, &right, &PerTestConfig::default()).is_ok());
     }
 
     #[tokio::test]
@@ -345,7 +372,7 @@ mod tests {
         let left = vec![batch1];
         let right = vec![batch2];
 
-        assert!(records_equal_as_sets(&left, &right).is_err());
+        assert!(records_equal_as_sets(&left, &right, &PerTestConfig::default()).is_err());
     }
 
     #[tokio::test]

--- a/src/test_utils/property_based.rs
+++ b/src/test_utils/property_based.rs
@@ -11,24 +11,10 @@ use datafusion::{
 };
 use std::sync::Arc;
 
-/// Per-test configuration knobs for the property-based comparison helpers.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct PerTestConfig {
-    /// If true, skip the set-equality comparison in [`compare_result_set`]. Use for queries
-    /// whose final operator is a non-deterministic LIMIT (no ORDER BY at all), where two
-    /// engines may correctly return different valid 10-row slices.
-    pub uses_undeterministic_limit_operator: bool,
-    /// If true, skip the set-equality comparison in [`compare_result_set`]. Use for queries
-    /// whose ORDER BY does not produce a total ordering (e.g. `ORDER BY c DESC` with ties
-    /// at the LIMIT boundary), where two engines may correctly pick different tied rows.
-    pub non_deterministic_sort: bool,
-}
-
 /// compares the set of record batches for equality
 pub fn compare_result_set(
     actual_result: &Result<Vec<RecordBatch>>,
     expected_result: &Result<Vec<RecordBatch>>,
-    config: &PerTestConfig,
 ) -> Result<()> {
     let test_batches = match actual_result.as_ref() {
         Ok(batches) => batches,
@@ -50,7 +36,7 @@ pub fn compare_result_set(
         }
     };
 
-    records_equal_as_sets(test_batches, compare_batches, config)
+    records_equal_as_sets(test_batches, compare_batches)
         .map_err(|e| internal_datafusion_err!("result sets were not equal: {}", e))
 }
 
@@ -106,7 +92,6 @@ pub fn compare_ordering(
 fn records_equal_as_sets(
     left: &[RecordBatch],
     right: &[RecordBatch],
-    config: &PerTestConfig,
 ) -> Result<(), DataFusionError> {
     // First check if total row counts match
     let left_rows: usize = left.iter().map(|b| b.num_rows()).sum();
@@ -127,13 +112,6 @@ fn records_equal_as_sets(
             left[0].schema(),
             right[0].schema()
         );
-    }
-    // Skip the row-by-row set comparison for queries where SQL semantics allow two engines
-    // to correctly return different result sets (e.g. LIMIT without ORDER BY, or ORDER BY
-    // with unbroken ties at the LIMIT boundary). Running the full comparison on these
-    // queries would surface false positives even though both engines are right.
-    if config.uses_undeterministic_limit_operator || config.non_deterministic_sort {
-        return Ok(());
     }
 
     detailed_batch_comparison(left, right)
@@ -317,7 +295,7 @@ mod tests {
     async fn test_records_equal_as_sets_empty() {
         let left: Vec<RecordBatch> = vec![];
         let right: Vec<RecordBatch> = vec![];
-        assert!(records_equal_as_sets(&left, &right, &PerTestConfig::default()).is_ok());
+        assert!(records_equal_as_sets(&left, &right).is_ok());
     }
 
     #[tokio::test]
@@ -350,7 +328,7 @@ mod tests {
         let right = vec![batch2];
 
         // Should be equal as sets (order independent)
-        assert!(records_equal_as_sets(&left, &right, &PerTestConfig::default()).is_ok());
+        assert!(records_equal_as_sets(&left, &right).is_ok());
     }
 
     #[tokio::test]
@@ -372,7 +350,7 @@ mod tests {
         let left = vec![batch1];
         let right = vec![batch2];
 
-        assert!(records_equal_as_sets(&left, &right, &PerTestConfig::default()).is_err());
+        assert!(records_equal_as_sets(&left, &right).is_err());
     }
 
     #[tokio::test]

--- a/tests/clickbench_correctness_test.rs
+++ b/tests/clickbench_correctness_test.rs
@@ -24,7 +24,8 @@ mod tests {
     const FILE_RANGE: Range<usize> = 0..3;
 
     #[tokio::test]
-    #[ignore = "Query q0 (SELECT COUNT(*) FROM hits) still does not get distributed. The planner correctly chooses a single-task plan because of parquet statistics."]
+    #[ignore = "Query 0 did not get distributed.The planner correctly chooses a single-task plan because of parquet statistics."]
+
     async fn test_clickbench_0() -> Result<()> {
         test_clickbench_query("q0", PerTestConfig::default()).await
     }
@@ -55,7 +56,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "Query q6 (SELECT MIN/MAX FROM hits) still does not get distributed. The planner correctly chooses a single-task plan because of parquet statistics."]
+    #[ignore = "Query 6 did not get distributed.The planner correctly chooses a single-task plan because of parquet statistics."]
     async fn test_clickbench_6() -> Result<()> {
         test_clickbench_query("q6", PerTestConfig::default()).await
     }

--- a/tests/clickbench_correctness_test.rs
+++ b/tests/clickbench_correctness_test.rs
@@ -7,7 +7,7 @@ mod tests {
     use datafusion::prelude::SessionContext;
     use datafusion_distributed::test_utils::in_memory_channel_resolver::start_in_memory_context;
     use datafusion_distributed::test_utils::property_based::{
-        PerTestConfig, compare_ordering, compare_result_set,
+        compare_ordering, compare_result_set,
     };
     use datafusion_distributed::{
         DefaultSessionBuilder, DistributedExec, DistributedExt, display_plan_ascii,
@@ -27,261 +27,225 @@ mod tests {
     #[ignore = "Query 0 did not get distributed.The planner correctly chooses a single-task plan because of parquet statistics."]
 
     async fn test_clickbench_0() -> Result<()> {
-        test_clickbench_query("q0", PerTestConfig::default()).await
+        test_clickbench_query("q0").await
     }
 
     #[tokio::test]
     async fn test_clickbench_1() -> Result<()> {
-        test_clickbench_query("q1", PerTestConfig::default()).await
+        test_clickbench_query("q1").await
     }
 
     #[tokio::test]
     async fn test_clickbench_2() -> Result<()> {
-        test_clickbench_query("q2", PerTestConfig::default()).await
+        test_clickbench_query("q2").await
     }
 
     #[tokio::test]
     async fn test_clickbench_3() -> Result<()> {
-        test_clickbench_query("q3", PerTestConfig::default()).await
+        test_clickbench_query("q3").await
     }
 
     #[tokio::test]
     async fn test_clickbench_4() -> Result<()> {
-        test_clickbench_query("q4", PerTestConfig::default()).await
+        test_clickbench_query("q4").await
     }
 
     #[tokio::test]
     async fn test_clickbench_5() -> Result<()> {
-        test_clickbench_query("q5", PerTestConfig::default()).await
+        test_clickbench_query("q5").await
     }
 
     #[tokio::test]
     #[ignore = "Query 6 did not get distributed.The planner correctly chooses a single-task plan because of parquet statistics."]
     async fn test_clickbench_6() -> Result<()> {
-        test_clickbench_query("q6", PerTestConfig::default()).await
+        test_clickbench_query("q6").await
     }
 
     #[tokio::test]
     async fn test_clickbench_7() -> Result<()> {
-        test_clickbench_query("q7", PerTestConfig::default()).await
+        test_clickbench_query("q7").await
     }
 
     #[tokio::test]
     async fn test_clickbench_8() -> Result<()> {
-        test_clickbench_query("q8", PerTestConfig::default()).await
+        test_clickbench_query("q8").await
     }
 
     #[tokio::test]
     async fn test_clickbench_9() -> Result<()> {
-        test_clickbench_query("q9", PerTestConfig::default()).await
+        test_clickbench_query("q9").await
     }
 
     #[tokio::test]
     async fn test_clickbench_10() -> Result<()> {
-        test_clickbench_query("q10", PerTestConfig::default()).await
+        test_clickbench_query("q10").await
     }
 
     #[tokio::test]
     async fn test_clickbench_11() -> Result<()> {
-        test_clickbench_query("q11", PerTestConfig::default()).await
+        test_clickbench_query("q11").await
     }
 
     #[tokio::test]
     async fn test_clickbench_12() -> Result<()> {
-        test_clickbench_query("q12", PerTestConfig::default()).await
+        test_clickbench_query("q12").await
     }
 
     #[tokio::test]
     async fn test_clickbench_13() -> Result<()> {
-        test_clickbench_query("q13", PerTestConfig::default()).await
+        test_clickbench_query("q13").await
     }
 
     #[tokio::test]
     async fn test_clickbench_14() -> Result<()> {
-        test_clickbench_query("q14", PerTestConfig::default()).await
+        test_clickbench_query("q14").await
     }
 
     #[tokio::test]
     async fn test_clickbench_15() -> Result<()> {
-        test_clickbench_query("q15", PerTestConfig::default()).await
+        test_clickbench_query("q15").await
     }
 
     #[tokio::test]
     async fn test_clickbench_16() -> Result<()> {
-        test_clickbench_query("q16", PerTestConfig::default()).await
+        test_clickbench_query("q16").await
     }
 
     #[tokio::test]
+    #[ignore = "query produces non-deterministic results, cannot compare directly"]
     async fn test_clickbench_17() -> Result<()> {
-        test_clickbench_query(
-            "q17",
-            PerTestConfig {
-                uses_undeterministic_limit_operator: true,
-                ..Default::default()
-            },
-        )
-        .await
+        test_clickbench_query("q17").await
     }
 
     #[tokio::test]
     async fn test_clickbench_18() -> Result<()> {
-        test_clickbench_query("q18", PerTestConfig::default()).await
+        test_clickbench_query("q18").await
     }
 
     #[tokio::test]
     async fn test_clickbench_19() -> Result<()> {
-        test_clickbench_query("q19", PerTestConfig::default()).await
+        test_clickbench_query("q19").await
     }
 
     #[tokio::test]
     async fn test_clickbench_20() -> Result<()> {
-        test_clickbench_query("q20", PerTestConfig::default()).await
+        test_clickbench_query("q20").await
     }
 
     #[tokio::test]
+    #[ignore = "query produces non-deterministic results, cannot compare directly"]
     async fn test_clickbench_21() -> Result<()> {
-        test_clickbench_query(
-            "q21",
-            PerTestConfig {
-                non_deterministic_sort: true,
-                ..Default::default()
-            },
-        )
-        .await
+        test_clickbench_query("q21").await
     }
 
     #[tokio::test]
+    #[ignore = "query produces non-deterministic results, cannot compare directly"]
     async fn test_clickbench_22() -> Result<()> {
-        test_clickbench_query(
-            "q22",
-            PerTestConfig {
-                uses_undeterministic_limit_operator: true,
-                ..Default::default()
-            },
-        )
-        .await
+        test_clickbench_query("q22").await
     }
 
     #[tokio::test]
     async fn test_clickbench_23() -> Result<()> {
-        test_clickbench_query("q23", PerTestConfig::default()).await
+        test_clickbench_query("q23").await
     }
 
     #[tokio::test]
+    #[ignore = "query produces non-deterministic results, cannot compare directly"]
     async fn test_clickbench_24() -> Result<()> {
-        test_clickbench_query(
-            "q24",
-            PerTestConfig {
-                non_deterministic_sort: true,
-                ..Default::default()
-            },
-        )
-        .await
+        test_clickbench_query("q24").await
     }
 
     #[tokio::test]
     async fn test_clickbench_25() -> Result<()> {
-        test_clickbench_query("q25", PerTestConfig::default()).await
+        test_clickbench_query("q25").await
     }
 
     #[tokio::test]
     async fn test_clickbench_26() -> Result<()> {
-        test_clickbench_query("q26", PerTestConfig::default()).await
+        test_clickbench_query("q26").await
     }
 
     #[tokio::test]
     async fn test_clickbench_27() -> Result<()> {
-        test_clickbench_query("q27", PerTestConfig::default()).await
+        test_clickbench_query("q27").await
     }
 
     #[tokio::test]
     async fn test_clickbench_28() -> Result<()> {
-        test_clickbench_query("q28", PerTestConfig::default()).await
+        test_clickbench_query("q28").await
     }
 
     #[tokio::test]
     async fn test_clickbench_29() -> Result<()> {
-        test_clickbench_query("q29", PerTestConfig::default()).await
+        test_clickbench_query("q29").await
     }
 
     #[tokio::test]
     async fn test_clickbench_30() -> Result<()> {
-        test_clickbench_query("q30", PerTestConfig::default()).await
+        test_clickbench_query("q30").await
     }
 
     #[tokio::test]
+    #[ignore = "query produces non-deterministic results, cannot compare directly"]
     async fn test_clickbench_31() -> Result<()> {
-        test_clickbench_query(
-            "q31",
-            PerTestConfig {
-                non_deterministic_sort: true,
-                ..Default::default()
-            },
-        )
-        .await
+        test_clickbench_query("q31").await
     }
 
     #[tokio::test]
+    #[ignore = "query produces non-deterministic results, cannot compare directly"]
     async fn test_clickbench_32() -> Result<()> {
-        test_clickbench_query(
-            "q32",
-            PerTestConfig {
-                non_deterministic_sort: true,
-                ..Default::default()
-            },
-        )
-        .await
+        test_clickbench_query("q32").await
     }
 
     #[tokio::test]
     async fn test_clickbench_33() -> Result<()> {
-        test_clickbench_query("q33", PerTestConfig::default()).await
+        test_clickbench_query("q33").await
     }
 
     #[tokio::test]
     async fn test_clickbench_34() -> Result<()> {
-        test_clickbench_query("q34", PerTestConfig::default()).await
+        test_clickbench_query("q34").await
     }
 
     #[tokio::test]
     async fn test_clickbench_35() -> Result<()> {
-        test_clickbench_query("q35", PerTestConfig::default()).await
+        test_clickbench_query("q35").await
     }
 
     #[tokio::test]
     async fn test_clickbench_36() -> Result<()> {
-        test_clickbench_query("q36", PerTestConfig::default()).await
+        test_clickbench_query("q36").await
     }
 
     #[tokio::test]
     async fn test_clickbench_37() -> Result<()> {
-        test_clickbench_query("q37", PerTestConfig::default()).await
+        test_clickbench_query("q37").await
     }
 
     #[tokio::test]
     async fn test_clickbench_38() -> Result<()> {
-        test_clickbench_query("q38", PerTestConfig::default()).await
+        test_clickbench_query("q38").await
     }
 
     #[tokio::test]
     async fn test_clickbench_39() -> Result<()> {
-        test_clickbench_query("q39", PerTestConfig::default()).await
+        test_clickbench_query("q39").await
     }
 
     #[tokio::test]
     async fn test_clickbench_40() -> Result<()> {
-        test_clickbench_query("q40", PerTestConfig::default()).await
+        test_clickbench_query("q40").await
     }
 
     #[tokio::test]
     async fn test_clickbench_41() -> Result<()> {
-        test_clickbench_query("q41", PerTestConfig::default()).await
+        test_clickbench_query("q41").await
     }
 
     #[tokio::test]
-    #[ignore = "Ordering mismatch on `date_trunc('minute', ...)`: `compare_ordering` reports `LexOrdering` inequality even though Debug output is byte-identical on both sides. The diff is in a non-printed field of LexOrdering (e.g. schema metadata or equivalence-class set membership)."]
+    #[ignore = "Ordering mismatch on `date_trunc('minute', ...)`: `compare_ordering` reports `LexOrdering` inequality even thought printed results match"]
     async fn test_clickbench_42() -> Result<()> {
-        test_clickbench_query("q42", PerTestConfig::default()).await
+        test_clickbench_query("q42").await
     }
 
     static INIT_TEST_TPCDS_TABLES: OnceCell<()> = OnceCell::const_new();
@@ -296,7 +260,7 @@ mod tests {
         (plan.clone(), Arc::new(collect(plan, task_ctx).await)) // Collect execution errors, do not unwrap.
     }
 
-    async fn test_clickbench_query(query_id: &str, config: PerTestConfig) -> Result<()> {
+    async fn test_clickbench_query(query_id: &str) -> Result<()> {
         let data_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join(format!(
             "testdata/clickbench/correctness_range{}-{}",
             FILE_RANGE.start, FILE_RANGE.end
@@ -335,7 +299,7 @@ mod tests {
             let d_results = d_results.clone();
             let s_results = s_results.clone();
             tokio::task::spawn_blocking(move || async move {
-                compare_result_set(&d_results, &s_results, &config)
+                compare_result_set(&d_results, &s_results)
             })
         };
         let compare_ordering = {

--- a/tests/clickbench_correctness_test.rs
+++ b/tests/clickbench_correctness_test.rs
@@ -7,7 +7,7 @@ mod tests {
     use datafusion::prelude::SessionContext;
     use datafusion_distributed::test_utils::in_memory_channel_resolver::start_in_memory_context;
     use datafusion_distributed::test_utils::property_based::{
-        compare_ordering, compare_result_set,
+        PerTestConfig, compare_ordering, compare_result_set,
     };
     use datafusion_distributed::{
         DefaultSessionBuilder, DistributedExec, DistributedExt, display_plan_ascii,
@@ -24,228 +24,263 @@ mod tests {
     const FILE_RANGE: Range<usize> = 0..3;
 
     #[tokio::test]
-    #[ignore = "Query 0 did not get distributed"]
+    #[ignore = "Query q0 (SELECT COUNT(*) FROM hits) still does not get distributed. The planner correctly chooses a single-task plan because of parquet statistics."]
     async fn test_clickbench_0() -> Result<()> {
-        test_clickbench_query("q0").await
+        test_clickbench_query("q0", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_1() -> Result<()> {
-        test_clickbench_query("q1").await
+        test_clickbench_query("q1", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_2() -> Result<()> {
-        test_clickbench_query("q2").await
+        test_clickbench_query("q2", PerTestConfig::default()).await
     }
 
     #[tokio::test]
-    #[ignore = "result sets were not equal: Internal error: Row content differs between result sets\nLeft set size: 1, Right set size: 1\n\nRows only in left (1 total):\n  2533767602294735360.00\n\nRows only in right (1 total):\n  2533767602294735872.00.\nThis issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues"]
     async fn test_clickbench_3() -> Result<()> {
-        test_clickbench_query("q3").await
+        test_clickbench_query("q3", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_4() -> Result<()> {
-        test_clickbench_query("q4").await
+        test_clickbench_query("q4", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_5() -> Result<()> {
-        test_clickbench_query("q5").await
+        test_clickbench_query("q5", PerTestConfig::default()).await
     }
 
     #[tokio::test]
-    #[ignore = "Query 6 did not get distributed"]
+    #[ignore = "Query q6 (SELECT MIN/MAX FROM hits) still does not get distributed. The planner correctly chooses a single-task plan because of parquet statistics."]
     async fn test_clickbench_6() -> Result<()> {
-        test_clickbench_query("q6").await
+        test_clickbench_query("q6", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_7() -> Result<()> {
-        test_clickbench_query("q7").await
+        test_clickbench_query("q7", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_8() -> Result<()> {
-        test_clickbench_query("q8").await
+        test_clickbench_query("q8", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_9() -> Result<()> {
-        test_clickbench_query("q9").await
+        test_clickbench_query("q9", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_10() -> Result<()> {
-        test_clickbench_query("q10").await
+        test_clickbench_query("q10", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_11() -> Result<()> {
-        test_clickbench_query("q11").await
+        test_clickbench_query("q11", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_12() -> Result<()> {
-        test_clickbench_query("q12").await
+        test_clickbench_query("q12", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_13() -> Result<()> {
-        test_clickbench_query("q13").await
+        test_clickbench_query("q13", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_14() -> Result<()> {
-        test_clickbench_query("q14").await
+        test_clickbench_query("q14", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_15() -> Result<()> {
-        test_clickbench_query("q15").await
+        test_clickbench_query("q15", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_16() -> Result<()> {
-        test_clickbench_query("q16").await
+        test_clickbench_query("q16", PerTestConfig::default()).await
     }
 
     #[tokio::test]
-    #[ignore = "result sets were not equal: Internal error: Row content differs between result sets\nLeft set size: 10, Right set size: 10\n\nRows only in left (10 total):\n  3219866204653196665||4\n  3220056705148678697||11\n  3221898002592879542||1\n  3223026783585713477||23\n  3223839745005575457||116\n  3223839745005575457|d0bcd0bed0b6d0bdd0be20d0bbd0b820d0b220d0bad180d0bed0bad0bed0b4d0b8d180d0bed0b2d0b5d0bbd18cd18820d0b1d180d0bed0b4d18b20d0bdd0b020d181d182d0bed0bbd18b20d0b2d0be20d0b2d0bbd0b0d0b4d0b8d0b2d0bed181d182d0bed0ba20d0b2d0b2d0be|1\n  3223949769615485893||1\n  3226415756450197918||24\n  3226664959488084815||62\n  3227160743723019373||71\n\nRows only in right (10 total):\n  700182585509527889||2\n  724127359630680276|d0b8d0b3d180d18b20d0b820d181d0b5d0b3d0bed0b4d0bdd18f3f|1\n  766120398574852544||1\n  766739966065297239||1\n  783205612738304865||3\n  797289180007803204||2\n  804968013253615745||1\n  830548852254311605||1\n  849024737642146119||1\n  849169469997862534||1.\nThis issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues"]
     async fn test_clickbench_17() -> Result<()> {
-        test_clickbench_query("q17").await
+        test_clickbench_query(
+            "q17",
+            PerTestConfig {
+                uses_undeterministic_limit_operator: true,
+                ..Default::default()
+            },
+        )
+        .await
     }
 
     #[tokio::test]
     async fn test_clickbench_18() -> Result<()> {
-        test_clickbench_query("q18").await
+        test_clickbench_query("q18", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_19() -> Result<()> {
-        test_clickbench_query("q19").await
+        test_clickbench_query("q19", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_20() -> Result<()> {
-        test_clickbench_query("q20").await
+        test_clickbench_query("q20", PerTestConfig::default()).await
     }
 
     #[tokio::test]
-    #[ignore = "result sets were not equal: Internal error: Row content differs between result sets\nLeft set size: 10, Right set size: 10\n\nRows only in left (5 total):\n  d181d0bbd0b0d0b2d0bbd18fd182d18c20d0bfd0bed180d0bed0b4d0b8d182d181d18f20d0bed182d0b5d0bbd0b8203230313320d181d0bcd0bed182d180d0b5d182d18c|687474703a253246253246766b2e636f6d2e75612f676f6f676c652d6a61726b6f76736b6179612d4c697065636b64|1\n  d0b1d0b0d0bdd0bad0bed0bcd0b0d182d0b5d180d0b8d0b0d0bbd18b20d181d0bcd0bed182d180d0b5d182d18c|687474703a2f2f6f72656e627572672e6972722e72752532466b7572746b692532462532467777772e676f6f676c652e72752f6d617a64612d332d6b6f6d6e2d6b762d4b617a616e2e74757475746f72736b2f64657461696c|1\n  d0bcd0bed0bdd0b8d182d18c20d0bad0b0d0bad0bed0b520d0bed0b7d0b5d180d0b0|687474703a2f2f6175746f2e7269612e75612f6175746f5f69643d30266f726465723d46616c7365266d696e707269782e72752f6b617465676f726979612f767369652d646c69612d647275676f652f6d61746572696e7374766f2f676f6f676c652d706f6c697331343334343532|1\n  d181d0bad0b0d187d0b0d182d18c20d0b4d0b5d0bdd0b5d0b320d181d183d180d0b3d183d182|687474703a2f2f7469656e736b6169612d6d6f64612d627269657469656c6b612d6b6f736b6f76736b2f64657461696c2e676f6f676c65|1\n  d0b220d0b0d0b2d0b3d183d181d1822032343720d0b3d180d183d181d182d0b8d0bcd0bed188d0bad0b020d0bdd0b020d0bad180d0b8d181d182d180d0b0d182|687474703a2f2f7469656e736b6169612d6d6f64612d627269756b692f676f6f676c652e72752f7e61706f6b2e72752f635f312d755f313138383839352c39373536|1\n\nRows only in right (5 total):\n  d0bcd0bed0b4d0b5d0bad18120d183d0bbd0b8d186d0b5d0bdd0b7d0b8d0bdd0bed0b2d0b020d0b3d0bed0b2d18fd0b4d0b8d0bdd0b0|687474703a2f2f73616d6172612e6972722e72752f636174616c6f675f676f6f676c652d636865726e796a2d393233353636363635372f3f64617465|1\n  d0bbd0b0d0b2d0bfd0bbd0b0d0bdd188d0b5d182d0bdd0b8d18520d183d181d0bbd0bed0b2d0b0d0bcd0b820d0b2d181d0b520d181d0b5d180d0b8d0b820d0b4d0b0d182d0b020d186d0b5d0bcd0b5d0bdd0b8|687474703a2f2f73616d6172612e6972722e72752f636174616c6f675f676f6f676c654d425225323661642533443930253236707a|1\n  d0bad0b0d0ba20d0bfd180d0bed0b4d0b0d0bcd0b820d0b4d0bbd18f20d0b4d0b5d0b2d183d188d0bad0b8|687474703a253246253246777777772e626f6e707269782e7275253235326625323532663737363925323532663131303931392d6c65766f652d676f6f676c652d7368746f72792e72752f666f72756d2f666f72756d2e6d617465722e72752f6461696c792f63616c63756c61746f72|1\n  d0b6d0b0d180d0b5d0bdd18cd18f20d0b32ed181d183d180d0bed0b2d0b0d0bdd0b8d0b520d0b2d0bed180d0bed0bdd0b5d0b6d181d0bad0b0d18f20d0bed0b1d0bbd0b0d181d182d0bed0bfd180d0b8d0bbd0b520d0bfd0bed181d0bbd0b5d0b4d0bdd0b8d0b520d0bad0bed181d18b|687474703a2f2f756b7261696e627572672f65636f2d6d6c656b2f65636f6e646172792f73686f77746f7069632e7068703f69643d3436333837362e68746d6c3f69643d32303634313333363631253246676f6f676c652d4170706c655765624b69742532463533372e333620284b48544d4c2c206c696b65|1\n  d180d0b8d0be20d0bdd0b020d0bad0b0d180d182d0bed187d0bdd0b8d186d0b020d181d0bcd0bed182d180d0b5d182d18c20d0bed0bdd0bbd0b0d0b9d0bd|687474703a2f2f73616d6172612e6972722e72752f636174616c6f675f676f6f676c654d425225323661642533443930253236707a|1.\nThis issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues"]
     async fn test_clickbench_21() -> Result<()> {
-        test_clickbench_query("q21").await
+        test_clickbench_query(
+            "q21",
+            PerTestConfig {
+                non_deterministic_sort: true,
+                ..Default::default()
+            },
+        )
+        .await
     }
 
     #[tokio::test]
-    #[ignore = "result sets were not equal: Internal error: Row content differs between result sets\nLeft set size: 10, Right set size: 10\n\nRows only in left (1 total):\n  d0bad0b0d0bad0bed0b920d0bfd0bbd0bed189d0b0d0b4d0bad0b8d0bcd0b820d0b4d0bed181d182d0b0d0b2d0bad0b8|687474703a253246253246766b2e636f6d2f696672616d652d6f77612e68746d6c3f313d31266369643d353737266f6b693d31266f705f63617465676f72795f69645d3d332673656c656374|d092d0b0d0bad0b0d0bdd181d0b8d18f20d091d0a0d090d09ad090d09d20d090d09dd094d0a0d095d0a1202d20d0bfd0bed0bfd0b0d0bbd0b820d0bad183d0bfd0b8d182d18c20d0b4d0bed0bcd0bed0b5d187d0bdd18bd0b520d188d0bad0b0d184d0b020476f6f676c652e636f6d203a3a20d0bad0bed182d182d0b5d0bad181d1822c20d091d183d180d18fd182d0bdd0b8d0bad0b820d0b4d0bbd18f20d0bfd0b5d187d18c20d0bcd0b5d0b1d0b5d0bbd18cd0b520d0b4d0bbd18f20d0b4d0b5d0b2d183d188d0bad0b0|5|1\n\nRows only in right (1 total):\n  d0bad0bed0bfd182d0b8d0bcd0b8d0bad0b2d0b8d0b4d18b20d18ed180d0b8d0b920d0bfd0bed181d0bbd0b5d0b4d0bdd18fd18f|68747470733a2f2f70726f64756b747925324670756c6f76652e72752f626f6f6b6c79617474696f6e2d7761722d73696e696a2d393430343139342c3936323435332f666f746f|d09bd0b5d0b3d0bad0be20d0bdd0b020d183d187d0b0d181d182d0bdd18bd0b520d183d187d0b0d181d182d0bdd0b8d0bad0bed0b22e2c20d0a6d0b5d0bdd18b202d20d0a1d182d0b8d0bbd18cd0bdd0b0d18f20d0bfd0b0d180d0bdd0b5d0bc2e20d0a1d0b0d0b3d0b0d0bdd180d0bed0b320d0b4d0bed0b3d0b0d0b4d0b5d0bdd0b8d18f203a20d0a2d183d180d186d0b8d0b82c20d0bad183d0bfd0b8d182d18c20d18320313020d0b4d0bdd0b520d0bad0bed0bbd18cd0bdd18bd0b520d0bcd0b0d188d0b8d0bdd0bad0b820d0bdd0b520d0bfd180d0b5d0b4d181d182d0b0d0b2d0bad0b8202d20d09dd0bed0b2d0b0d18f20d18120d0b8d0b7d0b1d0b8d0b5d0bdd0b8d0b520d181d0bfd180d0bed0b4d0b0d0b6d0b03a20d0bad0bed182d18fd182d0b0203230313420d0b32ed0b22e20d0a6d0b5d0bdd0b03a2034373530302d313045434f30363020e28093202d2d2d2d2d2d2d2d20d0bad183d0bfd0b8d182d18c20d0bad0b2d0b0d180d182d0b8d180d18320d09ed180d0b5d0bdd0b1d183d180d0b32028d0a0d0bed181d181d0b8d0b82047616c616e7472617820466c616d696c6961646120476f6f676c652c204ed0be20313820d184d0bed182d0bed0bad0bed0bdd0b2d0b5d180d0ba20d0a1d183d0bfd0b5d18020d09ad0b0d180d0b4d0b8d0b3d0b0d0bd|5|1.\nThis issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues"]
     async fn test_clickbench_22() -> Result<()> {
-        test_clickbench_query("q22").await
+        test_clickbench_query(
+            "q22",
+            PerTestConfig {
+                uses_undeterministic_limit_operator: true,
+                ..Default::default()
+            },
+        )
+        .await
     }
 
     #[tokio::test]
     async fn test_clickbench_23() -> Result<()> {
-        test_clickbench_query("q23").await
+        test_clickbench_query("q23", PerTestConfig::default()).await
     }
 
     #[tokio::test]
-    #[ignore = "result sets were not equal: Internal error: Row content differs between result sets\nLeft set size: 10, Right set size: 10\n\nRows only in left (1 total):\n  d0b2d181d0bfd0bed0bcd0bdd0b8d182d18c20d181d0bed0bbd0bdd0b5d0bdd0b8d0b520d0b1d0b0d0bdd0bad0b020d0bbd0b0d0b420d184d0b8d0bbd18cd0bc\n\nRows only in right (1 total):\n  d0bed182d0b2d0bed0b4d0b020d0b4d0bbd18f20d0bfd0b8d180d0bed0b6d0bad0b820d0bbd0b5d187d0b5d0bdd0bdd18b20d0b2d181d0b520d181d0b5d180d196d197.\nThis issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues"]
     async fn test_clickbench_24() -> Result<()> {
-        test_clickbench_query("q24").await
+        test_clickbench_query(
+            "q24",
+            PerTestConfig {
+                non_deterministic_sort: true,
+                ..Default::default()
+            },
+        )
+        .await
     }
 
     #[tokio::test]
     async fn test_clickbench_25() -> Result<()> {
-        test_clickbench_query("q25").await
+        test_clickbench_query("q25", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_26() -> Result<()> {
-        test_clickbench_query("q26").await
+        test_clickbench_query("q26", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_27() -> Result<()> {
-        test_clickbench_query("q27").await
+        test_clickbench_query("q27", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_28() -> Result<()> {
-        test_clickbench_query("q28").await
+        test_clickbench_query("q28", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_29() -> Result<()> {
-        test_clickbench_query("q29").await
+        test_clickbench_query("q29", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_30() -> Result<()> {
-        test_clickbench_query("q30").await
+        test_clickbench_query("q30", PerTestConfig::default()).await
     }
 
     #[tokio::test]
-    #[ignore = "result sets were not equal: Internal error: Row content differs between result sets\nLeft set size: 10, Right set size: 10\n\nRows only in left (10 total):\n  8673025726158767406|1264438551|1|0|1990.00\n  5320052218057629211|-1703087277|1|0|1996.00\n  6244273852606083750|1554672832|1|0|1638.00\n  8628753750962053665|1215278356|1|0|1087.00\n  7035318163404387241|1326714320|1|0|1638.00\n  8431857775494210873|1237512945|1|0|1996.00\n  5110752526539992124|37611695|1|0|1917.00\n  8986794334343068049|1860752926|1|0|1638.00\n  8044147848299485837|1382122372|1|0|1368.00\n  7936057634954670727|1897481896|1|0|1638.00\n\nRows only in right (10 total):\n  5132615111782210132|-50313020|1|0|1368.00\n  5783789691451717551|-1310327384|1|0|1638.00\n  5756260993772351383|1484317883|1|0|375.00\n  7739310142000732364|991864113|1|0|1368.00\n  7593472904893539271|-151291403|1|0|1087.00\n  6339599967989898410|1543815587|1|0|1638.00\n  7794346560421945218|1645556180|1|0|1368.00\n  6112645108657361792|593586188|1|0|1638.00\n  6675910710751922756|-816379256|1|0|1368.00\n  5802727636196431835|1986422271|1|0|1996.00.\nThis issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues"]
     async fn test_clickbench_31() -> Result<()> {
-        test_clickbench_query("q31").await
+        test_clickbench_query(
+            "q31",
+            PerTestConfig {
+                non_deterministic_sort: true,
+                ..Default::default()
+            },
+        )
+        .await
     }
 
     #[tokio::test]
-    #[ignore = "result sets were not equal: Internal error: Row content differs between result sets\nLeft set size: 10, Right set size: 10\n\nRows only in left (10 total):\n  7643059318918524417|1767085700|1|0|0.00\n  5437163248266133938|-1465369615|1|0|0.00\n  9142541582422390102|-1465369615|1|0|0.00\n  8438994503411842126|-1465369615|1|0|0.00\n  7362096505818029859|-565678477|1|0|0.00\n  4928022308880516715|1699955284|1|0|0.00\n  5269769817689282522|1699955284|1|0|0.00\n  9081648050908046886|1699955284|1|0|0.00\n  6824181869275536503|1699955284|1|0|0.00\n  6905712404475757487|1552811156|1|0|0.00\n\nRows only in right (10 total):\n  6967277596165459879|-941091661|1|0|1368.00\n  5796237228224217668|-1310327384|1|0|1638.00\n  7218628137278606666|1511490240|1|0|1638.00\n  8314760197723815280|1566105210|1|0|1996.00\n  7053263954762394007|757778490|1|0|339.00\n  6283334114093174531|1216031795|1|0|1368.00\n  8818295356247036741|83042182|1|0|1638.00\n  6620528864937282562|-862894777|1|0|1996.00\n  8466121050002905379|83042182|1|0|1638.00\n  7554844936512227411|-1746904856|1|0|1368.00.\nThis issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues"]
     async fn test_clickbench_32() -> Result<()> {
-        test_clickbench_query("q32").await
+        test_clickbench_query(
+            "q32",
+            PerTestConfig {
+                non_deterministic_sort: true,
+                ..Default::default()
+            },
+        )
+        .await
     }
 
     #[tokio::test]
     async fn test_clickbench_33() -> Result<()> {
-        test_clickbench_query("q33").await
+        test_clickbench_query("q33", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_34() -> Result<()> {
-        test_clickbench_query("q34").await
+        test_clickbench_query("q34", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_35() -> Result<()> {
-        test_clickbench_query("q35").await
+        test_clickbench_query("q35", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_36() -> Result<()> {
-        test_clickbench_query("q36").await
+        test_clickbench_query("q36", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_37() -> Result<()> {
-        test_clickbench_query("q37").await
+        test_clickbench_query("q37", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_38() -> Result<()> {
-        test_clickbench_query("q38").await
+        test_clickbench_query("q38", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_39() -> Result<()> {
-        test_clickbench_query("q39").await
+        test_clickbench_query("q39", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_40() -> Result<()> {
-        test_clickbench_query("q40").await
+        test_clickbench_query("q40", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_clickbench_41() -> Result<()> {
-        test_clickbench_query("q41").await
+        test_clickbench_query("q41", PerTestConfig::default()).await
     }
 
     #[tokio::test]
-    #[ignore = "ordering mismatch: expected ordering: Some(LexOrdering { exprs: [PhysicalSortExpr { expr: ScalarFunctionExpr { fun: \"<FUNC>\", name: \"date_trunc\", args: [Literal { value: Utf8(\"minute\"), field: Field { name: \"lit\", data_type: Utf8 } }, Column { name: \"m\", index: 0 }], return_field: Field { name: \"date_trunc\", data_type: Timestamp(Second, None), nullable: true } }, options: SortOptions { descending: false, nulls_first: false } }], set: {ScalarFunctionExpr { fun: \"<FUNC>\", name: \"date_trunc\", args: [Literal { value: Utf8(\"minute\"), field: Field { name: \"lit\", data_type: Utf8 } }, Column { name: \"m\", index: 0 }], return_field: Field { name: \"date_trunc\", data_type: Timestamp(Second, None), nullable: true } }} }), actual ordering: Some(LexOrdering { exprs: [PhysicalSortExpr { expr: ScalarFunctionExpr { fun: \"<FUNC>\", name: \"date_trunc\", args: [Literal { value: Utf8(\"minute\"), field: Field { name: \"lit\", data_type: Utf8 } }, Column { name: \"m\", index: 0 }], return_field: Field { name: \"date_trunc\", data_type: Timestamp(Second, None), nullable: true } }, options: SortOptions { descending: false, nulls_first: false } }], set: {ScalarFunctionExpr { fun: \"<FUNC>\", name: \"date_trunc\", args: [Literal { value: Utf8(\"minute\"), field: Field { name: \"lit\", data_type: Utf8 } }, Column { name: \"m\", index: 0 }], return_field: Field { name: \"date_trunc\", data_type: Timestamp(Second, None), nullable: true } }} })"]
+    #[ignore = "Ordering mismatch on `date_trunc('minute', ...)`: `compare_ordering` reports `LexOrdering` inequality even though Debug output is byte-identical on both sides. The diff is in a non-printed field of LexOrdering (e.g. schema metadata or equivalence-class set membership)."]
     async fn test_clickbench_42() -> Result<()> {
-        test_clickbench_query("q42").await
+        test_clickbench_query("q42", PerTestConfig::default()).await
     }
 
     static INIT_TEST_TPCDS_TABLES: OnceCell<()> = OnceCell::const_new();
@@ -260,7 +295,7 @@ mod tests {
         (plan.clone(), Arc::new(collect(plan, task_ctx).await)) // Collect execution errors, do not unwrap.
     }
 
-    async fn test_clickbench_query(query_id: &str) -> Result<()> {
+    async fn test_clickbench_query(query_id: &str, config: PerTestConfig) -> Result<()> {
         let data_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join(format!(
             "testdata/clickbench/correctness_range{}-{}",
             FILE_RANGE.start, FILE_RANGE.end
@@ -289,7 +324,6 @@ mod tests {
 
         let (s_plan, s_results) = run(&s_ctx, &query_sql).await;
         let (d_plan, d_results) = run(&d_ctx, &query_sql).await;
-
         if !d_plan.as_any().is::<DistributedExec>() {
             return plan_err!("Query {query_id} did not get distributed");
         }
@@ -300,7 +334,7 @@ mod tests {
             let d_results = d_results.clone();
             let s_results = s_results.clone();
             tokio::task::spawn_blocking(move || async move {
-                compare_result_set(&d_results, &s_results)
+                compare_result_set(&d_results, &s_results, &config)
             })
         };
         let compare_ordering = {

--- a/tests/clickbench_plans_test.rs
+++ b/tests/clickbench_plans_test.rs
@@ -888,10 +888,28 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "ordering mismatch: expected ordering: Some(LexOrdering { exprs: [PhysicalSortExpr { expr: ScalarFunctionExpr { fun: \"<FUNC>\", name: \"date_trunc\", args: [Literal { value: Utf8(\"minute\"), field: Field { name: \"lit\", data_type: Utf8 } }, Column { name: \"m\", index: 0 }], return_field: Field { name: \"date_trunc\", data_type: Timestamp(Second, None), nullable: true } }, options: SortOptions { descending: false, nulls_first: false } }], set: {ScalarFunctionExpr { fun: \"<FUNC>\", name: \"date_trunc\", args: [Literal { value: Utf8(\"minute\"), field: Field { name: \"lit\", data_type: Utf8 } }, Column { name: \"m\", index: 0 }], return_field: Field { name: \"date_trunc\", data_type: Timestamp(Second, None), nullable: true } }} }), actual ordering: Some(LexOrdering { exprs: [PhysicalSortExpr { expr: ScalarFunctionExpr { fun: \"<FUNC>\", name: \"date_trunc\", args: [Literal { value: Utf8(\"minute\"), field: Field { name: \"lit\", data_type: Utf8 } }, Column { name: \"m\", index: 0 }], return_field: Field { name: \"date_trunc\", data_type: Timestamp(Second, None), nullable: true } }, options: SortOptions { descending: false, nulls_first: false } }], set: {ScalarFunctionExpr { fun: \"<FUNC>\", name: \"date_trunc\", args: [Literal { value: Utf8(\"minute\"), field: Field { name: \"lit\", data_type: Utf8 } }, Column { name: \"m\", index: 0 }], return_field: Field { name: \"date_trunc\", data_type: Timestamp(Second, None), nullable: true } }} })"]
     async fn test_clickbench_42() -> Result<()> {
         let display = test_clickbench_query("q42").await?;
-        assert_snapshot!(display, @"");
+        assert_snapshot!(display, @r#"
+        ┌───── DistributedExec ── Tasks: t0:[p0]
+        │ GlobalLimitExec: skip=1000, fetch=10
+        │   SortPreservingMergeExec: [date_trunc(minute, m@0) ASC NULLS LAST], fetch=1010
+        │     [Stage 2] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
+        └──────────────────────────────────────────────────
+          ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p0..p2]
+          │ SortExec: TopK(fetch=1010), expr=[date_trunc(minute, m@0) ASC NULLS LAST], preserve_partitioning=[true]
+          │   ProjectionExec: expr=[date_trunc(Utf8("minute"),to_timestamp_seconds(hits.EventTime))@0 as m, count(Int64(1))@1 as pageviews]
+          │     AggregateExec: mode=FinalPartitioned, gby=[date_trunc(Utf8("minute"),to_timestamp_seconds(hits.EventTime))@0 as date_trunc(Utf8("minute"),to_timestamp_seconds(hits.EventTime))], aggr=[count(Int64(1))]
+          │       [Stage 1] => NetworkShuffleExec: output_partitions=3, input_tasks=3
+          └──────────────────────────────────────────────────
+            ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p0..p5] t2:[p0..p5]
+            │ RepartitionExec: partitioning=Hash([date_trunc(Utf8("minute"),to_timestamp_seconds(hits.EventTime))@0], 6), input_partitions=2
+            │   AggregateExec: mode=Partial, gby=[date_trunc(minute, to_timestamp_seconds(EventTime@0)) as date_trunc(Utf8("minute"),to_timestamp_seconds(hits.EventTime))], aggr=[count(Int64(1))]
+            │     FilterExec: CounterID@2 = 62 AND CAST(EventDate@1 AS Utf8) >= 2013-07-14 AND CAST(EventDate@1 AS Utf8) <= 2013-07-15 AND IsRefresh@3 = 0 AND DontCountHits@4 = 0, projection=[EventTime@0]
+            │       PartitionIsolatorExec: tasks=3 partitions=5
+            │         DataSourceExec: file_groups={5 groups: [[/testdata/clickbench/plans_range0-3/hits/0.parquet:<int>..<int>], [/testdata/clickbench/plans_range0-3/hits/1.parquet:<int>..<int>], [/testdata/clickbench/plans_range0-3/hits/1.parquet:<int>..<int>], [/testdata/clickbench/plans_range0-3/hits/2.parquet:<int>..<int>], [/testdata/clickbench/plans_range0-3/hits/2.parquet:<int>..<int>]]}, projection=[EventTime, EventDate, CounterID, IsRefresh, DontCountHits], file_type=parquet, predicate=CounterID@6 = 62 AND CAST(EventDate@5 AS Utf8) >= 2013-07-14 AND CAST(EventDate@5 AS Utf8) <= 2013-07-15 AND IsRefresh@15 = 0 AND DontCountHits@61 = 0, pruning_predicate=CounterID_null_count@2 != row_count@3 AND CounterID_min@0 <= 62 AND 62 <= CounterID_max@1 AND IsRefresh_null_count@6 != row_count@3 AND IsRefresh_min@4 <= 0 AND 0 <= IsRefresh_max@5 AND DontCountHits_null_count@9 != row_count@3 AND DontCountHits_min@7 <= 0 AND 0 <= DontCountHits_max@8, required_guarantees=[CounterID in (62), DontCountHits in (0), IsRefresh in (0)]
+            └──────────────────────────────────────────────────
+        "#);
         Ok(())
     }
 

--- a/tests/tpcds_correctness_test.rs
+++ b/tests/tpcds_correctness_test.rs
@@ -7,7 +7,7 @@ mod tests {
     use datafusion::prelude::SessionContext;
     use datafusion_distributed::test_utils::in_memory_channel_resolver::start_in_memory_context;
     use datafusion_distributed::test_utils::property_based::{
-        PerTestConfig, compare_ordering, compare_result_set,
+        compare_ordering, compare_result_set,
     };
     use datafusion_distributed::{
         DefaultSessionBuilder, DistributedExec, DistributedExt, display_plan_ascii,
@@ -26,358 +26,358 @@ mod tests {
 
     #[tokio::test]
     async fn test_tpcds_shard01_q1() -> Result<()> {
-        test_tpcds_query("q1", PerTestConfig::default()).await
+        test_tpcds_query("q1").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard01_q2() -> Result<()> {
-        test_tpcds_query("q2", PerTestConfig::default()).await
+        test_tpcds_query("q2").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard01_q3() -> Result<()> {
-        test_tpcds_query("q3", PerTestConfig::default()).await
+        test_tpcds_query("q3").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard01_q4() -> Result<()> {
-        test_tpcds_query("q4", PerTestConfig::default()).await
+        test_tpcds_query("q4").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard01_q5() -> Result<()> {
-        test_tpcds_query("q5", PerTestConfig::default()).await
+        test_tpcds_query("q5").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard01_q6() -> Result<()> {
-        test_tpcds_query("q6", PerTestConfig::default()).await
+        test_tpcds_query("q6").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard01_q7() -> Result<()> {
-        test_tpcds_query("q7", PerTestConfig::default()).await
+        test_tpcds_query("q7").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard01_q8() -> Result<()> {
-        test_tpcds_query("q8", PerTestConfig::default()).await
+        test_tpcds_query("q8").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard01_q9() -> Result<()> {
-        test_tpcds_query("q9", PerTestConfig::default()).await
+        test_tpcds_query("q9").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard01_q10() -> Result<()> {
-        test_tpcds_query("q10", PerTestConfig::default()).await
+        test_tpcds_query("q10").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard02_q11() -> Result<()> {
-        test_tpcds_query("q11", PerTestConfig::default()).await
+        test_tpcds_query("q11").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard02_q12() -> Result<()> {
-        test_tpcds_query("q12", PerTestConfig::default()).await
+        test_tpcds_query("q12").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard02_q13() -> Result<()> {
-        test_tpcds_query("q13", PerTestConfig::default()).await
+        test_tpcds_query("q13").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard02_q14() -> Result<()> {
-        test_tpcds_query("q14", PerTestConfig::default()).await
+        test_tpcds_query("q14").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard02_q15() -> Result<()> {
-        test_tpcds_query("q15", PerTestConfig::default()).await
+        test_tpcds_query("q15").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard02_q16() -> Result<()> {
-        test_tpcds_query("q16", PerTestConfig::default()).await
+        test_tpcds_query("q16").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard02_q17() -> Result<()> {
-        test_tpcds_query("q17", PerTestConfig::default()).await
+        test_tpcds_query("q17").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard02_q18() -> Result<()> {
-        test_tpcds_query("q18", PerTestConfig::default()).await
+        test_tpcds_query("q18").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard02_q19() -> Result<()> {
-        test_tpcds_query("q19", PerTestConfig::default()).await
+        test_tpcds_query("q19").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard02_q20() -> Result<()> {
-        test_tpcds_query("q20", PerTestConfig::default()).await
+        test_tpcds_query("q20").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard03_q21() -> Result<()> {
-        test_tpcds_query("q21", PerTestConfig::default()).await
+        test_tpcds_query("q21").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard03_q22() -> Result<()> {
-        test_tpcds_query("q22", PerTestConfig::default()).await
+        test_tpcds_query("q22").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard03_q23() -> Result<()> {
-        test_tpcds_query("q23", PerTestConfig::default()).await
+        test_tpcds_query("q23").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard03_q24() -> Result<()> {
-        test_tpcds_query("q24", PerTestConfig::default()).await
+        test_tpcds_query("q24").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard03_q25() -> Result<()> {
-        test_tpcds_query("q25", PerTestConfig::default()).await
+        test_tpcds_query("q25").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard03_q26() -> Result<()> {
-        test_tpcds_query("q26", PerTestConfig::default()).await
+        test_tpcds_query("q26").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard03_q27() -> Result<()> {
-        test_tpcds_query("q27", PerTestConfig::default()).await
+        test_tpcds_query("q27").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard03_q28() -> Result<()> {
-        test_tpcds_query("q28", PerTestConfig::default()).await
+        test_tpcds_query("q28").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard03_q29() -> Result<()> {
-        test_tpcds_query("q29", PerTestConfig::default()).await
+        test_tpcds_query("q29").await
     }
 
     #[tokio::test]
     #[ignore = "fails on CI but works locally, see https://github.com/datafusion-contrib/datafusion-distributed/pull/452#issuecomment-4439115012"]
     async fn test_tpcds_shard03_q30() -> Result<()> {
-        test_tpcds_query("q30", PerTestConfig::default()).await
+        test_tpcds_query("q30").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard04_q31() -> Result<()> {
-        test_tpcds_query("q31", PerTestConfig::default()).await
+        test_tpcds_query("q31").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard04_q32() -> Result<()> {
-        test_tpcds_query("q32", PerTestConfig::default()).await
+        test_tpcds_query("q32").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard04_q33() -> Result<()> {
-        test_tpcds_query("q33", PerTestConfig::default()).await
+        test_tpcds_query("q33").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard04_q34() -> Result<()> {
-        test_tpcds_query("q34", PerTestConfig::default()).await
+        test_tpcds_query("q34").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard04_q35() -> Result<()> {
-        test_tpcds_query("q35", PerTestConfig::default()).await
+        test_tpcds_query("q35").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard04_q36() -> Result<()> {
-        test_tpcds_query("q36", PerTestConfig::default()).await
+        test_tpcds_query("q36").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard04_q37() -> Result<()> {
-        test_tpcds_query("q37", PerTestConfig::default()).await
+        test_tpcds_query("q37").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard04_q38() -> Result<()> {
-        test_tpcds_query("q38", PerTestConfig::default()).await
+        test_tpcds_query("q38").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard04_q39() -> Result<()> {
-        test_tpcds_query("q39", PerTestConfig::default()).await
+        test_tpcds_query("q39").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard04_q40() -> Result<()> {
-        test_tpcds_query("q40", PerTestConfig::default()).await
+        test_tpcds_query("q40").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard05_q41() -> Result<()> {
-        test_tpcds_query("q41", PerTestConfig::default()).await
+        test_tpcds_query("q41").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard05_q42() -> Result<()> {
-        test_tpcds_query("q42", PerTestConfig::default()).await
+        test_tpcds_query("q42").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard05_q43() -> Result<()> {
-        test_tpcds_query("q43", PerTestConfig::default()).await
+        test_tpcds_query("q43").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard05_q44() -> Result<()> {
-        test_tpcds_query("q44", PerTestConfig::default()).await
+        test_tpcds_query("q44").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard05_q45() -> Result<()> {
-        test_tpcds_query("q45", PerTestConfig::default()).await
+        test_tpcds_query("q45").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard05_q46() -> Result<()> {
-        test_tpcds_query("q46", PerTestConfig::default()).await
+        test_tpcds_query("q46").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard05_q47() -> Result<()> {
-        test_tpcds_query("q47", PerTestConfig::default()).await
+        test_tpcds_query("q47").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard05_q48() -> Result<()> {
-        test_tpcds_query("q48", PerTestConfig::default()).await
+        test_tpcds_query("q48").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard05_q49() -> Result<()> {
-        test_tpcds_query("q49", PerTestConfig::default()).await
+        test_tpcds_query("q49").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard05_q50() -> Result<()> {
-        test_tpcds_query("q50", PerTestConfig::default()).await
+        test_tpcds_query("q50").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard06_q51() -> Result<()> {
-        test_tpcds_query("q51", PerTestConfig::default()).await
+        test_tpcds_query("q51").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard06_q52() -> Result<()> {
-        test_tpcds_query("q52", PerTestConfig::default()).await
+        test_tpcds_query("q52").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard06_q53() -> Result<()> {
-        test_tpcds_query("q53", PerTestConfig::default()).await
+        test_tpcds_query("q53").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard06_q54() -> Result<()> {
-        test_tpcds_query("q54", PerTestConfig::default()).await
+        test_tpcds_query("q54").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard06_q55() -> Result<()> {
-        test_tpcds_query("q55", PerTestConfig::default()).await
+        test_tpcds_query("q55").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard06_q56() -> Result<()> {
-        test_tpcds_query("q56", PerTestConfig::default()).await
+        test_tpcds_query("q56").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard06_q57() -> Result<()> {
-        test_tpcds_query("q57", PerTestConfig::default()).await
+        test_tpcds_query("q57").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard06_q58() -> Result<()> {
-        test_tpcds_query("q58", PerTestConfig::default()).await
+        test_tpcds_query("q58").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard06_q59() -> Result<()> {
-        test_tpcds_query("q59", PerTestConfig::default()).await
+        test_tpcds_query("q59").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard06_q60() -> Result<()> {
-        test_tpcds_query("q60", PerTestConfig::default()).await
+        test_tpcds_query("q60").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard07_q61() -> Result<()> {
-        test_tpcds_query("q61", PerTestConfig::default()).await
+        test_tpcds_query("q61").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard07_q62() -> Result<()> {
-        test_tpcds_query("q62", PerTestConfig::default()).await
+        test_tpcds_query("q62").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard07_q63() -> Result<()> {
-        test_tpcds_query("q63", PerTestConfig::default()).await
+        test_tpcds_query("q63").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard07_q64() -> Result<()> {
-        test_tpcds_query("q64", PerTestConfig::default()).await
+        test_tpcds_query("q64").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard07_q65() -> Result<()> {
-        test_tpcds_query("q65", PerTestConfig::default()).await
+        test_tpcds_query("q65").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard07_q66() -> Result<()> {
-        test_tpcds_query("q66", PerTestConfig::default()).await
+        test_tpcds_query("q66").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard07_q67() -> Result<()> {
-        test_tpcds_query("q67", PerTestConfig::default()).await
+        test_tpcds_query("q67").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard07_q68() -> Result<()> {
-        test_tpcds_query("q68", PerTestConfig::default()).await
+        test_tpcds_query("q68").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard07_q69() -> Result<()> {
-        test_tpcds_query("q69", PerTestConfig::default()).await
+        test_tpcds_query("q69").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard07_q70() -> Result<()> {
-        test_tpcds_query("q70", PerTestConfig::default()).await
+        test_tpcds_query("q70").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard08_q71() -> Result<()> {
-        test_tpcds_query("q71", PerTestConfig::default()).await
+        test_tpcds_query("q71").await
     }
 
     #[tokio::test]
@@ -389,138 +389,138 @@ mod tests {
         ignore = "Query takes too long to execute"
     )]
     async fn test_tpcds_shard08_q72() -> Result<()> {
-        test_tpcds_query("q72", PerTestConfig::default()).await
+        test_tpcds_query("q72").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard08_q73() -> Result<()> {
-        test_tpcds_query("q73", PerTestConfig::default()).await
+        test_tpcds_query("q73").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard08_q74() -> Result<()> {
-        test_tpcds_query("q74", PerTestConfig::default()).await
+        test_tpcds_query("q74").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard08_q75() -> Result<()> {
-        test_tpcds_query("q75", PerTestConfig::default()).await
+        test_tpcds_query("q75").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard08_q76() -> Result<()> {
-        test_tpcds_query("q76", PerTestConfig::default()).await
+        test_tpcds_query("q76").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard08_q77() -> Result<()> {
-        test_tpcds_query("q77", PerTestConfig::default()).await
+        test_tpcds_query("q77").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard08_q78() -> Result<()> {
-        test_tpcds_query("q78", PerTestConfig::default()).await
+        test_tpcds_query("q78").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard08_q79() -> Result<()> {
-        test_tpcds_query("q79", PerTestConfig::default()).await
+        test_tpcds_query("q79").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard08_q80() -> Result<()> {
-        test_tpcds_query("q80", PerTestConfig::default()).await
+        test_tpcds_query("q80").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard09_q81() -> Result<()> {
-        test_tpcds_query("q81", PerTestConfig::default()).await
+        test_tpcds_query("q81").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard09_q82() -> Result<()> {
-        test_tpcds_query("q82", PerTestConfig::default()).await
+        test_tpcds_query("q82").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard09_q83() -> Result<()> {
-        test_tpcds_query("q83", PerTestConfig::default()).await
+        test_tpcds_query("q83").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard09_q84() -> Result<()> {
-        test_tpcds_query("q84", PerTestConfig::default()).await
+        test_tpcds_query("q84").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard09_q85() -> Result<()> {
-        test_tpcds_query("q85", PerTestConfig::default()).await
+        test_tpcds_query("q85").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard09_q86() -> Result<()> {
-        test_tpcds_query("q86", PerTestConfig::default()).await
+        test_tpcds_query("q86").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard09_q87() -> Result<()> {
-        test_tpcds_query("q87", PerTestConfig::default()).await
+        test_tpcds_query("q87").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard09_q88() -> Result<()> {
-        test_tpcds_query("q88", PerTestConfig::default()).await
+        test_tpcds_query("q88").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard09_q89() -> Result<()> {
-        test_tpcds_query("q89", PerTestConfig::default()).await
+        test_tpcds_query("q89").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard09_q90() -> Result<()> {
-        test_tpcds_query("q90", PerTestConfig::default()).await
+        test_tpcds_query("q90").await
     }
 
     #[tokio::test]
     #[ignore = "Query q91 did not get distributed"]
     async fn test_tpcds_shard10_q91() -> Result<()> {
-        test_tpcds_query("q91", PerTestConfig::default()).await
+        test_tpcds_query("q91").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard10_q92() -> Result<()> {
-        test_tpcds_query("q92", PerTestConfig::default()).await
+        test_tpcds_query("q92").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard10_q93() -> Result<()> {
-        test_tpcds_query("q93", PerTestConfig::default()).await
+        test_tpcds_query("q93").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard10_q94() -> Result<()> {
-        test_tpcds_query("q94", PerTestConfig::default()).await
+        test_tpcds_query("q94").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard10_q95() -> Result<()> {
-        test_tpcds_query("q95", PerTestConfig::default()).await
+        test_tpcds_query("q95").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard10_q96() -> Result<()> {
-        test_tpcds_query("q96", PerTestConfig::default()).await
+        test_tpcds_query("q96").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard10_q97() -> Result<()> {
-        test_tpcds_query("q97", PerTestConfig::default()).await
+        test_tpcds_query("q97").await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard10_q98() -> Result<()> {
-        test_tpcds_query("q98", PerTestConfig::default()).await
+        test_tpcds_query("q98").await
     }
 
     #[tokio::test]
@@ -532,7 +532,7 @@ mod tests {
         ignore = "Query takes too long to execute"
     )]
     async fn test_tpcds_shard10_q99() -> Result<()> {
-        test_tpcds_query("q99", PerTestConfig::default()).await
+        test_tpcds_query("q99").await
     }
 
     static INIT_TEST_TPCDS_TABLES: OnceCell<()> = OnceCell::const_new();
@@ -547,7 +547,7 @@ mod tests {
         (plan.clone(), Arc::new(collect(plan, task_ctx).await)) // Collect execution errors, do not unwrap.
     }
 
-    async fn test_tpcds_query(query_id: &str, config: PerTestConfig) -> Result<()> {
+    async fn test_tpcds_query(query_id: &str) -> Result<()> {
         let data_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join(format!(
             "testdata/tpcds/correctness_sf{SF}_partitions{PARQUET_PARTITIONS}"
         ));
@@ -590,7 +590,7 @@ mod tests {
             let d_results = d_results.clone();
             let s_results = s_results.clone();
             tokio::task::spawn_blocking(move || async move {
-                compare_result_set(&d_results, &s_results, &config)
+                compare_result_set(&d_results, &s_results)
             })
         };
         let compare_ordering = {

--- a/tests/tpcds_correctness_test.rs
+++ b/tests/tpcds_correctness_test.rs
@@ -7,7 +7,7 @@ mod tests {
     use datafusion::prelude::SessionContext;
     use datafusion_distributed::test_utils::in_memory_channel_resolver::start_in_memory_context;
     use datafusion_distributed::test_utils::property_based::{
-        compare_ordering, compare_result_set,
+        PerTestConfig, compare_ordering, compare_result_set,
     };
     use datafusion_distributed::{
         DefaultSessionBuilder, DistributedExec, DistributedExt, display_plan_ascii,
@@ -26,514 +26,513 @@ mod tests {
 
     #[tokio::test]
     async fn test_tpcds_shard01_q1() -> Result<()> {
-        test_tpcds_query("q1").await
+        test_tpcds_query("q1", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard01_q2() -> Result<()> {
-        test_tpcds_query("q2").await
+        test_tpcds_query("q2", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard01_q3() -> Result<()> {
-        test_tpcds_query("q3").await
+        test_tpcds_query("q3", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard01_q4() -> Result<()> {
-        test_tpcds_query("q4").await
+        test_tpcds_query("q4", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard01_q5() -> Result<()> {
-        test_tpcds_query("q5").await
+        test_tpcds_query("q5", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard01_q6() -> Result<()> {
-        test_tpcds_query("q6").await
+        test_tpcds_query("q6", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard01_q7() -> Result<()> {
-        test_tpcds_query("q7").await
+        test_tpcds_query("q7", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard01_q8() -> Result<()> {
-        test_tpcds_query("q8").await
+        test_tpcds_query("q8", PerTestConfig::default()).await
     }
 
     #[tokio::test]
-    #[ignore = "expected no error but got: Arrow error: Invalid argument error: must either specify a row count or at least one column"]
     async fn test_tpcds_shard01_q9() -> Result<()> {
-        test_tpcds_query("q9").await
+        test_tpcds_query("q9", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard01_q10() -> Result<()> {
-        test_tpcds_query("q10").await
+        test_tpcds_query("q10", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard02_q11() -> Result<()> {
-        test_tpcds_query("q11").await
+        test_tpcds_query("q11", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard02_q12() -> Result<()> {
-        test_tpcds_query("q12").await
+        test_tpcds_query("q12", PerTestConfig::default()).await
     }
 
     #[tokio::test]
-    #[ignore = "Query q13 did not get distributed"]
     async fn test_tpcds_shard02_q13() -> Result<()> {
-        test_tpcds_query("q13").await
+        test_tpcds_query("q13", PerTestConfig::default()).await
     }
 
     #[tokio::test]
-    #[ignore = "result sets were not equal: Internal error: Row content differs between result sets\nLeft set size: 100, Right set size: 100\n\nRows only in left (71 total):\n  NULL|NULL|NULL|NULL|674173362.51|155629\n  catalog|NULL|NULL|NULL|237410857.47|46322\n  catalog|1001001.00|NULL|NULL|1697729.02|347\n  catalog|1001001.00|1.00|NULL|855204.24|167\n  catalog|1001001.00|2.00|NULL|125167.22|24\n  catalog|1001001.00|3.00|NULL|198685.08|43\n  catalog|1001001.00|4.00|NULL|109585.97|31\n  catalog|1001001.00|5.00|NULL|59790.61|17\n  catalog|1001001.00|8.00|NULL|55768.46|13\n  catalog|1001001.00|8.00|7.00|28872.49|7\n  catalog|1001001.00|8.00|10.00|26895.97|6\n  catalog|1001001.00|9.00|NULL|30944.19|5\n  catalog|1001001.00|9.00|6.00|30944.19|5\n  catalog|1001001.00|11.00|NULL|82810.87|12\n  catalog|1001001.00|11.00|9.00|82810.87|12\n  catalog|1001001.00|12.00|NULL|38427.52|9\n  catalog|1001001.00|12.00|10.00|38427.52|9\n  catalog|1001001.00|15.00|NULL|112838.10|20\n  catalog|1001001.00|15.00|9.00|53508.79|7\n  catalog|1001001.00|15.00|10.00|59329.31|13\n  catalog|1001002.00|NULL|NULL|3527831.33|706\n  catalog|1001002.00|1.00|NULL|2673969.89|530\n  catalog|1001002.00|1.00|1.00|2673969.89|530\n  catalog|1001002.00|2.00|NULL|140831.91|29\n  catalog|1001002.00|2.00|1.00|140831.91|29\n  catalog|1001002.00|3.00|NULL|320175.87|67\n  catalog|1001002.00|3.00|1.00|320175.87|67\n  catalog|1001002.00|4.00|NULL|133287.96|21\n  catalog|1001002.00|4.00|1.00|133287.96|21\n  catalog|1001002.00|5.00|NULL|16606.90|9\n  catalog|1001002.00|5.00|1.00|16606.90|9\n  catalog|1001002.00|6.00|NULL|15133.01|4\n  catalog|1001002.00|6.00|1.00|15133.01|4\n  catalog|1001002.00|7.00|NULL|24471.26|10\n  catalog|1001002.00|7.00|1.00|24471.26|10\n  catalog|1001002.00|8.00|NULL|63773.05|12\n  catalog|1001002.00|8.00|1.00|63773.05|12\n  catalog|1001002.00|9.00|NULL|9167.19|3\n  catalog|1001002.00|9.00|1.00|9167.19|3\n  catalog|1001002.00|12.00|NULL|29108.42|7\n  catalog|1001002.00|12.00|1.00|29108.42|7\n  catalog|1001002.00|15.00|NULL|31143.45|6\n  catalog|1001002.00|15.00|1.00|31143.45|6\n  catalog|1001002.00|16.00|NULL|70162.42|8\n  catalog|1001002.00|16.00|1.00|70162.42|8\n  catalog|1002001.00|NULL|NULL|2114110.72|380\n  catalog|1002001.00|1.00|NULL|348693.97|55\n  catalog|1002001.00|1.00|1.00|76392.13|14\n  catalog|1002001.00|1.00|2.00|118394.33|21\n  catalog|1002001.00|1.00|4.00|29395.79|5\n  catalog|1002001.00|1.00|5.00|35541.97|4\n  catalog|1002001.00|1.00|6.00|26104.36|3\n  catalog|1002001.00|1.00|9.00|18793.97|4\n  catalog|1002001.00|1.00|10.00|44071.42|4\n  catalog|1002001.00|2.00|NULL|1233961.70|225\n  catalog|1002001.00|2.00|1.00|239511.02|51\n  catalog|1002001.00|2.00|2.00|147993.14|26\n  catalog|1002001.00|2.00|3.00|100086.93|17\n  catalog|1002001.00|2.00|4.00|53524.42|13\n  catalog|1002001.00|2.00|5.00|48494.06|10\n  catalog|1002001.00|2.00|6.00|142857.04|20\n  catalog|1002001.00|2.00|7.00|116557.98|16\n  catalog|1002001.00|2.00|8.00|92743.93|24\n  catalog|1002001.00|2.00|9.00|203943.99|38\n  catalog|1002001.00|2.00|10.00|88249.19|10\n  catalog|1002001.00|3.00|NULL|91054.32|17\n  catalog|1002001.00|3.00|2.00|25171.13|6\n  catalog|1002001.00|3.00|7.00|27766.70|3\n  catalog|1002001.00|3.00|8.00|38116.49|8\n  catalog|1002001.00|4.00|NULL|182427.69|32\n  catalog|1002001.00|4.00|1.00|66896.68|15\n\nRows only in right (71 total):\n  NULL|NULL|NULL|NULL|47788579.87|11068\n  NULL|NULL|NULL|NULL|46294358.79|10609\n  NULL|NULL|NULL|NULL|40499040.27|9321\n  NULL|NULL|NULL|NULL|37952602.75|8889\n  NULL|NULL|NULL|NULL|50256292.02|11540\n  NULL|NULL|NULL|NULL|27943616.98|6397\n  NULL|NULL|NULL|NULL|43114338.77|10000\n  NULL|NULL|NULL|NULL|56239021.04|13003\n  NULL|NULL|NULL|NULL|25682800.66|6012\n  NULL|NULL|NULL|NULL|38529122.81|8922\n  NULL|NULL|NULL|NULL|59222982.16|13528\n  NULL|NULL|NULL|NULL|48322926.86|11228\n  NULL|NULL|NULL|NULL|39166012.10|9010\n  NULL|NULL|NULL|NULL|32661391.26|7453\n  NULL|NULL|NULL|NULL|43315152.10|10008\n  NULL|NULL|NULL|NULL|37185124.07|8641\n  catalog|NULL|NULL|NULL|16671923.72|3228\n  catalog|NULL|NULL|NULL|16630833.01|3143\n  catalog|NULL|NULL|NULL|14038550.02|2798\n  catalog|NULL|NULL|NULL|13135427.84|2638\n  catalog|NULL|NULL|NULL|17604907.44|3399\n  catalog|NULL|NULL|NULL|10119873.49|1959\n  catalog|NULL|NULL|NULL|14698922.72|2919\n  catalog|NULL|NULL|NULL|19534422.18|3931\n  catalog|NULL|NULL|NULL|9075046.95|1756\n  catalog|NULL|NULL|NULL|13829338.20|2662\n  catalog|NULL|NULL|NULL|21769645.88|4087\n  catalog|NULL|NULL|NULL|16890254.59|3343\n  catalog|NULL|NULL|NULL|13897305.68|2680\n  catalog|NULL|NULL|NULL|11719010.15|2217\n  catalog|NULL|NULL|NULL|14773719.71|2947\n  catalog|NULL|NULL|NULL|13021675.89|2615\n  catalog|1001001.00|NULL|NULL|188446.33|41\n  catalog|1001001.00|NULL|NULL|53508.79|7\n  catalog|1001001.00|NULL|NULL|100105.28|23\n  catalog|1001001.00|NULL|NULL|114412.27|25\n  catalog|1001001.00|NULL|NULL|77231.70|15\n  catalog|1001001.00|NULL|NULL|174489.15|42\n  catalog|1001001.00|NULL|NULL|206490.30|38\n  catalog|1001001.00|NULL|NULL|45473.85|13\n  catalog|1001001.00|NULL|NULL|146344.47|27\n  catalog|1001001.00|NULL|NULL|152599.38|28\n  catalog|1001001.00|NULL|NULL|206412.37|36\n  catalog|1001001.00|NULL|NULL|119368.21|23\n  catalog|1001001.00|NULL|NULL|45014.15|12\n  catalog|1001001.00|NULL|NULL|50948.80|14\n  catalog|1001001.00|NULL|NULL|16883.97|3\n  catalog|1001001.00|1.00|NULL|100105.28|23\n  catalog|1001001.00|1.00|NULL|99985.35|21\n  catalog|1001001.00|1.00|NULL|107555.43|23\n  catalog|1001001.00|1.00|NULL|161349.39|29\n  catalog|1001001.00|1.00|NULL|146344.47|27\n  catalog|1001001.00|1.00|NULL|122521.31|25\n  catalog|1001001.00|1.00|NULL|77861.85|13\n  catalog|1001001.00|1.00|NULL|22597.19|3\n  catalog|1001001.00|1.00|NULL|16883.97|3\n  catalog|1001001.00|2.00|NULL|68565.38|14\n  catalog|1001001.00|2.00|NULL|43967.97|7\n  catalog|1001001.00|2.00|NULL|12633.87|3\n  catalog|1001001.00|3.00|NULL|60551.64|14\n  catalog|1001001.00|3.00|NULL|14426.92|4\n  catalog|1001001.00|3.00|NULL|36821.61|7\n  catalog|1001001.00|3.00|NULL|30078.07|3\n  catalog|1001001.00|3.00|NULL|28455.23|4\n  catalog|1001001.00|3.00|NULL|28351.61|11\n  catalog|1001001.00|4.00|NULL|47553.20|10\n  catalog|1001001.00|4.00|NULL|45473.85|13\n  catalog|1001001.00|4.00|NULL|16558.92|8\n  catalog|1001001.00|5.00|NULL|29678.50|5\n  catalog|1001001.00|5.00|NULL|30112.11|12\n  catalog|1001001.00|8.00|NULL|26895.97|6.\nThis issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues"]
     async fn test_tpcds_shard02_q14() -> Result<()> {
-        test_tpcds_query("q14").await
+        test_tpcds_query("q14", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard02_q15() -> Result<()> {
-        test_tpcds_query("q15").await
+        test_tpcds_query("q15", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard02_q16() -> Result<()> {
-        test_tpcds_query("q16").await
+        test_tpcds_query("q16", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard02_q17() -> Result<()> {
-        test_tpcds_query("q17").await
+        test_tpcds_query("q17", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard02_q18() -> Result<()> {
-        test_tpcds_query("q18").await
+        test_tpcds_query("q18", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard02_q19() -> Result<()> {
-        test_tpcds_query("q19").await
+        test_tpcds_query("q19", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard02_q20() -> Result<()> {
-        test_tpcds_query("q20").await
+        test_tpcds_query("q20", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard03_q21() -> Result<()> {
-        test_tpcds_query("q21").await
+        test_tpcds_query("q21", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard03_q22() -> Result<()> {
-        test_tpcds_query("q22").await
+        test_tpcds_query("q22", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard03_q23() -> Result<()> {
-        test_tpcds_query("q23").await
+        test_tpcds_query("q23", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard03_q24() -> Result<()> {
-        test_tpcds_query("q24").await
+        test_tpcds_query("q24", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard03_q25() -> Result<()> {
-        test_tpcds_query("q25").await
+        test_tpcds_query("q25", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard03_q26() -> Result<()> {
-        test_tpcds_query("q26").await
+        test_tpcds_query("q26", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard03_q27() -> Result<()> {
-        test_tpcds_query("q27").await
+        test_tpcds_query("q27", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard03_q28() -> Result<()> {
-        test_tpcds_query("q28").await
+        test_tpcds_query("q28", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard03_q29() -> Result<()> {
-        test_tpcds_query("q29").await
+        test_tpcds_query("q29", PerTestConfig::default()).await
     }
 
     #[tokio::test]
-    #[ignore = "Fails with column 'c_last_review_date_sk' not found"]
+    #[ignore = "fails on CI but works locally, see https://github.com/datafusion-contrib/datafusion-distributed/pull/452#issuecomment-4439115012"]
     async fn test_tpcds_shard03_q30() -> Result<()> {
-        test_tpcds_query("q30").await
+        test_tpcds_query("q30", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard04_q31() -> Result<()> {
-        test_tpcds_query("q31").await
+        test_tpcds_query("q31", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard04_q32() -> Result<()> {
-        test_tpcds_query("q32").await
+        test_tpcds_query("q32", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard04_q33() -> Result<()> {
-        test_tpcds_query("q33").await
+        test_tpcds_query("q33", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard04_q34() -> Result<()> {
-        test_tpcds_query("q34").await
+        test_tpcds_query("q34", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard04_q35() -> Result<()> {
-        test_tpcds_query("q35").await
+        test_tpcds_query("q35", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard04_q36() -> Result<()> {
-        test_tpcds_query("q36").await
+        test_tpcds_query("q36", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard04_q37() -> Result<()> {
-        test_tpcds_query("q37").await
+        test_tpcds_query("q37", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard04_q38() -> Result<()> {
-        test_tpcds_query("q38").await
+        test_tpcds_query("q38", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard04_q39() -> Result<()> {
-        test_tpcds_query("q39").await
+        test_tpcds_query("q39", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard04_q40() -> Result<()> {
-        test_tpcds_query("q40").await
+        test_tpcds_query("q40", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard05_q41() -> Result<()> {
-        test_tpcds_query("q41").await
+        test_tpcds_query("q41", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard05_q42() -> Result<()> {
-        test_tpcds_query("q42").await
+        test_tpcds_query("q42", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard05_q43() -> Result<()> {
-        test_tpcds_query("q43").await
+        test_tpcds_query("q43", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard05_q44() -> Result<()> {
-        test_tpcds_query("q44").await
+        test_tpcds_query("q44", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard05_q45() -> Result<()> {
-        test_tpcds_query("q45").await
+        test_tpcds_query("q45", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard05_q46() -> Result<()> {
-        test_tpcds_query("q46").await
+        test_tpcds_query("q46", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard05_q47() -> Result<()> {
-        test_tpcds_query("q47").await
+        test_tpcds_query("q47", PerTestConfig::default()).await
     }
 
     #[tokio::test]
-    #[ignore = "Query q48 did not get distributed"]
     async fn test_tpcds_shard05_q48() -> Result<()> {
-        test_tpcds_query("q48").await
+        test_tpcds_query("q48", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard05_q49() -> Result<()> {
-        test_tpcds_query("q49").await
+        test_tpcds_query("q49", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard05_q50() -> Result<()> {
-        test_tpcds_query("q50").await
+        test_tpcds_query("q50", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard06_q51() -> Result<()> {
-        test_tpcds_query("q51").await
+        test_tpcds_query("q51", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard06_q52() -> Result<()> {
-        test_tpcds_query("q52").await
+        test_tpcds_query("q52", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard06_q53() -> Result<()> {
-        test_tpcds_query("q53").await
+        test_tpcds_query("q53", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard06_q54() -> Result<()> {
-        test_tpcds_query("q54").await
+        test_tpcds_query("q54", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard06_q55() -> Result<()> {
-        test_tpcds_query("q55").await
+        test_tpcds_query("q55", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard06_q56() -> Result<()> {
-        test_tpcds_query("q56").await
+        test_tpcds_query("q56", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard06_q57() -> Result<()> {
-        test_tpcds_query("q57").await
+        test_tpcds_query("q57", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard06_q58() -> Result<()> {
-        test_tpcds_query("q58").await
+        test_tpcds_query("q58", PerTestConfig::default()).await
     }
 
     #[tokio::test]
-    // FIXME: this test succeeds locally, but for some reason it fails on CI
-    #[ignore = "result sets were not equal: Internal error: Row counts differ: left=100, right=0"]
     async fn test_tpcds_shard06_q59() -> Result<()> {
-        test_tpcds_query("q59").await
+        test_tpcds_query("q59", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard06_q60() -> Result<()> {
-        test_tpcds_query("q60").await
+        test_tpcds_query("q60", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard07_q61() -> Result<()> {
-        test_tpcds_query("q61").await
+        test_tpcds_query("q61", PerTestConfig::default()).await
     }
 
     #[tokio::test]
-    #[ignore = "Query q62 did not get distributed"]
     async fn test_tpcds_shard07_q62() -> Result<()> {
-        test_tpcds_query("q62").await
+        test_tpcds_query("q62", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard07_q63() -> Result<()> {
-        test_tpcds_query("q63").await
+        test_tpcds_query("q63", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard07_q64() -> Result<()> {
-        test_tpcds_query("q64").await
+        test_tpcds_query("q64", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard07_q65() -> Result<()> {
-        test_tpcds_query("q65").await
+        test_tpcds_query("q65", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard07_q66() -> Result<()> {
-        test_tpcds_query("q66").await
+        test_tpcds_query("q66", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard07_q67() -> Result<()> {
-        test_tpcds_query("q67").await
+        test_tpcds_query("q67", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard07_q68() -> Result<()> {
-        test_tpcds_query("q68").await
+        test_tpcds_query("q68", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard07_q69() -> Result<()> {
-        test_tpcds_query("q69").await
+        test_tpcds_query("q69", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard07_q70() -> Result<()> {
-        test_tpcds_query("q70").await
+        test_tpcds_query("q70", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard08_q71() -> Result<()> {
-        test_tpcds_query("q71").await
+        test_tpcds_query("q71", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     // For some reason this test takes a ridiculous amount of time to execute. There might be
     // nothing wrong with it, and it just might be too heavy. The test passes, but it takes so
-    // long to execute that it's not worth the time.
-    #[ignore = "Query takes too long to execute"]
+    // long to execute that it's not worth the time. Gated behind the `slow-tests` feature.
+    #[cfg_attr(
+        not(feature = "slow-tests"),
+        ignore = "Query takes too long to execute"
+    )]
     async fn test_tpcds_shard08_q72() -> Result<()> {
-        test_tpcds_query("q72").await
+        test_tpcds_query("q72", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard08_q73() -> Result<()> {
-        test_tpcds_query("q73").await
+        test_tpcds_query("q73", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard08_q74() -> Result<()> {
-        test_tpcds_query("q74").await
+        test_tpcds_query("q74", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard08_q75() -> Result<()> {
-        test_tpcds_query("q75").await
+        test_tpcds_query("q75", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard08_q76() -> Result<()> {
-        test_tpcds_query("q76").await
+        test_tpcds_query("q76", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard08_q77() -> Result<()> {
-        test_tpcds_query("q77").await
+        test_tpcds_query("q77", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard08_q78() -> Result<()> {
-        test_tpcds_query("q78").await
+        test_tpcds_query("q78", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard08_q79() -> Result<()> {
-        test_tpcds_query("q79").await
+        test_tpcds_query("q79", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard08_q80() -> Result<()> {
-        test_tpcds_query("q80").await
+        test_tpcds_query("q80", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard09_q81() -> Result<()> {
-        test_tpcds_query("q81").await
+        test_tpcds_query("q81", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard09_q82() -> Result<()> {
-        test_tpcds_query("q82").await
+        test_tpcds_query("q82", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard09_q83() -> Result<()> {
-        test_tpcds_query("q83").await
+        test_tpcds_query("q83", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard09_q84() -> Result<()> {
-        test_tpcds_query("q84").await
+        test_tpcds_query("q84", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard09_q85() -> Result<()> {
-        test_tpcds_query("q85").await
+        test_tpcds_query("q85", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard09_q86() -> Result<()> {
-        test_tpcds_query("q86").await
+        test_tpcds_query("q86", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard09_q87() -> Result<()> {
-        test_tpcds_query("q87").await
+        test_tpcds_query("q87", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard09_q88() -> Result<()> {
-        test_tpcds_query("q88").await
+        test_tpcds_query("q88", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard09_q89() -> Result<()> {
-        test_tpcds_query("q89").await
+        test_tpcds_query("q89", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard09_q90() -> Result<()> {
-        test_tpcds_query("q90").await
+        test_tpcds_query("q90", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     #[ignore = "Query q91 did not get distributed"]
     async fn test_tpcds_shard10_q91() -> Result<()> {
-        test_tpcds_query("q91").await
+        test_tpcds_query("q91", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard10_q92() -> Result<()> {
-        test_tpcds_query("q92").await
+        test_tpcds_query("q92", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard10_q93() -> Result<()> {
-        test_tpcds_query("q93").await
+        test_tpcds_query("q93", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard10_q94() -> Result<()> {
-        test_tpcds_query("q94").await
+        test_tpcds_query("q94", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard10_q95() -> Result<()> {
-        test_tpcds_query("q95").await
+        test_tpcds_query("q95", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard10_q96() -> Result<()> {
-        test_tpcds_query("q96").await
+        test_tpcds_query("q96", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard10_q97() -> Result<()> {
-        test_tpcds_query("q97").await
+        test_tpcds_query("q97", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     async fn test_tpcds_shard10_q98() -> Result<()> {
-        test_tpcds_query("q98").await
+        test_tpcds_query("q98", PerTestConfig::default()).await
     }
 
     #[tokio::test]
     // For some reason this test takes a ridiculous amount of time to execute. There might be
     // nothing wrong with it, and it just might be too heavy. The test passes, but it takes so
-    // long to execute that it's not worth the time.
-    #[ignore = "Query takes too long to execute"]
+    // long to execute that it's not worth the time. Gated behind the `slow-tests` feature.
+    #[cfg_attr(
+        not(feature = "slow-tests"),
+        ignore = "Query takes too long to execute"
+    )]
     async fn test_tpcds_shard10_q99() -> Result<()> {
-        test_tpcds_query("q99").await
+        test_tpcds_query("q99", PerTestConfig::default()).await
     }
 
     static INIT_TEST_TPCDS_TABLES: OnceCell<()> = OnceCell::const_new();
@@ -548,7 +547,7 @@ mod tests {
         (plan.clone(), Arc::new(collect(plan, task_ctx).await)) // Collect execution errors, do not unwrap.
     }
 
-    async fn test_tpcds_query(query_id: &str) -> Result<()> {
+    async fn test_tpcds_query(query_id: &str, config: PerTestConfig) -> Result<()> {
         let data_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join(format!(
             "testdata/tpcds/correctness_sf{SF}_partitions{PARQUET_PARTITIONS}"
         ));
@@ -591,7 +590,7 @@ mod tests {
             let d_results = d_results.clone();
             let s_results = s_results.clone();
             tokio::task::spawn_blocking(move || async move {
-                compare_result_set(&d_results, &s_results)
+                compare_result_set(&d_results, &s_results, &config)
             })
         };
         let compare_ordering = {

--- a/tests/tpcds_plans_test.rs
+++ b/tests/tpcds_plans_test.rs
@@ -3438,10 +3438,109 @@ mod tests {
         Ok(())
     }
     #[tokio::test]
-    #[ignore = "Fails with column 'c_last_review_date_sk' not found"]
+    #[ignore = "fails on CI works locally"]
     async fn test_tpcds_30() -> Result<()> {
         let display = test_tpcds_query("q30").await?;
-        assert_snapshot!(display, @r"");
+        assert_snapshot!(display, @"
+        ┌───── DistributedExec ── Tasks: t0:[p0]
+        │ SortPreservingMergeExec: [c_customer_id@0 ASC, c_salutation@1 ASC, c_first_name@2 ASC, c_last_name@3 ASC, c_preferred_cust_flag@4 ASC, c_birth_day@5 ASC, c_birth_month@6 ASC, c_birth_year@7 ASC, c_birth_country@8 ASC, c_login@9 ASC, c_email_address@10 ASC, c_last_review_date_sk@11 ASC, ctr_total_return@12 ASC], fetch=100
+        │   [Stage 11] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
+        └──────────────────────────────────────────────────
+          ┌───── Stage 11 ── Tasks: t0:[p0..p2] t1:[p0..p2]
+          │ SortExec: TopK(fetch=100), expr=[c_customer_id@0 ASC, c_salutation@1 ASC, c_first_name@2 ASC, c_last_name@3 ASC, c_preferred_cust_flag@4 ASC, c_birth_day@5 ASC, c_birth_month@6 ASC, c_birth_year@7 ASC, c_birth_country@8 ASC, c_login@9 ASC, c_email_address@10 ASC, c_last_review_date_sk@11 ASC, ctr_total_return@12 ASC], preserve_partitioning=[true]
+          │   ProjectionExec: expr=[c_customer_id@1 as c_customer_id, c_salutation@2 as c_salutation, c_first_name@3 as c_first_name, c_last_name@4 as c_last_name, c_preferred_cust_flag@5 as c_preferred_cust_flag, c_birth_day@6 as c_birth_day, c_birth_month@7 as c_birth_month, c_birth_year@8 as c_birth_year, c_birth_country@9 as c_birth_country, c_login@10 as c_login, c_email_address@11 as c_email_address, c_last_review_date_sk@12 as c_last_review_date_sk, ctr_total_return@0 as ctr_total_return]
+          │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(ctr_state@0, ctr_state@1)], filter=CAST(ctr_total_return@0 AS Decimal128(30, 15)) > avg(ctr2.ctr_total_return) * Float64(1.2)@1, projection=[ctr_total_return@1, c_customer_id@2, c_salutation@3, c_first_name@4, c_last_name@5, c_preferred_cust_flag@6, c_birth_day@7, c_birth_month@8, c_birth_year@9, c_birth_country@10, c_login@11, c_email_address@12, c_last_review_date_sk@13]
+          │       CoalescePartitionsExec
+          │         [Stage 6] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=6, input_tasks=2
+          │       ProjectionExec: expr=[CAST(CAST(avg(ctr2.ctr_total_return)@1 AS Float64) * 1.2 AS Decimal128(30, 15)) as avg(ctr2.ctr_total_return) * Float64(1.2), ctr_state@0 as ctr_state]
+          │         AggregateExec: mode=FinalPartitioned, gby=[ctr_state@0 as ctr_state], aggr=[avg(ctr2.ctr_total_return)]
+          │           [Stage 10] => NetworkShuffleExec: output_partitions=3, input_tasks=1
+          └──────────────────────────────────────────────────
+            ┌───── Stage 6 ── Tasks: t0:[p0..p5] t1:[p6..p11]
+            │ BroadcastExec: input_partitions=3, consumer_tasks=2, output_partitions=6
+            │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(ca_address_sk@0, c_current_addr_sk@3)], projection=[ctr_state@1, ctr_total_return@2, c_customer_id@3, c_salutation@5, c_first_name@6, c_last_name@7, c_preferred_cust_flag@8, c_birth_day@9, c_birth_month@10, c_birth_year@11, c_birth_country@12, c_login@13, c_email_address@14, c_last_review_date_sk@15]
+            │     CoalescePartitionsExec
+            │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=6, input_tasks=2
+            │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(ctr_customer_sk@0, c_customer_sk@0)], projection=[ctr_state@1, ctr_total_return@2, c_customer_id@4, c_current_addr_sk@5, c_salutation@6, c_first_name@7, c_last_name@8, c_preferred_cust_flag@9, c_birth_day@10, c_birth_month@11, c_birth_year@12, c_birth_country@13, c_login@14, c_email_address@15, c_last_review_date_sk@16]
+            │       CoalescePartitionsExec
+            │         [Stage 5] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=6, input_tasks=1
+            │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+            │         PartitionIsolatorExec: tasks=2 partitions=4
+            │           DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/customer/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/customer/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/customer/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/customer/part-3.parquet]]}, projection=[c_customer_sk, c_customer_id, c_current_addr_sk, c_salutation, c_first_name, c_last_name, c_preferred_cust_flag, c_birth_day, c_birth_month, c_birth_year, c_birth_country, c_login, c_email_address, c_last_review_date_sk], file_type=parquet, predicate=DynamicFilter [ empty ] AND DynamicFilter [ empty ]
+            └──────────────────────────────────────────────────
+              ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p6..p11]
+              │ BroadcastExec: input_partitions=3, consumer_tasks=2, output_partitions=6
+              │   FilterExec: ca_state@1 = GA, projection=[ca_address_sk@0]
+              │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+              │       PartitionIsolatorExec: tasks=2 partitions=4
+              │         DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/customer_address/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/customer_address/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/customer_address/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/customer_address/part-3.parquet]]}, projection=[ca_address_sk, ca_state], file_type=parquet, predicate=ca_state@8 = GA, pruning_predicate=ca_state_null_count@2 != row_count@3 AND ca_state_min@0 <= GA AND GA <= ca_state_max@1, required_guarantees=[ca_state in (GA)]
+              └──────────────────────────────────────────────────
+              ┌───── Stage 5 ── Tasks: t0:[p0..p5]
+              │ BroadcastExec: input_partitions=3, consumer_tasks=2, output_partitions=6
+              │   ProjectionExec: expr=[wr_returning_customer_sk@0 as ctr_customer_sk, ca_state@1 as ctr_state, sum(web_returns.wr_return_amt)@2 as ctr_total_return]
+              │     AggregateExec: mode=FinalPartitioned, gby=[wr_returning_customer_sk@0 as wr_returning_customer_sk, ca_state@1 as ca_state], aggr=[sum(web_returns.wr_return_amt)]
+              │       [Stage 4] => NetworkShuffleExec: output_partitions=3, input_tasks=2
+              └──────────────────────────────────────────────────
+                ┌───── Stage 4 ── Tasks: t0:[p0..p2] t1:[p0..p2]
+                │ RepartitionExec: partitioning=Hash([wr_returning_customer_sk@0, ca_state@1], 3), input_partitions=3
+                │   AggregateExec: mode=Partial, gby=[wr_returning_customer_sk@0 as wr_returning_customer_sk, ca_state@2 as ca_state], aggr=[sum(web_returns.wr_return_amt)]
+                │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(wr_returning_addr_sk@1, ca_address_sk@0)], projection=[wr_returning_customer_sk@0, wr_return_amt@2, ca_state@4]
+                │       CoalescePartitionsExec
+                │         [Stage 3] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=6, input_tasks=2
+                │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+                │         PartitionIsolatorExec: tasks=2 partitions=4
+                │           DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/customer_address/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/customer_address/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/customer_address/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/customer_address/part-3.parquet]]}, projection=[ca_address_sk, ca_state], file_type=parquet, predicate=DynamicFilter [ empty ]
+                └──────────────────────────────────────────────────
+                  ┌───── Stage 3 ── Tasks: t0:[p0..p5] t1:[p6..p11]
+                  │ BroadcastExec: input_partitions=3, consumer_tasks=2, output_partitions=6
+                  │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(d_date_sk@0, wr_returned_date_sk@0)], projection=[wr_returning_customer_sk@2, wr_returning_addr_sk@3, wr_return_amt@4]
+                  │     CoalescePartitionsExec
+                  │       [Stage 2] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=6, input_tasks=2
+                  │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+                  │       PartitionIsolatorExec: tasks=2 partitions=4
+                  │         DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/web_returns/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/web_returns/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/web_returns/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/web_returns/part-3.parquet]]}, projection=[wr_returned_date_sk, wr_returning_customer_sk, wr_returning_addr_sk, wr_return_amt], file_type=parquet, predicate=DynamicFilter [ empty ]
+                  └──────────────────────────────────────────────────
+                    ┌───── Stage 2 ── Tasks: t0:[p0..p5] t1:[p6..p11]
+                    │ BroadcastExec: input_partitions=3, consumer_tasks=2, output_partitions=6
+                    │   FilterExec: d_year@1 = 2002, projection=[d_date_sk@0]
+                    │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+                    │       PartitionIsolatorExec: tasks=2 partitions=4
+                    │         DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/date_dim/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-3.parquet]]}, projection=[d_date_sk, d_year], file_type=parquet, predicate=d_year@6 = 2002, pruning_predicate=d_year_null_count@2 != row_count@3 AND d_year_min@0 <= 2002 AND 2002 <= d_year_max@1, required_guarantees=[d_year in (2002)]
+                    └──────────────────────────────────────────────────
+            ┌───── Stage 10 ── Tasks: t0:[p0..p5]
+            │ RepartitionExec: partitioning=Hash([ctr_state@0], 6), input_partitions=3
+            │   AggregateExec: mode=Partial, gby=[ctr_state@0 as ctr_state], aggr=[avg(ctr2.ctr_total_return)]
+            │     ProjectionExec: expr=[ca_state@1 as ctr_state, sum(web_returns.wr_return_amt)@2 as ctr_total_return]
+            │       AggregateExec: mode=FinalPartitioned, gby=[wr_returning_customer_sk@0 as wr_returning_customer_sk, ca_state@1 as ca_state], aggr=[sum(web_returns.wr_return_amt)]
+            │         [Stage 9] => NetworkShuffleExec: output_partitions=3, input_tasks=2
+            └──────────────────────────────────────────────────
+              ┌───── Stage 9 ── Tasks: t0:[p0..p2] t1:[p0..p2]
+              │ RepartitionExec: partitioning=Hash([wr_returning_customer_sk@0, ca_state@1], 3), input_partitions=3
+              │   AggregateExec: mode=Partial, gby=[wr_returning_customer_sk@0 as wr_returning_customer_sk, ca_state@2 as ca_state], aggr=[sum(web_returns.wr_return_amt)]
+              │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(wr_returning_addr_sk@1, ca_address_sk@0)], projection=[wr_returning_customer_sk@0, wr_return_amt@2, ca_state@4]
+              │       CoalescePartitionsExec
+              │         [Stage 8] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=6, input_tasks=2
+              │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+              │         PartitionIsolatorExec: tasks=2 partitions=4
+              │           DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/customer_address/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/customer_address/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/customer_address/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/customer_address/part-3.parquet]]}, projection=[ca_address_sk, ca_state], file_type=parquet, predicate=DynamicFilter [ empty ]
+              └──────────────────────────────────────────────────
+                ┌───── Stage 8 ── Tasks: t0:[p0..p5] t1:[p6..p11]
+                │ BroadcastExec: input_partitions=3, consumer_tasks=2, output_partitions=6
+                │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(d_date_sk@0, wr_returned_date_sk@0)], projection=[wr_returning_customer_sk@2, wr_returning_addr_sk@3, wr_return_amt@4]
+                │     CoalescePartitionsExec
+                │       [Stage 7] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=6, input_tasks=2
+                │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+                │       PartitionIsolatorExec: tasks=2 partitions=4
+                │         DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/web_returns/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/web_returns/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/web_returns/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/web_returns/part-3.parquet]]}, projection=[wr_returned_date_sk, wr_returning_customer_sk, wr_returning_addr_sk, wr_return_amt], file_type=parquet, predicate=DynamicFilter [ empty ]
+                └──────────────────────────────────────────────────
+                  ┌───── Stage 7 ── Tasks: t0:[p0..p5] t1:[p6..p11]
+                  │ BroadcastExec: input_partitions=3, consumer_tasks=2, output_partitions=6
+                  │   FilterExec: d_year@1 = 2002, projection=[d_date_sk@0]
+                  │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+                  │       PartitionIsolatorExec: tasks=2 partitions=4
+                  │         DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/date_dim/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-3.parquet]]}, projection=[d_date_sk, d_year], file_type=parquet, predicate=d_year@6 = 2002, pruning_predicate=d_year_null_count@2 != row_count@3 AND d_year_min@0 <= 2002 AND 2002 <= d_year_max@1, required_guarantees=[d_year in (2002)]
+                  └──────────────────────────────────────────────────
+        ");
         Ok(())
     }
     #[tokio::test]
@@ -7557,10 +7656,87 @@ mod tests {
         Ok(())
     }
     #[tokio::test]
-    #[ignore = "The ordering of the column names in the first nodes is non deterministickI"]
+    #[ignore = "Flaky plan: q70's ROLLUP emits two `grouping()` columns in non-deterministic order (HashMap-driven projection layout), so column indices @5/@6 swap run-to-run. Snapshot regen alone won't stabilize it."]
     async fn test_tpcds_70() -> Result<()> {
         let display = test_tpcds_query("q70").await?;
-        assert_snapshot!(display, @r#""#);
+        assert_snapshot!(display, @r#"
+        ┌───── DistributedExec ── Tasks: t0:[p0]
+        │ ProjectionExec: expr=[total_sum@0 as total_sum, s_state@1 as s_state, s_county@2 as s_county, lochierarchy@3 as lochierarchy, rank_within_parent@4 as rank_within_parent]
+        │   SortPreservingMergeExec: [lochierarchy@3 DESC, CASE WHEN grouping(store.s_state)@6 + grouping(store.s_county)@5 = 0 THEN s_state@1 END ASC NULLS LAST, rank_within_parent@4 ASC NULLS LAST], fetch=100
+        │     SortExec: TopK(fetch=100), expr=[lochierarchy@3 DESC, CASE WHEN grouping(store.s_state)@6 + grouping(store.s_county)@5 = 0 THEN s_state@1 END ASC NULLS LAST, rank_within_parent@4 ASC NULLS LAST], preserve_partitioning=[true]
+        │       ProjectionExec: expr=[sum(store_sales.ss_net_profit)@2 as total_sum, s_state@0 as s_state, s_county@1 as s_county, grouping(store.s_state)@3 + grouping(store.s_county)@4 as lochierarchy, rank() PARTITION BY [grouping(store.s_state) + grouping(store.s_county), CASE WHEN grouping(store.s_county) = Int64(0) THEN store.s_state END] ORDER BY [sum(store_sales.ss_net_profit) DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW@5 as rank_within_parent, grouping(store.s_county)@4 as grouping(store.s_county), grouping(store.s_state)@3 as grouping(store.s_state)]
+        │         BoundedWindowAggExec: wdw=[rank() PARTITION BY [grouping(store.s_state) + grouping(store.s_county), CASE WHEN grouping(store.s_county) = Int64(0) THEN store.s_state END] ORDER BY [sum(store_sales.ss_net_profit) DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW: Field { "rank() PARTITION BY [grouping(store.s_state) + grouping(store.s_county), CASE WHEN grouping(store.s_county) = Int64(0) THEN store.s_state END] ORDER BY [sum(store_sales.ss_net_profit) DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW": UInt64 }, frame: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], mode=[Sorted]
+        │           SortExec: expr=[grouping(store.s_state)@3 + grouping(store.s_county)@4 ASC NULLS LAST, CASE WHEN grouping(store.s_county)@4 = 0 THEN s_state@0 END ASC NULLS LAST, sum(store_sales.ss_net_profit)@2 DESC], preserve_partitioning=[true]
+        │             [Stage 8] => NetworkShuffleExec: output_partitions=3, input_tasks=2
+        └──────────────────────────────────────────────────
+          ┌───── Stage 8 ── Tasks: t0:[p0..p2] t1:[p0..p2]
+          │ RepartitionExec: partitioning=Hash([grouping(store.s_state)@3 + grouping(store.s_county)@4, CASE WHEN grouping(store.s_county)@4 = 0 THEN s_state@0 END], 3), input_partitions=3
+          │   ProjectionExec: expr=[s_state@0 as s_state, s_county@1 as s_county, sum(store_sales.ss_net_profit)@3 as sum(store_sales.ss_net_profit), CAST(__grouping_id@2 & 2 >> 1 AS Int32) as grouping(store.s_state), CAST(__grouping_id@2 & 1 AS Int32) as grouping(store.s_county)]
+          │     AggregateExec: mode=FinalPartitioned, gby=[s_state@0 as s_state, s_county@1 as s_county, __grouping_id@2 as __grouping_id], aggr=[sum(store_sales.ss_net_profit)]
+          │       [Stage 7] => NetworkShuffleExec: output_partitions=3, input_tasks=3
+          └──────────────────────────────────────────────────
+            ┌───── Stage 7 ── Tasks: t0:[p0..p5] t1:[p0..p5] t2:[p0..p5]
+            │ RepartitionExec: partitioning=Hash([s_state@0, s_county@1, __grouping_id@2], 6), input_partitions=3
+            │   AggregateExec: mode=Partial, gby=[(NULL as s_state, NULL as s_county), (s_state@2 as s_state, NULL as s_county), (s_state@2 as s_state, s_county@1 as s_county)], aggr=[sum(store_sales.ss_net_profit)]
+            │     HashJoinExec: mode=Partitioned, join_type=LeftSemi, on=[(s_state@2, s_state@0)]
+            │       [Stage 3] => NetworkShuffleExec: output_partitions=3, input_tasks=3
+            │       FilterExec: rank() PARTITION BY [store.s_state] ORDER BY [sum(store_sales.ss_net_profit) DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW@1 <= 5, projection=[s_state@0]
+            │         ProjectionExec: expr=[s_state@0 as s_state, rank() PARTITION BY [store.s_state] ORDER BY [sum(store_sales.ss_net_profit) DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW@2 as rank() PARTITION BY [store.s_state] ORDER BY [sum(store_sales.ss_net_profit) DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW]
+            │           BoundedWindowAggExec: wdw=[rank() PARTITION BY [store.s_state] ORDER BY [sum(store_sales.ss_net_profit) DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW: Field { "rank() PARTITION BY [store.s_state] ORDER BY [sum(store_sales.ss_net_profit) DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW": UInt64 }, frame: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], mode=[Sorted]
+            │             SortExec: expr=[s_state@0 ASC NULLS LAST, sum(store_sales.ss_net_profit)@1 DESC], preserve_partitioning=[true]
+            │               AggregateExec: mode=FinalPartitioned, gby=[s_state@0 as s_state], aggr=[sum(store_sales.ss_net_profit)]
+            │                 [Stage 6] => NetworkShuffleExec: output_partitions=3, input_tasks=3
+            └──────────────────────────────────────────────────
+              ┌───── Stage 3 ── Tasks: t0:[p0..p8] t1:[p0..p8] t2:[p0..p8]
+              │ RepartitionExec: partitioning=Hash([s_state@2], 9), input_partitions=2
+              │   ProjectionExec: expr=[ss_net_profit@2 as ss_net_profit, s_county@0 as s_county, s_state@1 as s_state]
+              │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(s_store_sk@0, ss_store_sk@0)], projection=[s_county@1, s_state@2, ss_net_profit@4]
+              │       CoalescePartitionsExec
+              │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=6, input_tasks=2
+              │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(d_date_sk@0, ss_sold_date_sk@0)], projection=[ss_store_sk@2, ss_net_profit@3]
+              │         CoalescePartitionsExec
+              │           [Stage 2] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=9, input_tasks=2
+              │         PartitionIsolatorExec: tasks=3 partitions=6
+              │           DataSourceExec: file_groups={6 groups: [[/testdata/tpcds/plans_sf1_partitions4/store_sales/part-0.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>], ...]}, projection=[ss_sold_date_sk, ss_store_sk, ss_net_profit], file_type=parquet, predicate=DynamicFilter [ empty ] AND DynamicFilter [ empty ]
+              └──────────────────────────────────────────────────
+                ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p6..p11]
+                │ BroadcastExec: input_partitions=2, consumer_tasks=3, output_partitions=6
+                │   PartitionIsolatorExec: tasks=2 partitions=4
+                │     DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/store/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/store/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/store/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/store/part-3.parquet]]}, projection=[s_store_sk, s_county, s_state], file_type=parquet
+                └──────────────────────────────────────────────────
+                ┌───── Stage 2 ── Tasks: t0:[p0..p8] t1:[p9..p17]
+                │ BroadcastExec: input_partitions=3, consumer_tasks=3, output_partitions=9
+                │   FilterExec: d_month_seq@1 >= 1200 AND d_month_seq@1 <= 1211, projection=[d_date_sk@0]
+                │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+                │       PartitionIsolatorExec: tasks=2 partitions=4
+                │         DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/date_dim/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-3.parquet]]}, projection=[d_date_sk, d_month_seq], file_type=parquet, predicate=d_month_seq@3 >= 1200 AND d_month_seq@3 <= 1211, pruning_predicate=d_month_seq_null_count@1 != row_count@2 AND d_month_seq_max@0 >= 1200 AND d_month_seq_null_count@1 != row_count@2 AND d_month_seq_min@3 <= 1211, required_guarantees=[]
+                └──────────────────────────────────────────────────
+              ┌───── Stage 6 ── Tasks: t0:[p0..p8] t1:[p0..p8] t2:[p0..p8]
+              │ RepartitionExec: partitioning=Hash([s_state@0], 9), input_partitions=2
+              │   AggregateExec: mode=Partial, gby=[s_state@1 as s_state], aggr=[sum(store_sales.ss_net_profit)]
+              │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(d_date_sk@0, ss_sold_date_sk@0)], projection=[ss_net_profit@2, s_state@3]
+              │       CoalescePartitionsExec
+              │         [Stage 4] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=9, input_tasks=2
+              │       ProjectionExec: expr=[ss_sold_date_sk@1 as ss_sold_date_sk, ss_net_profit@2 as ss_net_profit, s_state@0 as s_state]
+              │         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(s_store_sk@0, ss_store_sk@1)], projection=[s_state@1, ss_sold_date_sk@2, ss_net_profit@4]
+              │           CoalescePartitionsExec
+              │             [Stage 5] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=6, input_tasks=2
+              │           PartitionIsolatorExec: tasks=3 partitions=6
+              │             DataSourceExec: file_groups={6 groups: [[/testdata/tpcds/plans_sf1_partitions4/store_sales/part-0.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>], ...]}, projection=[ss_sold_date_sk, ss_store_sk, ss_net_profit], file_type=parquet, predicate=DynamicFilter [ empty ] AND DynamicFilter [ empty ]
+              └──────────────────────────────────────────────────
+                ┌───── Stage 4 ── Tasks: t0:[p0..p8] t1:[p9..p17]
+                │ BroadcastExec: input_partitions=3, consumer_tasks=3, output_partitions=9
+                │   FilterExec: d_month_seq@1 >= 1200 AND d_month_seq@1 <= 1211, projection=[d_date_sk@0]
+                │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+                │       PartitionIsolatorExec: tasks=2 partitions=4
+                │         DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/date_dim/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-3.parquet]]}, projection=[d_date_sk, d_month_seq], file_type=parquet, predicate=d_month_seq@3 >= 1200 AND d_month_seq@3 <= 1211, pruning_predicate=d_month_seq_null_count@1 != row_count@2 AND d_month_seq_max@0 >= 1200 AND d_month_seq_null_count@1 != row_count@2 AND d_month_seq_min@3 <= 1211, required_guarantees=[]
+                └──────────────────────────────────────────────────
+                ┌───── Stage 5 ── Tasks: t0:[p0..p5] t1:[p6..p11]
+                │ BroadcastExec: input_partitions=2, consumer_tasks=3, output_partitions=6
+                │   PartitionIsolatorExec: tasks=2 partitions=4
+                │     DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/store/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/store/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/store/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/store/part-3.parquet]]}, projection=[s_store_sk, s_state], file_type=parquet
+                └──────────────────────────────────────────────────
+        "#);
         Ok(())
     }
     #[tokio::test]
@@ -9428,10 +9604,51 @@ mod tests {
         Ok(())
     }
     #[tokio::test]
-    #[ignore = "The ordering of the column names in the first nodes is non deterministickI"]
+    #[ignore = "Flaky plan: q86's ROLLUP emits two `grouping()` columns in non-deterministic order (HashMap-driven projection layout), so column indices @5/@6 swap run-to-run. Snapshot regen alone won't stabilize it."]
     async fn test_tpcds_86() -> Result<()> {
         let display = test_tpcds_query("q86").await?;
-        assert_snapshot!(display, @r#""#);
+        assert_snapshot!(display, @r#"
+        ┌───── DistributedExec ── Tasks: t0:[p0]
+        │ ProjectionExec: expr=[total_sum@0 as total_sum, i_category@1 as i_category, i_class@2 as i_class, lochierarchy@3 as lochierarchy, rank_within_parent@4 as rank_within_parent]
+        │   SortPreservingMergeExec: [lochierarchy@3 DESC, CASE WHEN grouping(item.i_category)@6 + grouping(item.i_class)@5 = 0 THEN i_category@1 END ASC, rank_within_parent@4 ASC], fetch=100
+        │     SortExec: TopK(fetch=100), expr=[lochierarchy@3 DESC, CASE WHEN grouping(item.i_category)@6 + grouping(item.i_class)@5 = 0 THEN i_category@1 END ASC, rank_within_parent@4 ASC], preserve_partitioning=[true]
+        │       ProjectionExec: expr=[sum(web_sales.ws_net_paid)@2 as total_sum, i_category@0 as i_category, i_class@1 as i_class, grouping(item.i_category)@3 + grouping(item.i_class)@4 as lochierarchy, rank() PARTITION BY [grouping(item.i_category) + grouping(item.i_class), CASE WHEN grouping(item.i_class) = Int64(0) THEN item.i_category END] ORDER BY [sum(web_sales.ws_net_paid) DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW@5 as rank_within_parent, grouping(item.i_class)@4 as grouping(item.i_class), grouping(item.i_category)@3 as grouping(item.i_category)]
+        │         BoundedWindowAggExec: wdw=[rank() PARTITION BY [grouping(item.i_category) + grouping(item.i_class), CASE WHEN grouping(item.i_class) = Int64(0) THEN item.i_category END] ORDER BY [sum(web_sales.ws_net_paid) DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW: Field { "rank() PARTITION BY [grouping(item.i_category) + grouping(item.i_class), CASE WHEN grouping(item.i_class) = Int64(0) THEN item.i_category END] ORDER BY [sum(web_sales.ws_net_paid) DESC NULLS FIRST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW": UInt64 }, frame: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], mode=[Sorted]
+        │           SortExec: expr=[grouping(item.i_category)@3 + grouping(item.i_class)@4 ASC NULLS LAST, CASE WHEN grouping(item.i_class)@4 = 0 THEN i_category@0 END ASC NULLS LAST, sum(web_sales.ws_net_paid)@2 DESC], preserve_partitioning=[true]
+        │             [Stage 4] => NetworkShuffleExec: output_partitions=3, input_tasks=2
+        └──────────────────────────────────────────────────
+          ┌───── Stage 4 ── Tasks: t0:[p0..p2] t1:[p0..p2]
+          │ RepartitionExec: partitioning=Hash([grouping(item.i_category)@3 + grouping(item.i_class)@4, CASE WHEN grouping(item.i_class)@4 = 0 THEN i_category@0 END], 3), input_partitions=3
+          │   ProjectionExec: expr=[i_category@0 as i_category, i_class@1 as i_class, sum(web_sales.ws_net_paid)@3 as sum(web_sales.ws_net_paid), CAST(__grouping_id@2 & 2 >> 1 AS Int32) as grouping(item.i_category), CAST(__grouping_id@2 & 1 AS Int32) as grouping(item.i_class)]
+          │     AggregateExec: mode=FinalPartitioned, gby=[i_category@0 as i_category, i_class@1 as i_class, __grouping_id@2 as __grouping_id], aggr=[sum(web_sales.ws_net_paid)]
+          │       [Stage 3] => NetworkShuffleExec: output_partitions=3, input_tasks=3
+          └──────────────────────────────────────────────────
+            ┌───── Stage 3 ── Tasks: t0:[p0..p5] t1:[p0..p5] t2:[p0..p5]
+            │ RepartitionExec: partitioning=Hash([i_category@0, i_class@1, __grouping_id@2], 6), input_partitions=2
+            │   AggregateExec: mode=Partial, gby=[(NULL as i_category, NULL as i_class), (i_category@2 as i_category, NULL as i_class), (i_category@2 as i_category, i_class@1 as i_class)], aggr=[sum(web_sales.ws_net_paid)]
+            │     ProjectionExec: expr=[ws_net_paid@2 as ws_net_paid, i_class@0 as i_class, i_category@1 as i_category]
+            │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(i_item_sk@0, ws_item_sk@0)], projection=[i_class@1, i_category@2, ws_net_paid@4]
+            │         CoalescePartitionsExec
+            │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=6, input_tasks=2
+            │         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(d_date_sk@0, ws_sold_date_sk@0)], projection=[ws_item_sk@2, ws_net_paid@3]
+            │           CoalescePartitionsExec
+            │             [Stage 2] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=9, input_tasks=2
+            │           PartitionIsolatorExec: tasks=3 partitions=6
+            │             DataSourceExec: file_groups={6 groups: [[/testdata/tpcds/plans_sf1_partitions4/web_sales/part-0.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-2.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-2.parquet:<int>..<int>], ...]}, projection=[ws_sold_date_sk, ws_item_sk, ws_net_paid], file_type=parquet, predicate=DynamicFilter [ empty ] AND DynamicFilter [ empty ]
+            └──────────────────────────────────────────────────
+              ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p6..p11]
+              │ BroadcastExec: input_partitions=2, consumer_tasks=3, output_partitions=6
+              │   PartitionIsolatorExec: tasks=2 partitions=4
+              │     DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/item/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/item/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/item/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/item/part-3.parquet]]}, projection=[i_item_sk, i_class, i_category], file_type=parquet
+              └──────────────────────────────────────────────────
+              ┌───── Stage 2 ── Tasks: t0:[p0..p8] t1:[p9..p17]
+              │ BroadcastExec: input_partitions=3, consumer_tasks=3, output_partitions=9
+              │   FilterExec: d_month_seq@1 >= 1200 AND d_month_seq@1 <= 1211, projection=[d_date_sk@0]
+              │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+              │       PartitionIsolatorExec: tasks=2 partitions=4
+              │         DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/date_dim/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-3.parquet]]}, projection=[d_date_sk, d_month_seq], file_type=parquet, predicate=d_month_seq@3 >= 1200 AND d_month_seq@3 <= 1211, pruning_predicate=d_month_seq_null_count@1 != row_count@2 AND d_month_seq_max@0 >= 1200 AND d_month_seq_null_count@1 != row_count@2 AND d_month_seq_min@3 <= 1211, required_guarantees=[]
+              └──────────────────────────────────────────────────
+        "#);
         Ok(())
     }
     #[tokio::test]


### PR DESCRIPTION
see #451
color codes original ignored test
<img width="1308" height="580" alt="Image 5-13-26 at 2 28 PM" src="https://github.com/user-attachments/assets/2c41a9b5-33b4-44cc-8f58-090807b56e1f" />
<img width="1688" height="1220" alt="Image 5-13-26 at 2 28 PM (1)" src="https://github.com/user-attachments/assets/1fc41078-d32a-4dd5-ad26-6073004d51a5" />

### change log
- Added PerTestConfig in src/test_utils/property_based.rs with two booleans:
    - uses_undeterministic_limit_operator — LIMIT without ORDER BY (q17).
    - non_deterministic_sort — ORDER BY with unbroken ties at the LIMIT boundary (q21, q22, q24, q31, q32).
  - compare_result_set takes &PerTestConfig and short-circuits to Ok(()) when either flag is set, with a comment explaining that a strict set comparison would false-positive on SQL-legal answer variation.
  - Each call site is now explicit; only flagged queries opt out.
  - Threaded the same param through test_tpcds_query for symmetry; all tpcds correctness call sites pass PerTestConfig::default().

 Clickbench correctness q3 : shifted precision back by one digit. [see comment for details](https://github.com/datafusion-contrib/datafusion-distributed/pull/452/changes#diff-ff8aabeb67bceb6ab0a320cf9c644092c802c3c24b0246d5a6d549a17115f7d6R221)
 q0 & q6 are still ignored because datafusions planner is smart enough to resolve the answer through statistics.
 
### Still ignored (3)

- Clickbench q42 : compare_ordering reports LexOrdering PartialEq inequality even though the Debug output is byte-identical on both sides. fields are missing that are needed to debug. the current diff shows identical structs even though the comparison fails
- TPCDs q70 & q86 : GROUP BY rollup(s_state, s_county) with two grouping() calls in the projection. The trailing two projection columns swap positions between runs because the planner iterates a HashMap to figure out which columns the rank window function needs. That swap propagates upward through SortExec / SortPreservingMergeExec as @5/@6 index flips. these are very flaky and it flips between passing and failing
- TPCDs q30 - this works locally & fails on the CI, it might make sense to change the query to match [what was done in upstream datafusion](https://github.com/apache/datafusion/pull/22086) I.E changing the query. Will wait for @gabotechs thoughts on this.
