### PR TITLE
Add reproducer tests for ChildrenIsolatorUnionExec bug

### DIFF
--- a/tests/distributed_unions.rs
+++ b/tests/distributed_unions.rs
@@ -177,6 +177,102 @@ mod tests {
         exact_same_data(ctx.task_ctx(), physical, physical_distributed).await
     }
 
+    #[tokio::test]
+    async fn nested_unions() -> Result<(), Box<dyn Error>> {
+        let (ctx_distributed, _guard, _) = start_localhost_context(3, DefaultSessionBuilder).await;
+
+        // The LIMIT on the inner subqueries prevents the logical optimizer from
+        // flattening the nested `UNION ALL`s into a single `Union`, so the resulting
+        // physical plan contains a `UnionExec` whose child is another `UnionExec`.
+        let query = r#"
+        SELECT * FROM (
+            SELECT "MinTemp", "RainToday" FROM weather WHERE "MinTemp" > 10.0
+            UNION ALL
+            SELECT "MaxTemp", "RainToday" FROM weather WHERE "MaxTemp" < 30.0
+            LIMIT 1000000
+        )
+        UNION ALL
+        SELECT * FROM (
+            SELECT "Temp9am", "RainToday" FROM weather WHERE "Temp9am" > 15.0
+            UNION ALL
+            SELECT "Temp3pm", "RainToday" FROM weather WHERE "Temp3pm" < 25.0
+            LIMIT 1000000
+        )
+        ORDER BY "MinTemp", "RainToday"
+        "#;
+
+        let ctx = SessionContext::default();
+        *ctx.state_ref().write().config_mut() = ctx_distributed.copied_config();
+        register_parquet_tables(&ctx).await?;
+        let df = ctx.sql(query).await?;
+        let physical = df.create_physical_plan().await?;
+
+        register_parquet_tables(&ctx_distributed).await?;
+        ctx_distributed
+            .sql("SET distributed.children_isolator_unions=true;")
+            .await?;
+        let df_distributed = ctx_distributed.sql(query).await?;
+        let physical_distributed = df_distributed.create_physical_plan().await?;
+        let physical_distributed_str = display_plan_ascii(physical_distributed.as_ref(), false);
+
+        assert_snapshot!(physical_distributed_str,
+            @r"
+        ┌───── DistributedExec ── Tasks: t0:[p0]
+        │ SortPreservingMergeExec: [MinTemp@0 ASC NULLS LAST, RainToday@1 ASC NULLS LAST]
+        │   [Stage 7] => NetworkCoalesceExec: output_partitions=2, input_tasks=2
+        └──────────────────────────────────────────────────
+          ┌───── Stage 7 ── Tasks: t0:[p0] t1:[p1]
+          │ DistributedUnionExec: t0:[c0] t1:[c1]
+          │   SortExec: TopK(fetch=1000000), expr=[MinTemp@0 ASC NULLS LAST, RainToday@1 ASC NULLS LAST], preserve_partitioning=[false]
+          │     CoalescePartitionsExec
+          │       [Stage 3] => NetworkCoalesceExec: output_partitions=2, input_tasks=2
+          │   SortExec: expr=[MinTemp@0 ASC NULLS LAST, RainToday@1 ASC NULLS LAST], preserve_partitioning=[false]
+          │     ProjectionExec: expr=[Temp9am@0 as MinTemp, RainToday@1 as RainToday]
+          │       CoalescePartitionsExec: fetch=1000000
+          │         [Stage 6] => NetworkCoalesceExec: output_partitions=2, input_tasks=2
+          └──────────────────────────────────────────────────
+            ┌───── Stage 3 ── Tasks: t0:[p0] t1:[p1]
+            │ DistributedUnionExec: t0:[c0] t1:[c1]
+            │   CoalescePartitionsExec: fetch=1000000
+            │     [Stage 1] => NetworkCoalesceExec: output_partitions=3, input_tasks=3
+            │   ProjectionExec: expr=[MaxTemp@0 as MinTemp, RainToday@1 as RainToday]
+            │     CoalescePartitionsExec: fetch=1000000
+            │       [Stage 2] => NetworkCoalesceExec: output_partitions=3, input_tasks=3
+            └──────────────────────────────────────────────────
+              ┌───── Stage 1 ── Tasks: t0:[p0] t1:[p1] t2:[p2]
+              │ FilterExec: MinTemp@0 > 10, fetch=1000000
+              │   PartitionIsolatorExec: tasks=3 partitions=3
+              │     DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, RainToday], file_type=parquet, predicate=MinTemp@0 > 10 AND DynamicFilter [ empty ], pruning_predicate=MinTemp_null_count@1 != row_count@2 AND MinTemp_max@0 > 10, required_guarantees=[]
+              └──────────────────────────────────────────────────
+              ┌───── Stage 2 ── Tasks: t0:[p0] t1:[p1] t2:[p2]
+              │ FilterExec: MaxTemp@0 < 30, fetch=1000000
+              │   PartitionIsolatorExec: tasks=3 partitions=3
+              │     DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MaxTemp, RainToday], file_type=parquet, predicate=MaxTemp@1 < 30 AND DynamicFilter [ empty ], pruning_predicate=MaxTemp_null_count@1 != row_count@2 AND MaxTemp_min@0 < 30, required_guarantees=[]
+              └──────────────────────────────────────────────────
+            ┌───── Stage 6 ── Tasks: t0:[p0] t1:[p1]
+            │ DistributedUnionExec: t0:[c0] t1:[c1]
+            │   CoalescePartitionsExec: fetch=1000000
+            │     [Stage 4] => NetworkCoalesceExec: output_partitions=3, input_tasks=3
+            │   ProjectionExec: expr=[Temp3pm@0 as Temp9am, RainToday@1 as RainToday]
+            │     CoalescePartitionsExec: fetch=1000000
+            │       [Stage 5] => NetworkCoalesceExec: output_partitions=3, input_tasks=3
+            └──────────────────────────────────────────────────
+              ┌───── Stage 4 ── Tasks: t0:[p0] t1:[p1] t2:[p2]
+              │ FilterExec: Temp9am@0 > 15, fetch=1000000
+              │   PartitionIsolatorExec: tasks=3 partitions=3
+              │     DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[Temp9am, RainToday], file_type=parquet, predicate=Temp9am@17 > 15, pruning_predicate=Temp9am_null_count@1 != row_count@2 AND Temp9am_max@0 > 15, required_guarantees=[]
+              └──────────────────────────────────────────────────
+              ┌───── Stage 5 ── Tasks: t0:[p0] t1:[p1] t2:[p2]
+              │ FilterExec: Temp3pm@0 < 25, fetch=1000000
+              │   PartitionIsolatorExec: tasks=3 partitions=3
+              │     DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[Temp3pm, RainToday], file_type=parquet, predicate=Temp3pm@18 < 25, pruning_predicate=Temp3pm_null_count@1 != row_count@2 AND Temp3pm_min@0 < 25, required_guarantees=[]
+              └──────────────────────────────────────────────────
+        ",
+        );
+
+        exact_same_data(ctx.task_ctx(), physical, physical_distributed).await
+    }
+
     async fn exact_same_data(
         task_ctx: Arc<TaskContext>,
         one: Arc<dyn ExecutionPlan>,

--- a/tests/work_unit_feed.rs
+++ b/tests/work_unit_feed.rs
@@ -802,8 +802,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn nested_union_budget_exceeds_children_sum() {
-        let res = run_query(
+    #[ignore = "ChildrenIsolatorUnionExec had a task count 3, which is greater than the sum of child task counts 2"]
+    async fn nested_union_budget_exceeds_children_sum() -> Result<(), Box<dyn std::error::Error>> {
+        let (plan, results) = run_query(
             r#"
             SET distributed.broadcast_joins = true;
             SELECT b.tag, a.tag
@@ -813,19 +814,50 @@ mod tests {
                 UNION ALL
                 SELECT * FROM test_work_unit('small_b', 1, 'rows(1)', 'rows(1)', 'rows(1)')
             ) a ON a.letter = b.letter
+            ORDER BY a.tag, b.tag
             "#,
         )
-        .await;
+        .await?;
 
-        let err = res.expect_err(
-            "expected the planner to reject the inconsistent CIU input (budget > children sum)",
-        );
-        let msg = err.to_string();
-        assert!(
-            msg.contains("ChildrenIsolatorUnionExec had a task count")
-                && msg.contains("greater than the sum of child task counts"),
-            "unexpected error message: {msg}"
-        );
+        assert_snapshot!(plan + &results, @r"
+        ┌───── DistributedExec ── Tasks: t0:[p0]
+        │ SortPreservingMergeExec: [tag@1 ASC NULLS LAST, tag@0 ASC NULLS LAST]
+        │   [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+        └──────────────────────────────────────────────────
+          ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+          │ SortExec: expr=[tag@1 ASC NULLS LAST, tag@0 ASC NULLS LAST], preserve_partitioning=[true]
+          │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(letter@1, letter@1)], projection=[tag@0, tag@2]
+          │     CoalescePartitionsExec
+          │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=3
+          │     DistributedUnionExec: t0:[c0(0/2)] t1:[c0(1/2)] t2:[c1]
+          │       RowGeneratorExec: tag=small_a, tasks=1, partition_ops=[[rows(1)], [rows(1)], [rows(1)]]
+          │       RowGeneratorExec: tag=small_b, tasks=1, partition_ops=[[rows(1)], [rows(1)], [rows(1)]]
+          └──────────────────────────────────────────────────
+            ┌───── Stage 1 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+            │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+            │   RowGeneratorExec: tag=big, tasks=4, partition_ops=[[rows(1)], [rows(1)], [rows(1)], [rows(1)]]
+            └──────────────────────────────────────────────────
+        +-----+---------+
+        | tag | tag     |
+        +-----+---------+
+        | big | small_a |
+        | big | small_a |
+        | big | small_a |
+        | big | small_a |
+        | big | small_a |
+        | big | small_a |
+        | big | small_b |
+        | big | small_b |
+        | big | small_b |
+        | big | small_b |
+        | big | small_b |
+        | big | small_b |
+        | big | small_b |
+        | big | small_b |
+        | big | small_b |
+        +-----+---------+
+        ");
+        Ok(())
     }
 
     async fn run_query(sql: &str) -> Result<(String, String), DataFusionError> {

--- a/tests/work_unit_feed.rs
+++ b/tests/work_unit_feed.rs
@@ -360,6 +360,108 @@ mod tests {
         Ok(())
     }
 
+    /// Two `UNION ALL`s nested under an outer `UNION ALL`. A `LIMIT` on each inner
+    /// subquery prevents the logical optimizer from flattening them, so the physical
+    /// plan ends up with `DistributedUnionExec` stages whose inputs are themselves
+    /// `DistributedUnionExec` stages — each leaf still backed by an independent feed.
+    #[tokio::test]
+    async fn nested_unions_of_feeds() -> Result<(), Box<dyn std::error::Error>> {
+        let (plan, results) = run_query(
+            r#"
+            SELECT * FROM (
+                SELECT * FROM test_work_unit('a', 2, 'rows(2)', 'rows(1)', 'rows(1)', 'rows(2)')
+                UNION ALL
+                SELECT * FROM test_work_unit('b', 2, 'rows(1)', 'rows(2)', 'rows(2)', 'rows(1)')
+                LIMIT 1000000
+            )
+            UNION ALL
+            SELECT * FROM (
+                SELECT * FROM test_work_unit('c', 2, 'rows(3)', 'rows(1)', 'rows(1)', 'rows(2)')
+                UNION ALL
+                SELECT * FROM test_work_unit('d', 2, 'rows(1)', 'rows(1)', 'rows(2)', 'rows(1)')
+                LIMIT 1000000
+            )
+            ORDER BY tag, task, partition, letter
+        "#,
+        )
+        .await?;
+
+        assert_snapshot!(plan + &results, @r"
+        ┌───── DistributedExec ── Tasks: t0:[p0]
+        │ SortPreservingMergeExec: [tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST]
+        │   [Stage 7] => NetworkCoalesceExec: output_partitions=2, input_tasks=2
+        └──────────────────────────────────────────────────
+          ┌───── Stage 7 ── Tasks: t0:[p0] t1:[p1]
+          │ DistributedUnionExec: t0:[c0] t1:[c1]
+          │   SortExec: TopK(fetch=1000000), expr=[tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[false]
+          │     CoalescePartitionsExec
+          │       [Stage 3] => NetworkCoalesceExec: output_partitions=2, input_tasks=2
+          │   SortExec: TopK(fetch=1000000), expr=[tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[false]
+          │     CoalescePartitionsExec
+          │       [Stage 6] => NetworkCoalesceExec: output_partitions=2, input_tasks=2
+          └──────────────────────────────────────────────────
+            ┌───── Stage 3 ── Tasks: t0:[p0] t1:[p1]
+            │ DistributedUnionExec: t0:[c0] t1:[c1]
+            │   CoalescePartitionsExec: fetch=1000000
+            │     [Stage 1] => NetworkCoalesceExec: output_partitions=4, input_tasks=2
+            │   CoalescePartitionsExec: fetch=1000000
+            │     [Stage 2] => NetworkCoalesceExec: output_partitions=4, input_tasks=2
+            └──────────────────────────────────────────────────
+              ┌───── Stage 1 ── Tasks: t0:[p0..p1] t1:[p2..p3]
+              │ LocalLimitExec: fetch=1000000
+              │   RowGeneratorExec: tag=a, tasks=2, partition_ops=[[rows(2)], [rows(1)], [rows(1)], [rows(2)]]
+              └──────────────────────────────────────────────────
+              ┌───── Stage 2 ── Tasks: t0:[p0..p1] t1:[p2..p3]
+              │ LocalLimitExec: fetch=1000000
+              │   RowGeneratorExec: tag=b, tasks=2, partition_ops=[[rows(1)], [rows(2)], [rows(2)], [rows(1)]]
+              └──────────────────────────────────────────────────
+            ┌───── Stage 6 ── Tasks: t0:[p0] t1:[p1]
+            │ DistributedUnionExec: t0:[c0] t1:[c1]
+            │   CoalescePartitionsExec: fetch=1000000
+            │     [Stage 4] => NetworkCoalesceExec: output_partitions=4, input_tasks=2
+            │   CoalescePartitionsExec: fetch=1000000
+            │     [Stage 5] => NetworkCoalesceExec: output_partitions=4, input_tasks=2
+            └──────────────────────────────────────────────────
+              ┌───── Stage 4 ── Tasks: t0:[p0..p1] t1:[p2..p3]
+              │ LocalLimitExec: fetch=1000000
+              │   RowGeneratorExec: tag=c, tasks=2, partition_ops=[[rows(3)], [rows(1)], [rows(1)], [rows(2)]]
+              └──────────────────────────────────────────────────
+              ┌───── Stage 5 ── Tasks: t0:[p0..p1] t1:[p2..p3]
+              │ LocalLimitExec: fetch=1000000
+              │   RowGeneratorExec: tag=d, tasks=2, partition_ops=[[rows(1)], [rows(1)], [rows(2)], [rows(1)]]
+              └──────────────────────────────────────────────────
+        +-----+------+-----------+--------+
+        | tag | task | partition | letter |
+        +-----+------+-----------+--------+
+        | a   | 0    | 0         | a      |
+        | a   | 0    | 0         | b      |
+        | a   | 0    | 1         | a      |
+        | a   | 1    | 0         | a      |
+        | a   | 1    | 1         | a      |
+        | a   | 1    | 1         | b      |
+        | b   | 0    | 0         | a      |
+        | b   | 0    | 1         | a      |
+        | b   | 0    | 1         | b      |
+        | b   | 1    | 0         | a      |
+        | b   | 1    | 0         | b      |
+        | b   | 1    | 1         | a      |
+        | c   | 0    | 0         | a      |
+        | c   | 0    | 0         | b      |
+        | c   | 0    | 0         | c      |
+        | c   | 0    | 1         | a      |
+        | c   | 1    | 0         | a      |
+        | c   | 1    | 1         | a      |
+        | c   | 1    | 1         | b      |
+        | d   | 0    | 0         | a      |
+        | d   | 0    | 1         | a      |
+        | d   | 1    | 0         | a      |
+        | d   | 1    | 0         | b      |
+        | d   | 1    | 1         | a      |
+        +-----+------+-----------+--------+
+        ");
+        Ok(())
+    }
+
     /// UNION ALL mixing a work unit feed source with a plain VALUES subquery.
     /// Only one child of the ChildrenIsolatorUnionExec has a WorkUnitFeedExec.
     #[tokio::test]
@@ -697,6 +799,33 @@ mod tests {
         "
         );
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn nested_union_budget_exceeds_children_sum() {
+        let res = run_query(
+            r#"
+            SET distributed.broadcast_joins = true;
+            SELECT b.tag, a.tag
+            FROM test_work_unit('big', 4, 'rows(1)', 'rows(1)', 'rows(1)', 'rows(1)') b
+            INNER JOIN (
+                SELECT * FROM test_work_unit('small_a', 1, 'rows(1)', 'rows(1)', 'rows(1)')
+                UNION ALL
+                SELECT * FROM test_work_unit('small_b', 1, 'rows(1)', 'rows(1)', 'rows(1)')
+            ) a ON a.letter = b.letter
+            "#,
+        )
+        .await;
+
+        let err = res.expect_err(
+            "expected the planner to reject the inconsistent CIU input (budget > children sum)",
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("ChildrenIsolatorUnionExec had a task count")
+                && msg.contains("greater than the sum of child task counts"),
+            "unexpected error message: {msg}"
+        );
     }
 
     async fn run_query(sql: &str) -> Result<(String, String), DataFusionError> {


### PR DESCRIPTION
Stack of some PRs for fixing a bug in `ChildrenIsolatorUnionExec`:
- https://github.com/datafusion-contrib/datafusion-distributed/pull/455 <- you are here
- https://github.com/datafusion-contrib/datafusion-distributed/pull/456

---

Adds a regression test (`nested_union_budget_exceeds_children_sum` in `tests/work_unit_feed.rs`) that reproduces a production planning error:

  > Internal error: ChildrenIsolatorUnionExec had a task count N, which is greater than the sum of child task counts M

The bug is triggered when a `UnionExec` with cheap children (low combined task count) sits on the probe side of a broadcast `HashJoinExec` whose build side carries a higher task count into the same stage. Bottom-up reconciliation at the join takes `max(probe, build)`, and the top-down propagation pass then hands that inflated value down to the union as its CIU budget — exceeding the sum of the union's children's task counts.