### PR TITLE
Fix ChildrenIsolatorUnionExec budget mismatch via weight-based proportional allocation

### DIFF
--- a/src/distributed_planner/distributed_query_planner.rs
+++ b/src/distributed_planner/distributed_query_planner.rs
@@ -633,10 +633,10 @@ mod tests {
         assert_snapshot!(plan, @r"
         ┌───── DistributedExec ── Tasks: t0:[p0]
         │ CoalescePartitionsExec
-        │   [Stage 1] => NetworkCoalesceExec: output_partitions=36, input_tasks=3
+        │   [Stage 1] => NetworkCoalesceExec: output_partitions=24, input_tasks=3
         └──────────────────────────────────────────────────
-          ┌───── Stage 1 ── Tasks: t0:[p0..p11] t1:[p12..p23] t2:[p24..p35]
-          │ DistributedUnionExec: t0:[c0] t1:[c1] t2:[c2, c3, c4]
+          ┌───── Stage 1 ── Tasks: t0:[p0..p7] t1:[p8..p15] t2:[p16..p23]
+          │ DistributedUnionExec: t0:[c0, c3] t1:[c1, c4] t2:[c2]
           │   FilterExec: MinTemp@0 > 10
           │     RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=3
           │       DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, RainToday], file_type=parquet, predicate=MinTemp@0 > 10, pruning_predicate=MinTemp_null_count@1 != row_count@2 AND MinTemp_max@0 > 10, required_guarantees=[]

--- a/src/distributed_planner/distributed_query_planner.rs
+++ b/src/distributed_planner/distributed_query_planner.rs
@@ -563,15 +563,15 @@ mod tests {
         │   [Stage 1] => NetworkCoalesceExec: output_partitions=12, input_tasks=3
         └──────────────────────────────────────────────────
           ┌───── Stage 1 ── Tasks: t0:[p0..p3] t1:[p4..p7] t2:[p8..p11]
-          │ DistributedUnionExec: t0:[c0] t1:[c1(0/2)] t2:[c1(1/2)]
+          │ DistributedUnionExec: t0:[c0(0/2)] t1:[c0(1/2)] t2:[c1]
           │   FilterExec: MinTemp@0 > 10
-          │     RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=3
-          │       DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, RainToday], file_type=parquet, predicate=MinTemp@0 > 10, pruning_predicate=MinTemp_null_count@1 != row_count@2 AND MinTemp_max@0 > 10, required_guarantees=[]
+          │     RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=2
+          │       PartitionIsolatorExec: tasks=2 partitions=3
+          │         DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, RainToday], file_type=parquet, predicate=MinTemp@0 > 10, pruning_predicate=MinTemp_null_count@1 != row_count@2 AND MinTemp_max@0 > 10, required_guarantees=[]
           │   ProjectionExec: expr=[MaxTemp@0 as MinTemp, RainToday@1 as RainToday]
           │     FilterExec: MaxTemp@0 < 30
-          │       RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=2
-          │         PartitionIsolatorExec: tasks=2 partitions=3
-          │           DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MaxTemp, RainToday], file_type=parquet, predicate=MaxTemp@1 < 30, pruning_predicate=MaxTemp_null_count@1 != row_count@2 AND MaxTemp_min@0 < 30, required_guarantees=[]
+          │       RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=3
+          │         DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MaxTemp, RainToday], file_type=parquet, predicate=MaxTemp@1 < 30, pruning_predicate=MaxTemp_null_count@1 != row_count@2 AND MaxTemp_min@0 < 30, required_guarantees=[]
           └──────────────────────────────────────────────────
         ");
     }
@@ -633,10 +633,10 @@ mod tests {
         assert_snapshot!(plan, @r"
         ┌───── DistributedExec ── Tasks: t0:[p0]
         │ CoalescePartitionsExec
-        │   [Stage 1] => NetworkCoalesceExec: output_partitions=24, input_tasks=3
+        │   [Stage 1] => NetworkCoalesceExec: output_partitions=36, input_tasks=3
         └──────────────────────────────────────────────────
-          ┌───── Stage 1 ── Tasks: t0:[p0..p7] t1:[p8..p15] t2:[p16..p23]
-          │ DistributedUnionExec: t0:[c0, c1] t1:[c2, c3] t2:[c4]
+          ┌───── Stage 1 ── Tasks: t0:[p0..p11] t1:[p12..p23] t2:[p24..p35]
+          │ DistributedUnionExec: t0:[c0] t1:[c1] t2:[c2, c3, c4]
           │   FilterExec: MinTemp@0 > 10
           │     RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=3
           │       DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, RainToday], file_type=parquet, predicate=MinTemp@0 > 10, pruning_predicate=MinTemp_null_count@1 != row_count@2 AND MinTemp_max@0 > 10, required_guarantees=[]

--- a/src/distributed_planner/inject_network_boundaries.rs
+++ b/src/distributed_planner/inject_network_boundaries.rs
@@ -1,5 +1,5 @@
 use crate::TaskCountAnnotation::{Desired, Maximum};
-use crate::execution_plans::ChildrenIsolatorUnionExec;
+use crate::execution_plans::{ChildWeight, ChildrenIsolatorUnionExec};
 use crate::stage::LocalStage;
 use crate::{
     BroadcastExec, DistributedConfig, NetworkBoundaryExt, NetworkBroadcastExec,
@@ -429,12 +429,21 @@ fn propagate_task_count_until_network_boundaries(
         // in a non-distributed context. The ChildrenIsolatorUnionExec itself will make sure to
         // determine which children to run and which to exclude depending on the task index in
         // which it's running.
+        //
+        // Each child's bottom-up task count becomes its relative weight (children that want
+        // more parallelism get a proportionally larger share of the stage's budget). A
+        // `Maximum(N)` annotation maps to a hard cap so the allocator never assigns the
+        // child more than `N` task slots; surplus budget is redistributed to uncapped
+        // siblings, or stays empty if every child is capped.
         let children = plan.children();
-        let c_i_union = ChildrenIsolatorUnionExec::from_children_and_task_counts(
-            children.iter().map(|v| Arc::clone(*v)),
+        let c_i_union = ChildrenIsolatorUnionExec::from_children_and_weights(
+            children.iter().map(|v| Arc::clone(v)),
             children
                 .iter()
-                .map(|v| Ok(ctx.task_count(v)?.as_usize()))
+                .map(|v| match ctx.task_count(v)? {
+                    Desired(n) => Ok(ChildWeight::desired(n as f64)),
+                    Maximum(n) => Ok(ChildWeight::maximum(n)),
+                })
                 .collect::<Result<Vec<_>>>()?,
             task_count.as_usize(),
         )?;
@@ -757,18 +766,18 @@ mod tests {
         let annotated = sql_to_annotated(query).await;
         assert_snapshot!(annotated, @r"
         ChildrenIsolatorUnionExec: task_count=Desired(4)
-          FilterExec: task_count=Maximum(1)
-            RepartitionExec: task_count=Maximum(1)
-              DataSourceExec: task_count=Maximum(1)
+          FilterExec: task_count=Maximum(2)
+            RepartitionExec: task_count=Maximum(2)
+              PartitionIsolatorExec: task_count=Maximum(2)
+                DataSourceExec: task_count=Maximum(2)
           ProjectionExec: task_count=Maximum(1)
             FilterExec: task_count=Maximum(1)
               RepartitionExec: task_count=Maximum(1)
                 DataSourceExec: task_count=Maximum(1)
-          ProjectionExec: task_count=Maximum(2)
-            FilterExec: task_count=Maximum(2)
-              RepartitionExec: task_count=Maximum(2)
-                PartitionIsolatorExec: task_count=Maximum(2)
-                  DataSourceExec: task_count=Maximum(2)
+          ProjectionExec: task_count=Maximum(1)
+            FilterExec: task_count=Maximum(1)
+              RepartitionExec: task_count=Maximum(1)
+                DataSourceExec: task_count=Maximum(1)
         ")
     }
 
@@ -972,20 +981,6 @@ mod tests {
         // context.
         assert_snapshot!(annotated, @r"
         ChildrenIsolatorUnionExec: task_count=Desired(4)
-          HashJoinExec: task_count=Maximum(1)
-            CoalescePartitionsExec: task_count=Maximum(1)
-              NetworkBroadcastExec: task_count=Maximum(1)
-                BroadcastExec: task_count=Desired(3)
-                  PartitionIsolatorExec: task_count=Desired(3)
-                    DataSourceExec: task_count=Desired(3)
-            DataSourceExec: task_count=Maximum(1)
-          HashJoinExec: task_count=Maximum(1)
-            CoalescePartitionsExec: task_count=Maximum(1)
-              NetworkBroadcastExec: task_count=Maximum(1)
-                BroadcastExec: task_count=Desired(3)
-                  PartitionIsolatorExec: task_count=Desired(3)
-                    DataSourceExec: task_count=Desired(3)
-            DataSourceExec: task_count=Maximum(1)
           HashJoinExec: task_count=Maximum(2)
             CoalescePartitionsExec: task_count=Maximum(2)
               NetworkBroadcastExec: task_count=Maximum(2)
@@ -994,6 +989,20 @@ mod tests {
                     DataSourceExec: task_count=Desired(3)
             PartitionIsolatorExec: task_count=Maximum(2)
               DataSourceExec: task_count=Maximum(2)
+          HashJoinExec: task_count=Maximum(1)
+            CoalescePartitionsExec: task_count=Maximum(1)
+              NetworkBroadcastExec: task_count=Maximum(1)
+                BroadcastExec: task_count=Desired(3)
+                  PartitionIsolatorExec: task_count=Desired(3)
+                    DataSourceExec: task_count=Desired(3)
+            DataSourceExec: task_count=Maximum(1)
+          HashJoinExec: task_count=Maximum(1)
+            CoalescePartitionsExec: task_count=Maximum(1)
+              NetworkBroadcastExec: task_count=Maximum(1)
+                BroadcastExec: task_count=Desired(3)
+                  PartitionIsolatorExec: task_count=Desired(3)
+                    DataSourceExec: task_count=Desired(3)
+            DataSourceExec: task_count=Maximum(1)
         ");
     }
 

--- a/src/execution_plans/children_isolator_union.rs
+++ b/src/execution_plans/children_isolator_union.rs
@@ -99,25 +99,15 @@ pub struct ChildrenIsolatorUnionExec {
     >,
 }
 
-/// Per-child allocation hint passed to
-/// [`ChildrenIsolatorUnionExec::from_children_and_weights`].
-///
-/// `weight` sets the child's *relative* share of the stage's task budget — only the ratios
-/// among the non-zero entries matter. Valid values are any finite, non-negative `f64`:
-/// `0.0` means "no proportional share" (the child still runs but gets packed into an
-/// existing slot rather than earning its own). Negative and non-finite (`NaN`, `±∞`)
-/// values are rejected with an error. If every weight is `0.0`, the distribution falls
-/// back to uniform so the planner never has to special-case "no signal".
-///
-/// `max` is an optional *absolute* cap: the allocator will never assign the child more than
-/// `max` task slots, even if its proportional share would be larger. Use it to surface
-/// annotations like `Maximum(N)` that hard-limit how much parallelism a child can take.
-/// Leaving `max` unset means "no cap" — the child can absorb surplus budget from other
-/// capped siblings.
+/// Per-child allocation hint passed to [`ChildrenIsolatorUnionExec::from_children_and_weights`].
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ChildWeight {
-    pub weight: f64,
-    pub max: Option<usize>,
+    /// Weight relative to other children. The higher the weight vs other children, the more tasks
+    /// will be allocated to it.
+    pub(crate) weight: f64,
+    /// Maximum task count cap for this child. While allocating tasks for this child, it cannot
+    /// exceed the specified `max` no matter its `weight`
+    pub(crate) max: Option<usize>,
 }
 
 impl ChildWeight {

--- a/src/execution_plans/children_isolator_union.rs
+++ b/src/execution_plans/children_isolator_union.rs
@@ -86,6 +86,10 @@ pub struct ChildrenIsolatorUnionExec {
     pub(crate) properties: Arc<PlanProperties>,
     pub(crate) metrics: ExecutionPlanMetricsSet,
     pub(crate) children: Vec<Arc<dyn ExecutionPlan>>,
+    /// The original per-child weights (and their optional hard caps) used to build the
+    /// `task_idx_map`. Stored so `with_new_children` can re-run the allocator with the same
+    /// inputs and preserve `Maximum(N)` caps across plan rewrites.
+    pub(crate) child_weights: Vec<ChildWeight>,
     pub(crate) task_idx_map: Vec<
         /* outer distributed task idx */
         Vec<(
@@ -95,24 +99,63 @@ pub struct ChildrenIsolatorUnionExec {
     >,
 }
 
+/// Per-child allocation hint passed to
+/// [`ChildrenIsolatorUnionExec::from_children_and_weights`].
+///
+/// `weight` sets the child's *relative* share of the stage's task budget — only the ratios
+/// among the non-zero entries matter. Valid values are any finite, non-negative `f64`:
+/// `0.0` means "no proportional share" (the child still runs but gets packed into an
+/// existing slot rather than earning its own). Negative and non-finite (`NaN`, `±∞`)
+/// values are rejected with an error. If every weight is `0.0`, the distribution falls
+/// back to uniform so the planner never has to special-case "no signal".
+///
+/// `max` is an optional *absolute* cap: the allocator will never assign the child more than
+/// `max` task slots, even if its proportional share would be larger. Use it to surface
+/// annotations like `Maximum(N)` that hard-limit how much parallelism a child can take.
+/// Leaving `max` unset means "no cap" — the child can absorb surplus budget from other
+/// capped siblings.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ChildWeight {
+    pub weight: f64,
+    pub max: Option<usize>,
+}
+
+impl ChildWeight {
+    /// Convenience: a child with relative weight `w` and no cap.
+    pub fn desired(w: f64) -> Self {
+        Self {
+            weight: w,
+            max: None,
+        }
+    }
+
+    /// Convenience: a child whose relative weight equals its hard cap `n`.
+    pub fn maximum(n: usize) -> Self {
+        Self {
+            weight: n as f64,
+            max: Some(n),
+        }
+    }
+}
+
 impl ChildrenIsolatorUnionExec {
-    pub(crate) fn from_children_and_task_counts(
+    pub(crate) fn from_children_and_weights(
         children: impl IntoIterator<Item = Arc<dyn ExecutionPlan>>,
-        children_task_count: impl IntoIterator<Item = usize>,
+        children_weights: impl IntoIterator<Item = ChildWeight>,
         task_count: usize,
     ) -> Result<Self, DataFusionError> {
         let children = children.into_iter().collect_vec();
-        let task_count_per_children = children_task_count.into_iter().collect_vec();
+        let weights = children_weights.into_iter().collect_vec();
 
-        if children.len() != task_count_per_children.len() {
+        if children.len() != weights.len() {
             return internal_err!(
-                "ChildrenIsolatorUnionExec received {} children but a vec of {} positions for those children. This is a bug in the distributed planning logic, please report it",
+                "ChildrenIsolatorUnionExec received {} children but a vec of {} weights for those children. This is a bug in the distributed planning logic, please report it",
                 children.len(),
-                task_count_per_children.len()
+                weights.len()
             );
         }
 
-        let task_idx_map = split_children(task_count_per_children, task_count)?;
+        let task_idx_map = split_children(&weights, task_count)?;
 
         // Because different children might return a different number of partitions, and we might
         // execute a different number of children in different tasks, the reality is that this node,
@@ -145,6 +188,7 @@ impl ChildrenIsolatorUnionExec {
             properties: Arc::new(properties),
             metrics: ExecutionPlanMetricsSet::default(),
             children,
+            child_weights: weights,
             task_idx_map,
         })
     }
@@ -217,9 +261,9 @@ impl ExecutionPlan for ChildrenIsolatorUnionExec {
                 self.children.len()
             );
         }
-        Ok(Arc::new(Self::from_children_and_task_counts(
+        Ok(Arc::new(Self::from_children_and_weights(
             children,
-            self.child_task_counts(),
+            self.child_weights.clone(),
             self.task_idx_map.len(),
         )?))
     }
@@ -336,54 +380,49 @@ impl Stream for ObservedStream {
     }
 }
 
-/// Given a list of children with a different number of tasks assigned each, it redistributes them
-/// and re-assign tasks numbers to them so that they fit in the provided `task_count`.
+/// Given a per-child [`ChildWeight`] slice and a `task_count_budget`, distribute the budget
+/// across children proportional to their weights, honoring any per-child caps.
 ///
-/// For example, given these inputs:
-///     `task_count_per_children`: [1, 1, 1]
-///     `task_count`: 3
-/// It returns the following output:
-///     `[[(0, 0/1)], [(1, 0/1)], [(2, 0/1)]]`
-/// That means that:
-/// - Task 0 will execute task 0 from child 0
-/// - Task 1 will execute task 0 from child 1
-/// - Task 2 will execute task 0 from child 2
+/// Behavior (a single proportional allocation handles every regime — `budget < n`, `budget
+/// == n`, and `budget > n`):
+///  - The budget is allocated proportionally with the Hare largest-remainder method (ties
+///    broken by lower child index first, so the output is deterministic).
+///  - A child with `max = Some(N)` never receives more than `N` task slots; any excess that
+///    would have gone to it is redistributed to uncapped siblings. When every child is at
+///    its cap, the leftover budget stays as empty trailing task slots.
+///  - A child whose proportional share rounds down to zero is *packed* into the last
+///    occupied task slot — sharing execution with whoever is already there — rather than
+///    stealing a slot from a heavy-weight sibling. This is also what makes the `budget < n`
+///    case work: most children end up at zero share and pile into the few occupied slots.
 ///
-/// Things can get more complicated if the sum of all the tasks from the children is greater than
-/// the `task_count` passed:
+/// ## Examples (read alongside the unit tests for the full picture):
 ///
-/// For example, given these inputs:
-///     `task_count_per_children`: [2, 1, 1]
-///     `task_count`: 3
-/// It returns the following output:
-///     `[[(0, 0/1)], [(1, 0/1)], [(2, 0/1)]]`
-/// As we have 3 tasks available for executing 3 children with a total sum of 2+1+1=4 tasks, we
-/// need to tell that first child to be executed in 1 task.
+/// ```text
+///   weights: [w(1), w(1), w(1)], budget: 3  →  one task slot per child
+///       [[(0, 0/1)], [(1, 0/1)], [(2, 0/1)]]
 ///
-/// In this other case:
-///     `task_count_per_children`: [2, 3, 1]
-///     `task_count`: 5
-/// It returns the following output:
-///     `[[(0, 0/2)], [(0, 1/2)], [(1, 0/2)], [(1, 1/2)], [(2, 0/1)]]`
-/// Note how in this case there are 2+3+1=6 tasks to be executed, but we only have 5 tasks
-/// available. We need to trim a task from somewhere, and the only candidates are child 0 and 1.
-/// As child 1 is the one with the greatest task count (3), we prefer to trim the task from there,
-/// as that's what will yield the most even distribution of tasks given the 5 tasks budget.
+///   weights: [w(1), w(2), w(3)], budget: 6  →  weights match the budget exactly
+///       [[(0, 0/1)], [(1, 0/2)], [(1, 1/2)], [(2, 0/3)], [(2, 1/3)], [(2, 2/3)]]
 ///
-/// Going to the other extreme, given this input:
-///     `task_count_per_children`: [1, 1, 1, 1, 1]
-///     `task_count`: 2
-/// It returns the following output:
-///     `[[(0, 0/1), (1, 0/1), (2, 0/1)] , [(3, 0/1), (4, 0/1)]]`
-/// In this case, we have very few `task_count` available, so we cannot afford to execute one
-/// child per task. We need to group children so that one task executes several of them, and the
-/// other tasks execute the several other remaining.
+///   weights: [w(1), w(1)], budget: 3  →  more budget than the total weight — the heavier-
+///       share child (after tiebreak) covers two slots:
+///       [[(0, 0/2)], [(0, 1/2)], [(1, 0/1)]]
 ///
-/// The function looks pretty much like the solution of a LeetCode problem, so it's not super
-/// easy to understand just be looking at the code. The best way to get a grasp of what its doing
-/// is by looking at the tests.
+///   weights: [Maximum(1), Maximum(1)], budget: 3  →  both children are capped at 1; the
+///       third slot stays empty:
+///       [[(0, 0/1)], [(1, 0/1)], []]
+///
+///   weights: [Maximum(1), w(1)], budget: 3  →  the capped child gets exactly 1 slot, the
+///       uncapped sibling absorbs the surplus:
+///       [[(0, 0/1)], [(1, 0/2)], [(1, 1/2)]]
+///
+///   weights: [w(10), w(1), w(1)], budget: 3  →  child 0's proportional share is 2.5
+///       (rounds up to 3 via the largest-remainder pass); children 1 and 2 round down to 0
+///       and are packed into the last occupied slot instead of stealing one from child 0:
+///       [[(0, 0/3)], [(0, 1/3)], [(0, 2/3), (1, 0/1), (2, 0/1)]]
+/// ```
 fn split_children(
-    mut task_count_per_children: Vec<usize>,
+    children: &[ChildWeight],
     task_count_budget: usize,
 ) -> Result<
     // Task idx. This Vec will have `task_count_budget` length.
@@ -396,86 +435,153 @@ fn split_children(
     >,
     DataFusionError,
 > {
-    let total_children_tasks = task_count_per_children.iter().sum::<usize>();
-    if task_count_budget > total_children_tasks {
-        return internal_err!(
-            "ChildrenIsolatorUnionExec had a task count {task_count_budget}, which is greater than the sum of child task counts {total_children_tasks}. This is a bug in the distributed planning logic, please report it"
-        );
-    } else if task_count_budget == 0 {
+    if task_count_budget == 0 {
         return internal_err!(
             "ChildrenIsolatorUnionExec had a task count {task_count_budget}. This is a bug in the distributed planning logic, please report it"
         );
     }
+    if children.is_empty() {
+        return internal_err!(
+            "ChildrenIsolatorUnionExec built with no children. This is a bug in the distributed planning logic, please report it"
+        );
+    }
+    for (i, weight) in children.iter().enumerate() {
+        if weight.max == Some(0) {
+            return plan_err!(
+                "ChildrenIsolatorUnionExec child {i} has a max task count of 0, which is invalid"
+            );
+        }
+        if weight.weight < 0.0 {
+            return plan_err!(
+                "ChildrenIsolatorUnionExec child {i} has a negative desired wait of {}, which is invalid.",
+                weight.weight
+            );
+        }
+        if !weight.weight.is_finite() {
+            return plan_err!(
+                "ChildrenIsolatorUnionExec child {i} has a non-finite desired wait of {}, which is invalid.",
+                weight.weight
+            );
+        }
+    }
 
-    let mut tasks_to_trim = total_children_tasks - task_count_budget;
-    while tasks_to_trim > 0 {
-        let mut max_child_task_count_idx = 0;
-        let mut max_child_task_count_value = 1;
-        for (i, child_task_count) in task_count_per_children.iter().enumerate() {
-            if child_task_count > &max_child_task_count_value {
-                max_child_task_count_idx = i;
-                max_child_task_count_value = *child_task_count;
+    // Two running examples (A and B) traced through every step below.
+    // A: [w(10), w(1), w(1)], budget=3   (heavy child dominates)
+    // B: [max(1), w(1)],      budget=3   (cap kicks in during remainder pass)
+    let child_weights: Vec<f64> = children.iter().map(|w| w.weight).collect();
+    let total_weight: f64 = child_weights.iter().sum(); // A→12.0  B→2.0
+    let child_count = children.len();
+
+    // Ideal share per child = budget * w_i / Σw.
+    // A: [2.5, 0.25, 0.25]
+    // B: [1.5, 1.5]
+    let unrounded_child_task_counts: Vec<f64> = if total_weight > 0.0 {
+        child_weights
+            .iter()
+            .map(|w| task_count_budget as f64 * w / total_weight)
+            .collect()
+    } else {
+        // All weights zero → even split.
+        vec![task_count_budget as f64 / child_count as f64; child_count]
+    };
+
+    // Floor each share, then clamp by any per-child cap.
+    // A: floor:[2,0,0] cap:unchanged
+    // B: floor:[1,1]   cap:c0        min(1,1)=1 → unchanged
+    let mut child_task_counts = unrounded_child_task_counts
+        .iter()
+        .map(|x| x.floor() as usize)
+        .collect::<Vec<_>>();
+    for (task_count, child_weight) in child_task_counts.iter_mut().zip(children.iter()) {
+        if let Some(max) = child_weight.max {
+            *task_count = (*task_count).min(max);
+        }
+    }
+
+    // Hare largest-remainder: give the remaining slots to children with the biggest
+    // fractional parts, skipping any already at their cap.
+    // A: Σfloors=2, unallocated=1; remainders=[0.5,0.25,0.25] → c0 wins → [3,0,0]
+    // B: Σfloors=2, unallocated=1; remainders=[0.5,0.5] → c0 tied-wins but capped → c1 wins → [1,2]
+    let allocated_task_counts: usize = child_task_counts.iter().sum();
+    let mut unallocated_task_counts = task_count_budget.saturating_sub(allocated_task_counts);
+    if unallocated_task_counts > 0 {
+        let mut order: Vec<usize> = (0..child_count).collect();
+        // Sort descending by fractional part; lower index breaks ties deterministically.
+        order.sort_by(|&a, &b| {
+            let ra = unrounded_child_task_counts[a] - unrounded_child_task_counts[a].floor();
+            let rb = unrounded_child_task_counts[b] - unrounded_child_task_counts[b].floor();
+            rb.partial_cmp(&ra)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(a.cmp(&b))
+        });
+        while unallocated_task_counts > 0 {
+            let mut made_progress = false;
+            for &idx in &order {
+                if unallocated_task_counts == 0 {
+                    break;
+                }
+                if let Some(max) = children[idx].max
+                    && child_task_counts[idx] >= max
+                {
+                    continue;
+                }
+                child_task_counts[idx] += 1;
+                unallocated_task_counts -= 1;
+                made_progress = true;
+            }
+            if !made_progress {
+                // All remaining children are at their cap; leftover budget becomes empty slots.
+                break;
             }
         }
-        if max_child_task_count_value == 1 {
-            break;
-        }
-        task_count_per_children[max_child_task_count_idx] -= 1;
-        tasks_to_trim -= 1;
     }
 
-    let total_child_tasks: usize = task_count_per_children.iter().sum();
-    let base_per_task = total_child_tasks / task_count_budget;
-    let mut extra = total_child_tasks % task_count_budget;
-
+    // Lay out each child's alloc in consecutive result slots.
+    // A: c0×3 → slots 0=(0,0/3), 1=(0,1/3), 2=(0,2/3); c1,c2 alloc=0 → skipped; task_idx=3
+    // B: c0×1 → slot  0=(0,0/1); c1×2 → slots 1=(1,0/2), 2=(1,1/2);       task_idx=3
     let mut result = vec![vec![]; task_count_budget];
     let mut task_idx = 0;
-    let mut current_task_count = 0;
-    let mut current_task_capacity = base_per_task;
-    if extra > 0 {
-        extra -= 1;
-        current_task_capacity += 1
-    }
-
-    for (child_idx, &child_task_count) in task_count_per_children.iter().enumerate() {
-        for task_i in 0..child_task_count {
+    for (child_idx, &task_count) in child_task_counts.iter().enumerate() {
+        for task_i in 0..task_count {
             result[task_idx].push((
                 child_idx,
                 DistributedTaskContext {
                     task_index: task_i,
-                    task_count: child_task_count,
+                    task_count,
                 },
             ));
-            current_task_count += 1;
-
-            if current_task_count >= current_task_capacity && task_idx < task_count_budget - 1 {
-                task_idx += 1;
-                current_task_count = 0;
-                current_task_capacity = base_per_task;
-                if extra > 0 {
-                    extra -= 1;
-                    current_task_capacity += 1
-                }
-            }
+            task_idx += 1;
         }
     }
 
+    // Pack zero-alloc children into the last occupied slot so their data still gets produced.
+    // A: c1,c2 → appended to slot 2: [(0,2/3),(1,0/1),(2,0/1)]
+    // B: no zero-alloc children → result unchanged
+    if let Some(last_occupied) = task_idx.checked_sub(1) {
+        for (child_idx, &task_count) in child_task_counts.iter().enumerate() {
+            if task_count != 0 {
+                continue;
+            }
+            result[last_occupied].push((
+                child_idx,
+                DistributedTaskContext {
+                    task_index: 0,
+                    task_count: 1,
+                },
+            ));
+        }
+    }
     Ok(result)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion::arrow::datatypes::{DataType, Field, Schema};
-    use datafusion::physical_plan::ExecutionPlan;
-    use datafusion::physical_plan::empty::EmptyExec;
-    use datafusion::physical_plan::repartition::RepartitionExec;
-    use std::sync::Arc;
 
     #[test]
     fn children_split_all_1_task() -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(
-            split_children(vec![1, 1, 1], 3)?,
+            split_children(&[des(1.0), des(1.0), des(1.0)], 3)?,
             vec![
                 vec![(0, ctx(0, 1))],
                 vec![(1, ctx(0, 1))],
@@ -483,11 +589,13 @@ mod tests {
             ]
         );
         assert_eq!(
-            split_children(vec![1, 1, 1], 2)?,
-            vec![vec![(0, ctx(0, 1)), (1, ctx(0, 1))], vec![(2, ctx(0, 1))]]
+            split_children(&[des(1.0), des(1.0), des(1.0)], 2)?,
+            // Floor = [0,0,0]. The remainder pass gives one slot each to c0 and c1 (tiebreak
+            // by lower index); c2 rounds to zero and is packed into the last occupied slot.
+            vec![vec![(0, ctx(0, 1))], vec![(1, ctx(0, 1)), (2, ctx(0, 1))]]
         );
         assert_eq!(
-            split_children(vec![1, 1, 1], 1)?,
+            split_children(&[des(1.0), des(1.0), des(1.0)], 1)?,
             vec![vec![(0, ctx(0, 1)), (1, ctx(0, 1)), (2, ctx(0, 1))]]
         );
         Ok(())
@@ -496,7 +604,7 @@ mod tests {
     #[test]
     fn split_children_different_tasks() -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(
-            split_children(vec![1, 2, 3], 6)?,
+            split_children(&[des(1.0), des(2.0), des(3.0)], 6)?,
             vec![
                 vec![(0, ctx(0, 1))],
                 vec![(1, ctx(0, 2))],
@@ -507,7 +615,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            split_children(vec![1, 2, 3], 5)?,
+            split_children(&[des(1.0), des(2.0), des(3.0)], 5)?,
             vec![
                 vec![(0, ctx(0, 1))],
                 vec![(1, ctx(0, 2))],
@@ -517,7 +625,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            split_children(vec![1, 2, 3], 4)?,
+            split_children(&[des(1.0), des(2.0), des(3.0)], 4)?,
             vec![
                 vec![(0, ctx(0, 1))],
                 vec![(1, ctx(0, 1))],
@@ -526,7 +634,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            split_children(vec![1, 2, 3], 3)?,
+            split_children(&[des(1.0), des(2.0), des(3.0)], 3)?,
             vec![
                 vec![(0, ctx(0, 1))],
                 vec![(1, ctx(0, 1))],
@@ -534,14 +642,192 @@ mod tests {
             ]
         );
         assert_eq!(
-            split_children(vec![1, 2, 3], 2)?,
-            vec![vec![(0, ctx(0, 1)), (1, ctx(0, 1))], vec![(2, ctx(0, 1))]]
+            split_children(&[des(1.0), des(2.0), des(3.0)], 2)?,
+            // Floor = [0, 0, 1] (only c2's share is ≥ 1). Remainder of 1 goes to c1 (highest
+            // fractional remainder). c0 rounds to zero and packs into the last occupied slot.
+            vec![vec![(1, ctx(0, 1))], vec![(2, ctx(0, 1)), (0, ctx(0, 1))]]
         );
         assert_eq!(
-            split_children(vec![1, 2, 3], 1)?,
-            vec![vec![(0, ctx(0, 1)), (1, ctx(0, 1)), (2, ctx(0, 1))]]
+            split_children(&[des(1.0), des(2.0), des(3.0)], 1)?,
+            // Only c2 (the highest weight) wins the single slot via the remainder pass; c0
+            // and c1 pack onto it.
+            vec![vec![(2, ctx(0, 1)), (0, ctx(0, 1)), (1, ctx(0, 1))]]
         );
         Ok(())
+    }
+
+    /// Regression test for a production planner bug: the budget can legitimately exceed the
+    /// sum of children weights (when a sibling subtree in the same stage drives the stage
+    /// budget up). The CIU redistributes the surplus proportionally rather than rejecting it.
+    #[test]
+    fn split_children_budget_exceeds_children_weight_sum() -> Result<(), Box<dyn std::error::Error>>
+    {
+        // weights=[1,1], budget=3 → fractional shares of 1.5 each; lower-index child wins the
+        // tiebreak and absorbs the surplus, getting 2 task slots; the other gets 1.
+        assert_eq!(
+            split_children(&[des(1.0), des(1.0)], 3)?,
+            vec![
+                vec![(0, ctx(0, 2))],
+                vec![(0, ctx(1, 2))],
+                vec![(1, ctx(0, 1))],
+            ]
+        );
+        // weights=[1,1], budget=5 → fractional shares of 2.5 each; tiebreak gives the extra to
+        // the lower-index child.
+        assert_eq!(
+            split_children(&[des(1.0), des(1.0)], 5)?,
+            vec![
+                vec![(0, ctx(0, 3))],
+                vec![(0, ctx(1, 3))],
+                vec![(0, ctx(2, 3))],
+                vec![(1, ctx(0, 2))],
+                vec![(1, ctx(1, 2))],
+            ]
+        );
+        // weights=[1,2], budget=4 → shares of 4/3≈1.33 and 8/3≈2.67; floors are [1,2] with one
+        // leftover, awarded to the larger-remainder child (idx 1).
+        assert_eq!(
+            split_children(&[des(1.0), des(2.0)], 4)?,
+            vec![
+                vec![(0, ctx(0, 1))],
+                vec![(1, ctx(0, 3))],
+                vec![(1, ctx(1, 3))],
+                vec![(1, ctx(2, 3))],
+            ]
+        );
+        Ok(())
+    }
+
+    /// A child whose proportional share rounds down to zero doesn't steal a slot from heavier
+    /// children — instead it's packed into the last occupied task slot, so its data still
+    /// gets produced without disturbing the proportional layout for the heavy children.
+    #[test]
+    fn split_children_packs_zero_share_children_into_last_slot()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // weights=[10, 1, 1], budget=3 → child 0 wins the budget (2.5 → 3 via largest-remainder);
+        // children 1 and 2 round down to 0 and share child 0's last task slot.
+        assert_eq!(
+            split_children(&[des(10.0), des(1.0), des(1.0)], 3)?,
+            vec![
+                vec![(0, ctx(0, 3))],
+                vec![(0, ctx(1, 3))],
+                vec![(0, ctx(2, 3)), (1, ctx(0, 1)), (2, ctx(0, 1))],
+            ]
+        );
+        Ok(())
+    }
+
+    /// Hard cap (`Maximum(N)`) is honored: a capped child never receives more slots than its
+    /// cap, even if its proportional share would be larger. Excess budget is redistributed to
+    /// uncapped siblings; if every child is capped, the surplus slots stay empty.
+    #[test]
+    fn split_children_respects_maximum_caps() -> Result<(), Box<dyn std::error::Error>> {
+        // Two children both capped at 1. Budget 3 → can only hand out 2 (one per child),
+        // the third slot stays empty.
+        assert_eq!(
+            split_children(&[max(1), max(1)], 3)?,
+            vec![vec![(0, ctx(0, 1))], vec![(1, ctx(0, 1))], vec![]]
+        );
+
+        // One capped at 1, one uncapped with weight 1. Budget 3 → c0 stuck at 1, c1 absorbs
+        // the surplus and ends up running in 2 tasks.
+        assert_eq!(
+            split_children(&[max(1), des(1.0)], 3)?,
+            vec![
+                vec![(0, ctx(0, 1))],
+                vec![(1, ctx(0, 2))],
+                vec![(1, ctx(1, 2))],
+            ]
+        );
+
+        // Three children: c0 capped at 2, c1 and c2 uncapped with weight 1 each. Budget 6 →
+        // c0's proportional share would be 3 but it caps at 2; the saved slot goes to c1
+        // (lower-index tiebreak among the uncapped siblings).
+        assert_eq!(
+            split_children(&[max(2), des(1.0), des(1.0)], 6)?,
+            vec![
+                vec![(0, ctx(0, 2))],
+                vec![(0, ctx(1, 2))],
+                vec![(1, ctx(0, 2))],
+                vec![(1, ctx(1, 2))],
+                vec![(2, ctx(0, 2))],
+                vec![(2, ctx(1, 2))],
+            ]
+        );
+
+        // All children capped, but budget matches the cap sum exactly — no surplus, no empty
+        // slots.
+        assert_eq!(
+            split_children(&[max(2), max(1)], 3)?,
+            vec![
+                vec![(0, ctx(0, 2))],
+                vec![(0, ctx(1, 2))],
+                vec![(1, ctx(0, 1))],
+            ]
+        );
+        Ok(())
+    }
+
+    /// All-zero weights are valid: the budget is split evenly across children.
+    #[test]
+    fn split_children_all_zero_weights_splits_evenly() -> Result<(), Box<dyn std::error::Error>> {
+        assert_eq!(
+            split_children(&[des(0.0), des(0.0), des(0.0)], 3)?,
+            vec![
+                vec![(0, ctx(0, 1))],
+                vec![(1, ctx(0, 1))],
+                vec![(2, ctx(0, 1))],
+            ]
+        );
+        Ok(())
+    }
+
+    /// Negative and non-finite weights are rejected upfront.
+    #[test]
+    fn split_children_rejects_negative_weight() {
+        let err = split_children(&[des(1.0), des(-1.0), des(1.0)], 3).unwrap_err();
+        assert!(
+            err.to_string().contains("negative"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn split_children_rejects_nan_weight() {
+        let err = split_children(&[des(f64::NAN), des(1.0)], 2).unwrap_err();
+        assert!(
+            err.to_string().contains("non-finite"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn split_children_rejects_infinite_weight() {
+        let err = split_children(&[des(1.0), des(f64::INFINITY)], 2).unwrap_err();
+        assert!(
+            err.to_string().contains("non-finite"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn split_children_rejects_zero_max() {
+        let err = split_children(
+            &[
+                des(1.0),
+                ChildWeight {
+                    weight: 1.0,
+                    max: Some(0),
+                },
+                des(1.0),
+            ],
+            3,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("max task count of 0"),
+            "unexpected error: {err}"
+        );
     }
 
     fn ctx(task_index: usize, task_count: usize) -> DistributedTaskContext {
@@ -551,39 +837,13 @@ mod tests {
         }
     }
 
-    fn empty_partitions(partitions: usize) -> Arc<dyn ExecutionPlan> {
-        let schema = Arc::new(Schema::new(vec![Field::new("k", DataType::Int32, false)]));
-        Arc::new(EmptyExec::new(schema).with_partitions(partitions))
+    /// Shorthand for `ChildWeight::desired(w)` — keeps the unit tests readable.
+    fn des(w: f64) -> ChildWeight {
+        ChildWeight::desired(w)
     }
 
-    #[test]
-    fn with_new_children_recomputes_partitioning() -> Result<(), Box<dyn std::error::Error>> {
-        let child0 = empty_partitions(2);
-        let child1 = empty_partitions(1);
-
-        let union = Arc::new(ChildrenIsolatorUnionExec::from_children_and_task_counts(
-            vec![Arc::clone(&child0), Arc::clone(&child1)],
-            vec![2, 1],
-            3,
-        )?);
-        assert_eq!(
-            union.properties().output_partitioning().partition_count(),
-            2
-        );
-
-        // Rewrites can wrap a child in a partition-changing operator. The cached union
-        // properties must be part of the replacement. If not, the downstream planning can skip
-        // partitions that the new child produces.
-        let repartitioned_child0: Arc<dyn ExecutionPlan> = Arc::new(RepartitionExec::try_new(
-            child0,
-            Partitioning::RoundRobinBatch(8),
-        )?);
-        let rebuilt = union.with_new_children(vec![repartitioned_child0, child1])?;
-        assert_eq!(
-            rebuilt.properties().output_partitioning().partition_count(),
-            8
-        );
-
-        Ok(())
+    /// Shorthand for `ChildWeight::maximum(n)` — keeps the unit tests readable.
+    fn max(n: usize) -> ChildWeight {
+        ChildWeight::maximum(n)
     }
 }

--- a/src/execution_plans/children_isolator_union.rs
+++ b/src/execution_plans/children_isolator_union.rs
@@ -396,8 +396,8 @@ impl Stream for ObservedStream {
 ///
 ///   weights: [w(10), w(1), w(1)], budget: 3  →  child 0's proportional share is 2.5
 ///       (rounds up to 3 via the largest-remainder pass); children 1 and 2 round down to 0
-///       and are packed into the last occupied slot instead of stealing one from child 0:
-///       [[(0, 0/3)], [(0, 1/3)], [(0, 2/3), (1, 0/1), (2, 0/1)]]
+///       and are distributed round-robin across occupied slots instead of stealing one from child 0:
+///       [[(0, 0/3), (1, 0/1)], [(0, 1/3), (2, 0/1)], [(0, 2/3)]]
 /// ```
 fn split_children(
     children: &[ChildWeight],
@@ -532,21 +532,25 @@ fn split_children(
         }
     }
 
-    // Pack zero-alloc children into the last occupied slot so their data still gets produced.
-    // A: c1,c2 → appended to slot 2: [(0,2/3),(1,0/1),(2,0/1)]
+    // Distribute zero-alloc children round-robin across occupied slots so their data still
+    // gets produced without overpacking a single slot.
+    // A: c1 → slot 0, c2 → slot 1: [(0,0/3),(1,0/1)], [(0,1/3),(2,0/1)], [(0,2/3)]
     // B: no zero-alloc children → result unchanged
-    if let Some(last_occupied) = task_idx.checked_sub(1) {
+    if task_idx > 0 {
+        let mut zero_alloc_i = 0usize;
         for (child_idx, &task_count) in child_task_counts.iter().enumerate() {
             if task_count != 0 {
                 continue;
             }
-            result[last_occupied].push((
+            let slot = zero_alloc_i % task_idx;
+            result[slot].push((
                 child_idx,
                 DistributedTaskContext {
                     task_index: 0,
                     task_count: 1,
                 },
             ));
+            zero_alloc_i += 1;
         }
     }
     Ok(result)
@@ -569,8 +573,8 @@ mod tests {
         assert_eq!(
             split_children(&[des(1.0), des(1.0), des(1.0)], 2)?,
             // Floor = [0,0,0]. The remainder pass gives one slot each to c0 and c1 (tiebreak
-            // by lower index); c2 rounds to zero and is packed into the last occupied slot.
-            vec![vec![(0, ctx(0, 1))], vec![(1, ctx(0, 1)), (2, ctx(0, 1))]]
+            // by lower index); c2 rounds to zero and is distributed round-robin: slot 0 % 2 = 0.
+            vec![vec![(0, ctx(0, 1)), (2, ctx(0, 1))], vec![(1, ctx(0, 1))]]
         );
         assert_eq!(
             split_children(&[des(1.0), des(1.0), des(1.0)], 1)?,
@@ -622,8 +626,8 @@ mod tests {
         assert_eq!(
             split_children(&[des(1.0), des(2.0), des(3.0)], 2)?,
             // Floor = [0, 0, 1] (only c2's share is ≥ 1). Remainder of 1 goes to c1 (highest
-            // fractional remainder). c0 rounds to zero and packs into the last occupied slot.
-            vec![vec![(1, ctx(0, 1))], vec![(2, ctx(0, 1)), (0, ctx(0, 1))]]
+            // fractional remainder). c0 rounds to zero and is distributed round-robin: slot 0 % 2 = 0.
+            vec![vec![(1, ctx(0, 1)), (0, ctx(0, 1))], vec![(2, ctx(0, 1))]]
         );
         assert_eq!(
             split_children(&[des(1.0), des(2.0), des(3.0)], 1)?,
@@ -683,13 +687,13 @@ mod tests {
     fn split_children_packs_zero_share_children_into_last_slot()
     -> Result<(), Box<dyn std::error::Error>> {
         // weights=[10, 1, 1], budget=3 → child 0 wins the budget (2.5 → 3 via largest-remainder);
-        // children 1 and 2 round down to 0 and share child 0's last task slot.
+        // children 1 and 2 round down to 0 and are distributed round-robin: c1 → slot 0, c2 → slot 1.
         assert_eq!(
             split_children(&[des(10.0), des(1.0), des(1.0)], 3)?,
             vec![
-                vec![(0, ctx(0, 3))],
-                vec![(0, ctx(1, 3))],
-                vec![(0, ctx(2, 3)), (1, ctx(0, 1)), (2, ctx(0, 1))],
+                vec![(0, ctx(0, 3)), (1, ctx(0, 1))],
+                vec![(0, ctx(1, 3)), (2, ctx(0, 1))],
+                vec![(0, ctx(2, 3))],
             ]
         );
         Ok(())

--- a/src/execution_plans/children_isolator_union.rs
+++ b/src/execution_plans/children_isolator_union.rs
@@ -373,18 +373,6 @@ impl Stream for ObservedStream {
 /// Given a per-child [`ChildWeight`] slice and a `task_count_budget`, distribute the budget
 /// across children proportional to their weights, honoring any per-child caps.
 ///
-/// Behavior (a single proportional allocation handles every regime — `budget < n`, `budget
-/// == n`, and `budget > n`):
-///  - The budget is allocated proportionally with the Hare largest-remainder method (ties
-///    broken by lower child index first, so the output is deterministic).
-///  - A child with `max = Some(N)` never receives more than `N` task slots; any excess that
-///    would have gone to it is redistributed to uncapped siblings. When every child is at
-///    its cap, the leftover budget stays as empty trailing task slots.
-///  - A child whose proportional share rounds down to zero is *packed* into the last
-///    occupied task slot — sharing execution with whoever is already there — rather than
-///    stealing a slot from a heavy-weight sibling. This is also what makes the `budget < n`
-///    case work: most children end up at zero share and pile into the few occupied slots.
-///
 /// ## Examples (read alongside the unit tests for the full picture):
 ///
 /// ```text

--- a/src/execution_plans/mod.rs
+++ b/src/execution_plans/mod.rs
@@ -11,6 +11,7 @@ mod partition_isolator;
 pub mod benchmarks;
 
 pub use broadcast::BroadcastExec;
+pub(crate) use children_isolator_union::ChildWeight;
 pub use children_isolator_union::ChildrenIsolatorUnionExec;
 pub(crate) use metrics::MetricsWrapperExec;
 pub use network_broadcast::NetworkBroadcastExec;

--- a/src/protobuf/distributed_codec.rs
+++ b/src/protobuf/distributed_codec.rs
@@ -1,7 +1,8 @@
 use super::get_distributed_user_codecs;
 use crate::common::{deserialize_uuid, serialize_uuid};
 use crate::execution_plans::{
-    BroadcastExec, ChildrenIsolatorUnionExec, NetworkBroadcastExec, NetworkCoalesceExec,
+    BroadcastExec, ChildWeight, ChildrenIsolatorUnionExec, NetworkBroadcastExec,
+    NetworkCoalesceExec,
 };
 use crate::stage::{LocalStage, RemoteStage, Stage};
 use crate::worker::WorkerConnectionPool;
@@ -202,6 +203,7 @@ impl PhysicalExtensionCodec for DistributedCodec {
             DistributedExecNode::ChildrenIsolatorUnion(ChildrenIsolatorUnionExecProto {
                 partition_count,
                 task_idx_map,
+                child_weights,
             }) => {
                 // Building a UnionExec just to get the properties out of it is not the most
                 // efficient thing to do. However, it's the easiest way of getting the properties
@@ -218,6 +220,13 @@ impl PhysicalExtensionCodec for DistributedCodec {
                     properties: Arc::new(properties),
                     metrics: Default::default(),
                     children: inputs.to_vec(),
+                    child_weights: child_weights
+                        .iter()
+                        .map(|cw| ChildWeight {
+                            weight: cw.weight,
+                            max: cw.max.map(|m| m as usize),
+                        })
+                        .collect(),
                     task_idx_map: task_idx_map
                         .iter()
                         .map(|entry| {
@@ -350,6 +359,14 @@ impl PhysicalExtensionCodec for DistributedCodec {
                             .collect_vec(),
                     })
                     .collect_vec(),
+                child_weights: node
+                    .child_weights
+                    .iter()
+                    .map(|cw| ChildWeightProto {
+                        weight: cw.weight,
+                        max: cw.max.map(|m| m as u64),
+                    })
+                    .collect_vec(),
             };
 
             let wrapper = DistributedExecProto {
@@ -432,6 +449,16 @@ pub struct ChildrenIsolatorUnionExecProto {
     partition_count: u64,
     #[prost(message, repeated, tag = "2")]
     task_idx_map: Vec<TaskIdxMapEntryProto>,
+    #[prost(message, repeated, tag = "3")]
+    child_weights: Vec<ChildWeightProto>,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ChildWeightProto {
+    #[prost(double, tag = "1")]
+    weight: f64,
+    #[prost(uint64, optional, tag = "2")]
+    max: Option<u64>,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -813,9 +840,9 @@ mod tests {
         )) as Arc<dyn ExecutionPlan>;
 
         let plan: Arc<dyn ExecutionPlan> =
-            Arc::new(ChildrenIsolatorUnionExec::from_children_and_task_counts(
+            Arc::new(ChildrenIsolatorUnionExec::from_children_and_weights(
                 vec![left.clone(), right.clone()],
-                vec![2, 2],
+                vec![ChildWeight::desired(3.0), ChildWeight::maximum(1)],
                 4,
             )?);
 

--- a/tests/distributed_unions.rs
+++ b/tests/distributed_unions.rs
@@ -147,10 +147,10 @@ mod tests {
             @r"
         ┌───── DistributedExec ── Tasks: t0:[p0]
         │ SortPreservingMergeExec: [MinTemp@0 ASC NULLS LAST, RainToday@1 ASC NULLS LAST]
-        │   [Stage 1] => NetworkCoalesceExec: output_partitions=27, input_tasks=3
+        │   [Stage 1] => NetworkCoalesceExec: output_partitions=18, input_tasks=3
         └──────────────────────────────────────────────────
-          ┌───── Stage 1 ── Tasks: t0:[p0..p8] t1:[p9..p17] t2:[p18..p26]
-          │ DistributedUnionExec: t0:[c0] t1:[c1] t2:[c2, c3, c4]
+          ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p6..p11] t2:[p12..p17]
+          │ DistributedUnionExec: t0:[c0, c3] t1:[c1, c4] t2:[c2]
           │   SortExec: expr=[MinTemp@0 ASC NULLS LAST, RainToday@1 ASC NULLS LAST], preserve_partitioning=[true]
           │     FilterExec: MinTemp@0 > 10
           │       DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, RainToday], file_type=parquet, predicate=MinTemp@0 > 10, pruning_predicate=MinTemp_null_count@1 != row_count@2 AND MinTemp_max@0 > 10, required_guarantees=[]

--- a/tests/distributed_unions.rs
+++ b/tests/distributed_unions.rs
@@ -43,15 +43,15 @@ mod tests {
         │   [Stage 1] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
         └──────────────────────────────────────────────────
           ┌───── Stage 1 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
-          │ DistributedUnionExec: t0:[c0] t1:[c1(0/2)] t2:[c1(1/2)]
+          │ DistributedUnionExec: t0:[c0(0/2)] t1:[c0(1/2)] t2:[c1]
           │   SortExec: expr=[MinTemp@0 ASC NULLS LAST, RainToday@1 ASC NULLS LAST], preserve_partitioning=[true]
           │     FilterExec: MinTemp@0 > 10
-          │       DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, RainToday], file_type=parquet, predicate=MinTemp@0 > 10, pruning_predicate=MinTemp_null_count@1 != row_count@2 AND MinTemp_max@0 > 10, required_guarantees=[]
+          │       PartitionIsolatorExec: tasks=2 partitions=3
+          │         DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, RainToday], file_type=parquet, predicate=MinTemp@0 > 10, pruning_predicate=MinTemp_null_count@1 != row_count@2 AND MinTemp_max@0 > 10, required_guarantees=[]
           │   SortExec: expr=[MinTemp@0 ASC NULLS LAST, RainToday@1 ASC NULLS LAST], preserve_partitioning=[true]
           │     ProjectionExec: expr=[MaxTemp@0 as MinTemp, RainToday@1 as RainToday]
           │       FilterExec: MaxTemp@0 < 30
-          │         PartitionIsolatorExec: tasks=2 partitions=3
-          │           DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MaxTemp, RainToday], file_type=parquet, predicate=MaxTemp@1 < 30, pruning_predicate=MaxTemp_null_count@1 != row_count@2 AND MaxTemp_min@0 < 30, required_guarantees=[]
+          │         DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MaxTemp, RainToday], file_type=parquet, predicate=MaxTemp@1 < 30, pruning_predicate=MaxTemp_null_count@1 != row_count@2 AND MaxTemp_min@0 < 30, required_guarantees=[]
           └──────────────────────────────────────────────────
         ",
         );
@@ -147,10 +147,10 @@ mod tests {
             @r"
         ┌───── DistributedExec ── Tasks: t0:[p0]
         │ SortPreservingMergeExec: [MinTemp@0 ASC NULLS LAST, RainToday@1 ASC NULLS LAST]
-        │   [Stage 1] => NetworkCoalesceExec: output_partitions=18, input_tasks=3
+        │   [Stage 1] => NetworkCoalesceExec: output_partitions=27, input_tasks=3
         └──────────────────────────────────────────────────
-          ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p6..p11] t2:[p12..p17]
-          │ DistributedUnionExec: t0:[c0, c1] t1:[c2, c3] t2:[c4]
+          ┌───── Stage 1 ── Tasks: t0:[p0..p8] t1:[p9..p17] t2:[p18..p26]
+          │ DistributedUnionExec: t0:[c0] t1:[c1] t2:[c2, c3, c4]
           │   SortExec: expr=[MinTemp@0 ASC NULLS LAST, RainToday@1 ASC NULLS LAST], preserve_partitioning=[true]
           │     FilterExec: MinTemp@0 > 10
           │       DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, RainToday], file_type=parquet, predicate=MinTemp@0 > 10, pruning_predicate=MinTemp_null_count@1 != row_count@2 AND MinTemp_max@0 > 10, required_guarantees=[]

--- a/tests/task_estimator_test.rs
+++ b/tests/task_estimator_test.rs
@@ -136,7 +136,7 @@ mod tests {
         .await?;
 
         assert_snapshot!(plan + &results,
-            @"
+            @r"
         ┌───── DistributedExec ── Tasks: t0:[p0]
         │ SortPreservingMergeExec: [tag@2 ASC NULLS LAST, task_index@1 ASC NULLS LAST]
         │   [Stage 2] => NetworkCoalesceExec: output_partitions=12, input_tasks=4
@@ -149,20 +149,20 @@ mod tests {
             ┌───── Stage 1 ── Tasks: t0:[p0..p11] t1:[p0..p11] t2:[p0..p11] t3:[p0..p11] t4:[p0..p11]
             │ RepartitionExec: partitioning=Hash([task_count@0, task_index@1, tag@2, worker_url@3], 12), input_partitions=3
             │   AggregateExec: mode=Partial, gby=[task_count@0 as task_count, task_index@1 as task_index, tag@2 as tag, worker_url@3 as worker_url], aggr=[]
-            │     DistributedUnionExec: t0:[c0(0/2)] t1:[c0(1/2)] t2:[c1(0/3)] t3:[c1(1/3)] t4:[c1(2/3)]
-            │       PartitionIsolatorExec: tasks=2 partitions=5
-            │         URLEmitterExec: tasks=5 partitions=5 tag=left
+            │     DistributedUnionExec: t0:[c0(0/3)] t1:[c0(1/3)] t2:[c0(2/3)] t3:[c1(0/2)] t4:[c1(1/2)]
             │       PartitionIsolatorExec: tasks=3 partitions=5
+            │         URLEmitterExec: tasks=5 partitions=5 tag=left
+            │       PartitionIsolatorExec: tasks=2 partitions=5
             │         URLEmitterExec: tasks=5 partitions=5 tag=right
             └──────────────────────────────────────────────────
         +------------+------------+-------+--------------+
         | task_count | task_index | tag   | worker_url   |
         +------------+------------+-------+--------------+
-        | 2          | 0          | left  | http://url-4 |
-        | 2          | 1          | left  | http://url-3 |
-        | 3          | 0          | right | http://url-2 |
-        | 3          | 1          | right | http://url-1 |
-        | 3          | 2          | right | http://url-0 |
+        | 3          | 0          | left  | http://url-4 |
+        | 3          | 1          | left  | http://url-3 |
+        | 3          | 2          | left  | http://url-2 |
+        | 2          | 0          | right | http://url-1 |
+        | 2          | 1          | right | http://url-0 |
         +------------+------------+-------+--------------+
         ",
         );
@@ -184,7 +184,7 @@ mod tests {
         .await?;
 
         assert_snapshot!(plan + &results,
-            @"
+            @r"
         ┌───── DistributedExec ── Tasks: t0:[p0]
         │ SortPreservingMergeExec: [tag@2 ASC NULLS LAST, task_index@1 ASC NULLS LAST]
         │   [Stage 2] => NetworkCoalesceExec: output_partitions=12, input_tasks=4
@@ -195,22 +195,21 @@ mod tests {
           │     [Stage 1] => NetworkShuffleExec: output_partitions=3, input_tasks=5
           └──────────────────────────────────────────────────
             ┌───── Stage 1 ── Tasks: t0:[p0..p11] t1:[p0..p11] t2:[p0..p11] t3:[p0..p11] t4:[p0..p11]
-            │ RepartitionExec: partitioning=Hash([task_count@0, task_index@1, tag@2, worker_url@3], 12), input_partitions=2
+            │ RepartitionExec: partitioning=Hash([task_count@0, task_index@1, tag@2, worker_url@3], 12), input_partitions=4
             │   AggregateExec: mode=Partial, gby=[task_count@0 as task_count, task_index@1 as task_index, tag@2 as tag, worker_url@3 as worker_url], aggr=[]
-            │     DistributedUnionExec: t0:[c0(0/3)] t1:[c0(1/3)] t2:[c0(2/3)] t3:[c1(0/2)] t4:[c1(1/2)]
-            │       PartitionIsolatorExec: tasks=3 partitions=3
+            │     DistributedUnionExec: t0:[c0(0/4)] t1:[c0(1/4)] t2:[c0(2/4)] t3:[c0(3/4)] t4:[c1]
+            │       PartitionIsolatorExec: tasks=4 partitions=3
             │         URLEmitterExec: tasks=8 partitions=3 tag=left
-            │       PartitionIsolatorExec: tasks=2 partitions=4
+            │       PartitionIsolatorExec: tasks=1 partitions=4
             │         URLEmitterExec: tasks=2 partitions=4 tag=right
             └──────────────────────────────────────────────────
         +------------+------------+-------+--------------+
         | task_count | task_index | tag   | worker_url   |
         +------------+------------+-------+--------------+
-        | 3          | 0          | left  | http://url-4 |
-        | 3          | 1          | left  | http://url-3 |
-        | 3          | 2          | left  | http://url-2 |
-        | 2          | 0          | right | http://url-1 |
-        | 2          | 1          | right | http://url-0 |
+        | 4          | 0          | left  | http://url-4 |
+        | 4          | 1          | left  | http://url-3 |
+        | 4          | 2          | left  | http://url-2 |
+        | 1          | 0          | right | http://url-0 |
         +------------+------------+-------+--------------+
         ",
         );

--- a/tests/tpcds_plans_test.rs
+++ b/tests/tpcds_plans_test.rs
@@ -480,7 +480,7 @@ mod tests {
     #[tokio::test]
     async fn test_tpcds_5() -> Result<()> {
         let display = test_tpcds_query("q5").await?;
-        assert_snapshot!(display, @"
+        assert_snapshot!(display, @r"
         ┌───── DistributedExec ── Tasks: t0:[p0]
         │ SortPreservingMergeExec: [channel@0 ASC, id@1 ASC], fetch=100
         │   SortExec: TopK(fetch=100), expr=[channel@0 ASC, id@1 ASC], preserve_partitioning=[true]
@@ -491,7 +491,7 @@ mod tests {
           ┌───── Stage 12 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2] t3:[p0..p2]
           │ RepartitionExec: partitioning=Hash([channel@0, id@1, __grouping_id@2], 3), input_partitions=3
           │   AggregateExec: mode=Partial, gby=[(NULL as channel, NULL as id), (channel@0 as channel, NULL as id), (channel@0 as channel, id@1 as id)], aggr=[sum(x.sales), sum(x.returns_), sum(x.profit)]
-          │     DistributedUnionExec: t0:[c0] t1:[c1] t2:[c2(0/2)] t3:[c2(1/2)]
+          │     DistributedUnionExec: t0:[c0(0/2)] t1:[c0(1/2)] t2:[c1] t3:[c2]
           │       ProjectionExec: expr=[store channel as channel, concat(store, s_store_id@0) as id, sum(salesreturns.sales_price)@1 as sales, sum(salesreturns.return_amt)@3 as returns_, sum(salesreturns.profit)@2 - sum(salesreturns.net_loss)@4 as profit]
           │         AggregateExec: mode=FinalPartitioned, gby=[s_store_id@0 as s_store_id], aggr=[sum(salesreturns.sales_price), sum(salesreturns.profit), sum(salesreturns.return_amt), sum(salesreturns.net_loss)]
           │           [Stage 3] => NetworkShuffleExec: output_partitions=3, input_tasks=4
@@ -502,8 +502,8 @@ mod tests {
           │         AggregateExec: mode=FinalPartitioned, gby=[web_site_id@0 as web_site_id], aggr=[sum(salesreturns.sales_price), sum(salesreturns.profit), sum(salesreturns.return_amt), sum(salesreturns.net_loss)]
           │           [Stage 11] => NetworkShuffleExec: output_partitions=3, input_tasks=4
           └──────────────────────────────────────────────────
-            ┌───── Stage 3 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2] t3:[p0..p2]
-            │ RepartitionExec: partitioning=Hash([s_store_id@0], 3), input_partitions=3
+            ┌───── Stage 3 ── Tasks: t0:[p0..p5] t1:[p0..p5] t2:[p0..p5] t3:[p0..p5]
+            │ RepartitionExec: partitioning=Hash([s_store_id@0], 6), input_partitions=3
             │   AggregateExec: mode=Partial, gby=[s_store_id@4 as s_store_id], aggr=[sum(salesreturns.sales_price), sum(salesreturns.profit), sum(salesreturns.return_amt), sum(salesreturns.net_loss)]
             │     ProjectionExec: expr=[sales_price@1 as sales_price, profit@2 as profit, return_amt@3 as return_amt, net_loss@4 as net_loss, s_store_id@0 as s_store_id]
             │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(CAST(store.s_store_sk AS Float64)@2, store_sk@0)], projection=[s_store_id@1, sales_price@4, profit@5, return_amt@6, net_loss@7]
@@ -562,8 +562,8 @@ mod tests {
               │         PartitionIsolatorExec: tasks=2 partitions=4
               │           DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/date_dim/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-3.parquet]]}, projection=[d_date_sk, d_date], file_type=parquet, predicate=d_date@2 >= 2000-08-23 AND d_date@2 <= 2000-09-06, pruning_predicate=d_date_null_count@1 != row_count@2 AND d_date_max@0 >= 2000-08-23 AND d_date_null_count@1 != row_count@2 AND d_date_min@3 <= 2000-09-06, required_guarantees=[]
               └──────────────────────────────────────────────────
-            ┌───── Stage 11 ── Tasks: t0:[p0..p5] t1:[p0..p5] t2:[p0..p5] t3:[p0..p5]
-            │ RepartitionExec: partitioning=Hash([web_site_id@0], 6), input_partitions=3
+            ┌───── Stage 11 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2] t3:[p0..p2]
+            │ RepartitionExec: partitioning=Hash([web_site_id@0], 3), input_partitions=3
             │   AggregateExec: mode=Partial, gby=[web_site_id@4 as web_site_id], aggr=[sum(salesreturns.sales_price), sum(salesreturns.profit), sum(salesreturns.return_amt), sum(salesreturns.net_loss)]
             │     ProjectionExec: expr=[sales_price@1 as sales_price, profit@2 as profit, return_amt@3 as return_amt, net_loss@4 as net_loss, web_site_id@0 as web_site_id]
             │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(CAST(web_site.web_site_sk AS Float64)@2, wsr_web_site_sk@0)], projection=[web_site_id@1, sales_price@4, profit@5, return_amt@6, net_loss@7]
@@ -1463,12 +1463,13 @@ mod tests {
         └──────────────────────────────────────────────────
           ┌───── Stage 4 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8] t3:[p9..p11]
           │ AggregateExec: mode=Partial, gby=[], aggr=[avg(sq2.quantity * sq2.list_price)]
-          │   DistributedUnionExec: t0:[c0] t1:[c1] t2:[c2(0/2)] t3:[c2(1/2)]
+          │   DistributedUnionExec: t0:[c0(0/2)] t1:[c0(1/2)] t2:[c1] t3:[c2]
           │     ProjectionExec: expr=[ss_quantity@0 as quantity, ss_list_price@1 as list_price]
           │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(CAST(date_dim.d_date_sk AS Float64)@1, ss_sold_date_sk@0)], projection=[ss_quantity@3, ss_list_price@4]
           │         CoalescePartitionsExec
-          │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=3, input_tasks=2
-          │         DataSourceExec: file_groups={3 groups: [[/testdata/tpcds/plans_sf1_partitions4/store_sales/part-0.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/store_sales/part-3.parquet:<int>..<int>]]}, projection=[ss_sold_date_sk, ss_quantity, ss_list_price], file_type=parquet, predicate=DynamicFilter [ empty ]
+          │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=6, input_tasks=2
+          │         PartitionIsolatorExec: tasks=2 partitions=6
+          │           DataSourceExec: file_groups={6 groups: [[/testdata/tpcds/plans_sf1_partitions4/store_sales/part-0.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>], ...]}, projection=[ss_sold_date_sk, ss_quantity, ss_list_price], file_type=parquet, predicate=DynamicFilter [ empty ]
           │     ProjectionExec: expr=[cs_quantity@0 as quantity, cs_list_price@1 as list_price]
           │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(CAST(date_dim.d_date_sk AS Float64)@1, cs_sold_date_sk@0)], projection=[cs_quantity@3, cs_list_price@4]
           │         CoalescePartitionsExec
@@ -1477,12 +1478,11 @@ mod tests {
           │     ProjectionExec: expr=[ws_quantity@0 as quantity, ws_list_price@1 as list_price]
           │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(CAST(date_dim.d_date_sk AS Float64)@1, ws_sold_date_sk@0)], projection=[ws_quantity@3, ws_list_price@4]
           │         CoalescePartitionsExec
-          │           [Stage 3] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=6, input_tasks=2
-          │         PartitionIsolatorExec: tasks=2 partitions=6
-          │           DataSourceExec: file_groups={6 groups: [[/testdata/tpcds/plans_sf1_partitions4/web_sales/part-0.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-2.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-2.parquet:<int>..<int>], ...]}, projection=[ws_sold_date_sk, ws_quantity, ws_list_price], file_type=parquet, predicate=DynamicFilter [ empty ]
+          │           [Stage 3] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=3, input_tasks=2
+          │         DataSourceExec: file_groups={3 groups: [[/testdata/tpcds/plans_sf1_partitions4/web_sales/part-0.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/web_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-1.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/web_sales/part-2.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-2.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/web_sales/part-3.parquet:<int>..<int>]]}, projection=[ws_sold_date_sk, ws_quantity, ws_list_price], file_type=parquet, predicate=DynamicFilter [ empty ]
           └──────────────────────────────────────────────────
-            ┌───── Stage 1 ── Tasks: t0:[p0..p2] t1:[p3..p5]
-            │ BroadcastExec: input_partitions=3, consumer_tasks=1, output_partitions=3
+            ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p6..p11]
+            │ BroadcastExec: input_partitions=3, consumer_tasks=2, output_partitions=6
             │   ProjectionExec: expr=[d_date_sk@0 as d_date_sk, CAST(d_date_sk@0 AS Float64) as CAST(date_dim.d_date_sk AS Float64)]
             │     FilterExec: d_year@1 >= 1999 AND d_year@1 <= 2001, projection=[d_date_sk@0]
             │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
@@ -1497,8 +1497,8 @@ mod tests {
             │         PartitionIsolatorExec: tasks=2 partitions=4
             │           DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/date_dim/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-3.parquet]]}, projection=[d_date_sk, d_year], file_type=parquet, predicate=d_year@6 >= 1999 AND d_year@6 <= 2001, pruning_predicate=d_year_null_count@1 != row_count@2 AND d_year_max@0 >= 1999 AND d_year_null_count@1 != row_count@2 AND d_year_min@3 <= 2001, required_guarantees=[]
             └──────────────────────────────────────────────────
-            ┌───── Stage 3 ── Tasks: t0:[p0..p5] t1:[p6..p11]
-            │ BroadcastExec: input_partitions=3, consumer_tasks=2, output_partitions=6
+            ┌───── Stage 3 ── Tasks: t0:[p0..p2] t1:[p3..p5]
+            │ BroadcastExec: input_partitions=3, consumer_tasks=1, output_partitions=3
             │   ProjectionExec: expr=[d_date_sk@0 as d_date_sk, CAST(d_date_sk@0 AS Float64) as CAST(date_dim.d_date_sk AS Float64)]
             │     FilterExec: d_year@1 >= 1999 AND d_year@1 <= 2001, projection=[d_date_sk@0]
             │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
@@ -1620,12 +1620,13 @@ mod tests {
               └──────────────────────────────────────────────────
           ┌───── Stage 21 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8] t3:[p9..p11]
           │ AggregateExec: mode=Partial, gby=[], aggr=[avg(sq2.quantity * sq2.list_price)]
-          │   DistributedUnionExec: t0:[c0] t1:[c1] t2:[c2(0/2)] t3:[c2(1/2)]
+          │   DistributedUnionExec: t0:[c0(0/2)] t1:[c0(1/2)] t2:[c1] t3:[c2]
           │     ProjectionExec: expr=[ss_quantity@0 as quantity, ss_list_price@1 as list_price]
           │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(CAST(date_dim.d_date_sk AS Float64)@1, ss_sold_date_sk@0)], projection=[ss_quantity@3, ss_list_price@4]
           │         CoalescePartitionsExec
-          │           [Stage 18] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=3, input_tasks=2
-          │         DataSourceExec: file_groups={3 groups: [[/testdata/tpcds/plans_sf1_partitions4/store_sales/part-0.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/store_sales/part-3.parquet:<int>..<int>]]}, projection=[ss_sold_date_sk, ss_quantity, ss_list_price], file_type=parquet, predicate=DynamicFilter [ empty ]
+          │           [Stage 18] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=6, input_tasks=2
+          │         PartitionIsolatorExec: tasks=2 partitions=6
+          │           DataSourceExec: file_groups={6 groups: [[/testdata/tpcds/plans_sf1_partitions4/store_sales/part-0.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>], ...]}, projection=[ss_sold_date_sk, ss_quantity, ss_list_price], file_type=parquet, predicate=DynamicFilter [ empty ]
           │     ProjectionExec: expr=[cs_quantity@0 as quantity, cs_list_price@1 as list_price]
           │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(CAST(date_dim.d_date_sk AS Float64)@1, cs_sold_date_sk@0)], projection=[cs_quantity@3, cs_list_price@4]
           │         CoalescePartitionsExec
@@ -1634,12 +1635,11 @@ mod tests {
           │     ProjectionExec: expr=[ws_quantity@0 as quantity, ws_list_price@1 as list_price]
           │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(CAST(date_dim.d_date_sk AS Float64)@1, ws_sold_date_sk@0)], projection=[ws_quantity@3, ws_list_price@4]
           │         CoalescePartitionsExec
-          │           [Stage 20] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=6, input_tasks=2
-          │         PartitionIsolatorExec: tasks=2 partitions=6
-          │           DataSourceExec: file_groups={6 groups: [[/testdata/tpcds/plans_sf1_partitions4/web_sales/part-0.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-2.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-2.parquet:<int>..<int>], ...]}, projection=[ws_sold_date_sk, ws_quantity, ws_list_price], file_type=parquet, predicate=DynamicFilter [ empty ]
+          │           [Stage 20] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=3, input_tasks=2
+          │         DataSourceExec: file_groups={3 groups: [[/testdata/tpcds/plans_sf1_partitions4/web_sales/part-0.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/web_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-1.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/web_sales/part-2.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-2.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/web_sales/part-3.parquet:<int>..<int>]]}, projection=[ws_sold_date_sk, ws_quantity, ws_list_price], file_type=parquet, predicate=DynamicFilter [ empty ]
           └──────────────────────────────────────────────────
-            ┌───── Stage 18 ── Tasks: t0:[p0..p2] t1:[p3..p5]
-            │ BroadcastExec: input_partitions=3, consumer_tasks=1, output_partitions=3
+            ┌───── Stage 18 ── Tasks: t0:[p0..p5] t1:[p6..p11]
+            │ BroadcastExec: input_partitions=3, consumer_tasks=2, output_partitions=6
             │   ProjectionExec: expr=[d_date_sk@0 as d_date_sk, CAST(d_date_sk@0 AS Float64) as CAST(date_dim.d_date_sk AS Float64)]
             │     FilterExec: d_year@1 >= 1999 AND d_year@1 <= 2001, projection=[d_date_sk@0]
             │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
@@ -1654,8 +1654,8 @@ mod tests {
             │         PartitionIsolatorExec: tasks=2 partitions=4
             │           DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/date_dim/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-3.parquet]]}, projection=[d_date_sk, d_year], file_type=parquet, predicate=d_year@6 >= 1999 AND d_year@6 <= 2001, pruning_predicate=d_year_null_count@1 != row_count@2 AND d_year_max@0 >= 1999 AND d_year_null_count@1 != row_count@2 AND d_year_min@3 <= 2001, required_guarantees=[]
             └──────────────────────────────────────────────────
-            ┌───── Stage 20 ── Tasks: t0:[p0..p5] t1:[p6..p11]
-            │ BroadcastExec: input_partitions=3, consumer_tasks=2, output_partitions=6
+            ┌───── Stage 20 ── Tasks: t0:[p0..p2] t1:[p3..p5]
+            │ BroadcastExec: input_partitions=3, consumer_tasks=1, output_partitions=3
             │   ProjectionExec: expr=[d_date_sk@0 as d_date_sk, CAST(d_date_sk@0 AS Float64) as CAST(date_dim.d_date_sk AS Float64)]
             │     FilterExec: d_year@1 >= 1999 AND d_year@1 <= 2001, projection=[d_date_sk@0]
             │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
@@ -1777,12 +1777,13 @@ mod tests {
               └──────────────────────────────────────────────────
           ┌───── Stage 38 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8] t3:[p9..p11]
           │ AggregateExec: mode=Partial, gby=[], aggr=[avg(sq2.quantity * sq2.list_price)]
-          │   DistributedUnionExec: t0:[c0] t1:[c1] t2:[c2(0/2)] t3:[c2(1/2)]
+          │   DistributedUnionExec: t0:[c0(0/2)] t1:[c0(1/2)] t2:[c1] t3:[c2]
           │     ProjectionExec: expr=[ss_quantity@0 as quantity, ss_list_price@1 as list_price]
           │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(CAST(date_dim.d_date_sk AS Float64)@1, ss_sold_date_sk@0)], projection=[ss_quantity@3, ss_list_price@4]
           │         CoalescePartitionsExec
-          │           [Stage 35] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=3, input_tasks=2
-          │         DataSourceExec: file_groups={3 groups: [[/testdata/tpcds/plans_sf1_partitions4/store_sales/part-0.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/store_sales/part-3.parquet:<int>..<int>]]}, projection=[ss_sold_date_sk, ss_quantity, ss_list_price], file_type=parquet, predicate=DynamicFilter [ empty ]
+          │           [Stage 35] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=6, input_tasks=2
+          │         PartitionIsolatorExec: tasks=2 partitions=6
+          │           DataSourceExec: file_groups={6 groups: [[/testdata/tpcds/plans_sf1_partitions4/store_sales/part-0.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>], ...]}, projection=[ss_sold_date_sk, ss_quantity, ss_list_price], file_type=parquet, predicate=DynamicFilter [ empty ]
           │     ProjectionExec: expr=[cs_quantity@0 as quantity, cs_list_price@1 as list_price]
           │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(CAST(date_dim.d_date_sk AS Float64)@1, cs_sold_date_sk@0)], projection=[cs_quantity@3, cs_list_price@4]
           │         CoalescePartitionsExec
@@ -1791,12 +1792,11 @@ mod tests {
           │     ProjectionExec: expr=[ws_quantity@0 as quantity, ws_list_price@1 as list_price]
           │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(CAST(date_dim.d_date_sk AS Float64)@1, ws_sold_date_sk@0)], projection=[ws_quantity@3, ws_list_price@4]
           │         CoalescePartitionsExec
-          │           [Stage 37] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=6, input_tasks=2
-          │         PartitionIsolatorExec: tasks=2 partitions=6
-          │           DataSourceExec: file_groups={6 groups: [[/testdata/tpcds/plans_sf1_partitions4/web_sales/part-0.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-2.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-2.parquet:<int>..<int>], ...]}, projection=[ws_sold_date_sk, ws_quantity, ws_list_price], file_type=parquet, predicate=DynamicFilter [ empty ]
+          │           [Stage 37] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=3, input_tasks=2
+          │         DataSourceExec: file_groups={3 groups: [[/testdata/tpcds/plans_sf1_partitions4/web_sales/part-0.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/web_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-1.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/web_sales/part-2.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-2.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/web_sales/part-3.parquet:<int>..<int>]]}, projection=[ws_sold_date_sk, ws_quantity, ws_list_price], file_type=parquet, predicate=DynamicFilter [ empty ]
           └──────────────────────────────────────────────────
-            ┌───── Stage 35 ── Tasks: t0:[p0..p2] t1:[p3..p5]
-            │ BroadcastExec: input_partitions=3, consumer_tasks=1, output_partitions=3
+            ┌───── Stage 35 ── Tasks: t0:[p0..p5] t1:[p6..p11]
+            │ BroadcastExec: input_partitions=3, consumer_tasks=2, output_partitions=6
             │   ProjectionExec: expr=[d_date_sk@0 as d_date_sk, CAST(d_date_sk@0 AS Float64) as CAST(date_dim.d_date_sk AS Float64)]
             │     FilterExec: d_year@1 >= 1999 AND d_year@1 <= 2001, projection=[d_date_sk@0]
             │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
@@ -1811,8 +1811,8 @@ mod tests {
             │         PartitionIsolatorExec: tasks=2 partitions=4
             │           DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/date_dim/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-3.parquet]]}, projection=[d_date_sk, d_year], file_type=parquet, predicate=d_year@6 >= 1999 AND d_year@6 <= 2001, pruning_predicate=d_year_null_count@1 != row_count@2 AND d_year_max@0 >= 1999 AND d_year_null_count@1 != row_count@2 AND d_year_min@3 <= 2001, required_guarantees=[]
             └──────────────────────────────────────────────────
-            ┌───── Stage 37 ── Tasks: t0:[p0..p5] t1:[p6..p11]
-            │ BroadcastExec: input_partitions=3, consumer_tasks=2, output_partitions=6
+            ┌───── Stage 37 ── Tasks: t0:[p0..p2] t1:[p3..p5]
+            │ BroadcastExec: input_partitions=3, consumer_tasks=1, output_partitions=3
             │   ProjectionExec: expr=[d_date_sk@0 as d_date_sk, CAST(d_date_sk@0 AS Float64) as CAST(date_dim.d_date_sk AS Float64)]
             │     FilterExec: d_year@1 >= 1999 AND d_year@1 <= 2001, projection=[d_date_sk@0]
             │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
@@ -3075,14 +3075,14 @@ mod tests {
     #[tokio::test]
     async fn test_tpcds_27() -> Result<()> {
         let display = test_tpcds_query("q27").await?;
-        assert_snapshot!(display, @"
+        assert_snapshot!(display, @r"
         ┌───── DistributedExec ── Tasks: t0:[p0]
         │ SortPreservingMergeExec: [i_item_id@0 ASC, s_state@1 ASC], fetch=100
         │   [Stage 19] => NetworkCoalesceExec: output_partitions=12, input_tasks=4
         └──────────────────────────────────────────────────
           ┌───── Stage 19 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8] t3:[p9..p11]
           │ SortExec: TopK(fetch=100), expr=[i_item_id@0 ASC], preserve_partitioning=[true]
-          │   DistributedUnionExec: t0:[c0] t1:[c1(0/2)] t2:[c1(1/2)] t3:[c2]
+          │   DistributedUnionExec: t0:[c0(0/2)] t1:[c0(1/2)] t2:[c1] t3:[c2]
           │     ProjectionExec: expr=[i_item_id@0 as i_item_id, CAST(s_state@1 AS Utf8) as s_state, 0 as g_state, avg(results.agg1)@2 as agg1, avg(results.agg2)@3 as agg2, avg(results.agg3)@4 as agg3, avg(results.agg4)@5 as agg4]
           │       AggregateExec: mode=FinalPartitioned, gby=[i_item_id@0 as i_item_id, s_state@1 as s_state], aggr=[avg(results.agg1), avg(results.agg2), avg(results.agg3), avg(results.agg4)], ordering_mode=PartiallySorted([1])
           │         [Stage 6] => NetworkShuffleExec: output_partitions=3, input_tasks=3
@@ -3094,8 +3094,8 @@ mod tests {
           │         CoalescePartitionsExec
           │           [Stage 18] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
           └──────────────────────────────────────────────────
-            ┌───── Stage 6 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2]
-            │ RepartitionExec: partitioning=Hash([i_item_id@0, s_state@1], 3), input_partitions=3
+            ┌───── Stage 6 ── Tasks: t0:[p0..p5] t1:[p0..p5] t2:[p0..p5]
+            │ RepartitionExec: partitioning=Hash([i_item_id@0, s_state@1], 6), input_partitions=3
             │   AggregateExec: mode=Partial, gby=[i_item_id@0 as i_item_id, s_state@1 as s_state], aggr=[avg(results.agg1), avg(results.agg2), avg(results.agg3), avg(results.agg4)], ordering_mode=PartiallySorted([1])
             │     ProjectionExec: expr=[i_item_id@5 as i_item_id, s_state@4 as s_state, ss_quantity@0 as agg1, ss_list_price@1 as agg2, ss_coupon_amt@3 as agg3, ss_sales_price@2 as agg4]
             │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(ss_item_sk@0, i_item_sk@0)], projection=[ss_quantity@1, ss_list_price@2, ss_sales_price@3, ss_coupon_amt@4, s_state@5, i_item_id@7]
@@ -3146,8 +3146,8 @@ mod tests {
                 │   PartitionIsolatorExec: tasks=3 partitions=6
                 │     DataSourceExec: file_groups={6 groups: [[/testdata/tpcds/plans_sf1_partitions4/store_sales/part-0.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>], ...]}, projection=[ss_sold_date_sk, ss_item_sk, ss_cdemo_sk, ss_store_sk, ss_quantity, ss_list_price, ss_sales_price, ss_coupon_amt], file_type=parquet, predicate=DynamicFilter [ empty ] AND DynamicFilter [ empty ] AND DynamicFilter [ empty ]
                 └──────────────────────────────────────────────────
-            ┌───── Stage 12 ── Tasks: t0:[p0..p5] t1:[p0..p5] t2:[p0..p5]
-            │ RepartitionExec: partitioning=Hash([i_item_id@0], 6), input_partitions=3
+            ┌───── Stage 12 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2]
+            │ RepartitionExec: partitioning=Hash([i_item_id@0], 3), input_partitions=3
             │   AggregateExec: mode=Partial, gby=[i_item_id@0 as i_item_id], aggr=[avg(results.agg1), avg(results.agg2), avg(results.agg3), avg(results.agg4)]
             │     ProjectionExec: expr=[i_item_id@4 as i_item_id, ss_quantity@0 as agg1, ss_list_price@1 as agg2, ss_coupon_amt@3 as agg3, ss_sales_price@2 as agg4]
             │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(ss_item_sk@0, i_item_sk@0)], projection=[ss_quantity@1, ss_list_price@2, ss_sales_price@3, ss_coupon_amt@4, i_item_id@6]
@@ -7602,12 +7602,13 @@ mod tests {
               └──────────────────────────────────────────────────
                 ┌───── Stage 4 ── Tasks: t0:[p0..p11] t1:[p12..p23] t2:[p24..p35] t3:[p36..p47]
                 │ BroadcastExec: input_partitions=3, consumer_tasks=4, output_partitions=12
-                │   DistributedUnionExec: t0:[c0] t1:[c1] t2:[c2(0/2)] t3:[c2(1/2)]
+                │   DistributedUnionExec: t0:[c0(0/2)] t1:[c0(1/2)] t2:[c1] t3:[c2]
                 │     ProjectionExec: expr=[ws_ext_sales_price@2 as ext_price, ws_item_sk@1 as sold_item_sk, ws_sold_time_sk@0 as time_sk]
                 │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(CAST(date_dim.d_date_sk AS Float64)@1, ws_sold_date_sk@0)], projection=[ws_sold_time_sk@3, ws_item_sk@4, ws_ext_sales_price@5]
                 │         CoalescePartitionsExec
-                │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=3, input_tasks=2
-                │         DataSourceExec: file_groups={3 groups: [[/testdata/tpcds/plans_sf1_partitions4/web_sales/part-0.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/web_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-1.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/web_sales/part-2.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-2.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/web_sales/part-3.parquet:<int>..<int>]]}, projection=[ws_sold_date_sk, ws_sold_time_sk, ws_item_sk, ws_ext_sales_price], file_type=parquet, predicate=DynamicFilter [ empty ]
+                │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=6, input_tasks=2
+                │         PartitionIsolatorExec: tasks=2 partitions=6
+                │           DataSourceExec: file_groups={6 groups: [[/testdata/tpcds/plans_sf1_partitions4/web_sales/part-0.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-2.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/web_sales/part-2.parquet:<int>..<int>], ...]}, projection=[ws_sold_date_sk, ws_sold_time_sk, ws_item_sk, ws_ext_sales_price], file_type=parquet, predicate=DynamicFilter [ empty ]
                 │     ProjectionExec: expr=[cs_ext_sales_price@2 as ext_price, cs_item_sk@1 as sold_item_sk, cs_sold_time_sk@0 as time_sk]
                 │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(CAST(date_dim.d_date_sk AS Float64)@1, cs_sold_date_sk@0)], projection=[cs_sold_time_sk@3, cs_item_sk@4, cs_ext_sales_price@5]
                 │         CoalescePartitionsExec
@@ -7616,12 +7617,11 @@ mod tests {
                 │     ProjectionExec: expr=[ss_ext_sales_price@2 as ext_price, ss_item_sk@1 as sold_item_sk, ss_sold_time_sk@0 as time_sk]
                 │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(CAST(date_dim.d_date_sk AS Float64)@1, ss_sold_date_sk@0)], projection=[ss_sold_time_sk@3, ss_item_sk@4, ss_ext_sales_price@5]
                 │         CoalescePartitionsExec
-                │           [Stage 3] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=6, input_tasks=2
-                │         PartitionIsolatorExec: tasks=2 partitions=6
-                │           DataSourceExec: file_groups={6 groups: [[/testdata/tpcds/plans_sf1_partitions4/store_sales/part-0.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>], ...]}, projection=[ss_sold_date_sk, ss_sold_time_sk, ss_item_sk, ss_ext_sales_price], file_type=parquet, predicate=DynamicFilter [ empty ]
+                │           [Stage 3] => NetworkBroadcastExec: partitions_per_consumer=3, stage_partitions=3, input_tasks=2
+                │         DataSourceExec: file_groups={3 groups: [[/testdata/tpcds/plans_sf1_partitions4/store_sales/part-0.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-1.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/store_sales/part-2.parquet:<int>..<int>, /testdata/tpcds/plans_sf1_partitions4/store_sales/part-3.parquet:<int>..<int>]]}, projection=[ss_sold_date_sk, ss_sold_time_sk, ss_item_sk, ss_ext_sales_price], file_type=parquet, predicate=DynamicFilter [ empty ]
                 └──────────────────────────────────────────────────
-                  ┌───── Stage 1 ── Tasks: t0:[p0..p2] t1:[p3..p5]
-                  │ BroadcastExec: input_partitions=3, consumer_tasks=1, output_partitions=3
+                  ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p6..p11]
+                  │ BroadcastExec: input_partitions=3, consumer_tasks=2, output_partitions=6
                   │   ProjectionExec: expr=[d_date_sk@0 as d_date_sk, CAST(d_date_sk@0 AS Float64) as CAST(date_dim.d_date_sk AS Float64)]
                   │     FilterExec: d_moy@2 = 11 AND d_year@1 = 1999, projection=[d_date_sk@0]
                   │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
@@ -7636,8 +7636,8 @@ mod tests {
                   │         PartitionIsolatorExec: tasks=2 partitions=4
                   │           DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/date_dim/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-3.parquet]]}, projection=[d_date_sk, d_year, d_moy], file_type=parquet, predicate=d_moy@8 = 11 AND d_year@6 = 1999, pruning_predicate=d_moy_null_count@2 != row_count@3 AND d_moy_min@0 <= 11 AND 11 <= d_moy_max@1 AND d_year_null_count@6 != row_count@3 AND d_year_min@4 <= 1999 AND 1999 <= d_year_max@5, required_guarantees=[d_moy in (11), d_year in (1999)]
                   └──────────────────────────────────────────────────
-                  ┌───── Stage 3 ── Tasks: t0:[p0..p5] t1:[p6..p11]
-                  │ BroadcastExec: input_partitions=3, consumer_tasks=2, output_partitions=6
+                  ┌───── Stage 3 ── Tasks: t0:[p0..p2] t1:[p3..p5]
+                  │ BroadcastExec: input_partitions=3, consumer_tasks=1, output_partitions=3
                   │   ProjectionExec: expr=[d_date_sk@0 as d_date_sk, CAST(d_date_sk@0 AS Float64) as CAST(date_dim.d_date_sk AS Float64)]
                   │     FilterExec: d_moy@2 = 11 AND d_year@1 = 1999, projection=[d_date_sk@0]
                   │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
@@ -8238,7 +8238,7 @@ mod tests {
     #[tokio::test]
     async fn test_tpcds_76() -> Result<()> {
         let display = test_tpcds_query("q76").await?;
-        assert_snapshot!(display, @"
+        assert_snapshot!(display, @r"
         ┌───── DistributedExec ── Tasks: t0:[p0]
         │ SortPreservingMergeExec: [channel@0 ASC, col_name@1 ASC, d_year@2 ASC, d_qoy@3 ASC, i_category@4 ASC], fetch=100
         │   [Stage 11] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
@@ -8252,7 +8252,7 @@ mod tests {
             ┌───── Stage 10 ── Tasks: t0:[p0..p5] t1:[p0..p5] t2:[p0..p5] t3:[p0..p5]
             │ RepartitionExec: partitioning=Hash([channel@0, col_name@1, d_year@2, d_qoy@3, i_category@4], 6), input_partitions=3
             │   AggregateExec: mode=Partial, gby=[channel@0 as channel, col_name@1 as col_name, d_year@2 as d_year, d_qoy@3 as d_qoy, i_category@4 as i_category], aggr=[count(Int64(1)), sum(foo.ext_sales_price)], ordering_mode=PartiallySorted([0, 1])
-            │     DistributedUnionExec: t0:[c0] t1:[c1] t2:[c2(0/2)] t3:[c2(1/2)]
+            │     DistributedUnionExec: t0:[c0(0/2)] t1:[c0(1/2)] t2:[c1] t3:[c2]
             │       ProjectionExec: expr=[store as channel, ss_store_sk as col_name, d_year@0 as d_year, d_qoy@1 as d_qoy, i_category@3 as i_category, ss_ext_sales_price@2 as ext_sales_price]
             │         HashJoinExec: mode=Partitioned, join_type=Inner, on=[(CAST(date_dim.d_date_sk AS Float64)@3, ss_sold_date_sk@0)], projection=[d_year@1, d_qoy@2, ss_ext_sales_price@5, i_category@6]
             │           [Stage 1] => NetworkShuffleExec: output_partitions=3, input_tasks=2
@@ -8266,15 +8266,15 @@ mod tests {
             │           [Stage 7] => NetworkShuffleExec: output_partitions=3, input_tasks=2
             │           [Stage 9] => NetworkShuffleExec: output_partitions=3, input_tasks=3
             └──────────────────────────────────────────────────
-              ┌───── Stage 1 ── Tasks: t0:[p0..p2] t1:[p0..p2]
-              │ RepartitionExec: partitioning=Hash([CAST(date_dim.d_date_sk AS Float64)@3], 3), input_partitions=3
+              ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p0..p5]
+              │ RepartitionExec: partitioning=Hash([CAST(date_dim.d_date_sk AS Float64)@3], 6), input_partitions=3
               │   ProjectionExec: expr=[d_date_sk@0 as d_date_sk, d_year@1 as d_year, d_qoy@2 as d_qoy, CAST(d_date_sk@0 AS Float64) as CAST(date_dim.d_date_sk AS Float64)]
               │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
               │       PartitionIsolatorExec: tasks=2 partitions=4
               │         DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/date_dim/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-3.parquet]]}, projection=[d_date_sk, d_year, d_qoy], file_type=parquet
               └──────────────────────────────────────────────────
-              ┌───── Stage 3 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2]
-              │ RepartitionExec: partitioning=Hash([ss_sold_date_sk@0], 3), input_partitions=2
+              ┌───── Stage 3 ── Tasks: t0:[p0..p5] t1:[p0..p5] t2:[p0..p5]
+              │ RepartitionExec: partitioning=Hash([ss_sold_date_sk@0], 6), input_partitions=2
               │   ProjectionExec: expr=[ss_sold_date_sk@1 as ss_sold_date_sk, ss_ext_sales_price@2 as ss_ext_sales_price, i_category@0 as i_category]
               │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(i_item_sk@0, ss_item_sk@1)], projection=[i_category@1, ss_sold_date_sk@2, ss_ext_sales_price@4]
               │       CoalescePartitionsExec
@@ -8310,15 +8310,15 @@ mod tests {
                 │   PartitionIsolatorExec: tasks=2 partitions=4
                 │     DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/item/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/item/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/item/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/item/part-3.parquet]]}, projection=[i_item_sk, i_category], file_type=parquet
                 └──────────────────────────────────────────────────
-              ┌───── Stage 7 ── Tasks: t0:[p0..p5] t1:[p0..p5]
-              │ RepartitionExec: partitioning=Hash([CAST(date_dim.d_date_sk AS Float64)@3], 6), input_partitions=3
+              ┌───── Stage 7 ── Tasks: t0:[p0..p2] t1:[p0..p2]
+              │ RepartitionExec: partitioning=Hash([CAST(date_dim.d_date_sk AS Float64)@3], 3), input_partitions=3
               │   ProjectionExec: expr=[d_date_sk@0 as d_date_sk, d_year@1 as d_year, d_qoy@2 as d_qoy, CAST(d_date_sk@0 AS Float64) as CAST(date_dim.d_date_sk AS Float64)]
               │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
               │       PartitionIsolatorExec: tasks=2 partitions=4
               │         DataSourceExec: file_groups={4 groups: [[/testdata/tpcds/plans_sf1_partitions4/date_dim/part-0.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-1.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-2.parquet], [/testdata/tpcds/plans_sf1_partitions4/date_dim/part-3.parquet]]}, projection=[d_date_sk, d_year, d_qoy], file_type=parquet
               └──────────────────────────────────────────────────
-              ┌───── Stage 9 ── Tasks: t0:[p0..p5] t1:[p0..p5] t2:[p0..p5]
-              │ RepartitionExec: partitioning=Hash([cs_sold_date_sk@0], 6), input_partitions=2
+              ┌───── Stage 9 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2]
+              │ RepartitionExec: partitioning=Hash([cs_sold_date_sk@0], 3), input_partitions=2
               │   ProjectionExec: expr=[cs_sold_date_sk@1 as cs_sold_date_sk, cs_ext_sales_price@2 as cs_ext_sales_price, i_category@0 as i_category]
               │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(i_item_sk@0, cs_item_sk@1)], projection=[i_category@1, cs_sold_date_sk@2, cs_ext_sales_price@4]
               │       CoalescePartitionsExec
@@ -8736,7 +8736,7 @@ mod tests {
     #[tokio::test]
     async fn test_tpcds_80() -> Result<()> {
         let display = test_tpcds_query("q80").await?;
-        assert_snapshot!(display, @"
+        assert_snapshot!(display, @r"
         ┌───── DistributedExec ── Tasks: t0:[p0]
         │ SortPreservingMergeExec: [channel@0 ASC, id@1 ASC], fetch=100
         │   SortExec: TopK(fetch=100), expr=[channel@0 ASC, id@1 ASC], preserve_partitioning=[true]
@@ -8747,7 +8747,7 @@ mod tests {
           ┌───── Stage 22 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2] t3:[p0..p2]
           │ RepartitionExec: partitioning=Hash([channel@0, id@1, __grouping_id@2], 3), input_partitions=3
           │   AggregateExec: mode=Partial, gby=[(NULL as channel, NULL as id), (channel@0 as channel, NULL as id), (channel@0 as channel, id@1 as id)], aggr=[sum(x.sales), sum(x.returns_), sum(x.profit)]
-          │     DistributedUnionExec: t0:[c0] t1:[c1] t2:[c2(0/2)] t3:[c2(1/2)]
+          │     DistributedUnionExec: t0:[c0(0/2)] t1:[c0(1/2)] t2:[c1] t3:[c2]
           │       ProjectionExec: expr=[store channel as channel, concat(store, s_store_id@0) as id, sum(store_sales.ss_ext_sales_price)@1 as sales, sum(coalesce(store_returns.sr_return_amt,Int64(0)))@2 as returns_, sum(store_sales.ss_net_profit - coalesce(store_returns.sr_net_loss,Int64(0)))@3 as profit]
           │         AggregateExec: mode=FinalPartitioned, gby=[s_store_id@0 as s_store_id], aggr=[sum(store_sales.ss_ext_sales_price), sum(coalesce(store_returns.sr_return_amt,Int64(0))), sum(store_sales.ss_net_profit - coalesce(store_returns.sr_net_loss,Int64(0)))]
           │           [Stage 7] => NetworkShuffleExec: output_partitions=3, input_tasks=3
@@ -8758,8 +8758,8 @@ mod tests {
           │         AggregateExec: mode=FinalPartitioned, gby=[web_site_id@0 as web_site_id], aggr=[sum(web_sales.ws_ext_sales_price), sum(coalesce(web_returns.wr_return_amt,Int64(0))), sum(web_sales.ws_net_profit - coalesce(web_returns.wr_net_loss,Int64(0)))]
           │           [Stage 21] => NetworkShuffleExec: output_partitions=3, input_tasks=3
           └──────────────────────────────────────────────────
-            ┌───── Stage 7 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2]
-            │ RepartitionExec: partitioning=Hash([s_store_id@0], 3), input_partitions=3
+            ┌───── Stage 7 ── Tasks: t0:[p0..p5] t1:[p0..p5] t2:[p0..p5]
+            │ RepartitionExec: partitioning=Hash([s_store_id@0], 6), input_partitions=3
             │   AggregateExec: mode=Partial, gby=[s_store_id@4 as s_store_id], aggr=[sum(store_sales.ss_ext_sales_price), sum(coalesce(store_returns.sr_return_amt,Int64(0))), sum(store_sales.ss_net_profit - coalesce(store_returns.sr_net_loss,Int64(0)))]
             │     ProjectionExec: expr=[CAST(sr_return_amt@2 AS Decimal128(22, 2)) as __common_expr_1, CAST(sr_net_loss@3 AS Decimal128(22, 2)) as __common_expr_2, ss_ext_sales_price@0 as ss_ext_sales_price, ss_net_profit@1 as ss_net_profit, s_store_id@4 as s_store_id]
             │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(CAST(promotion.p_promo_sk AS Float64)@1, ss_promo_sk@0)], projection=[ss_ext_sales_price@3, ss_net_profit@4, sr_return_amt@5, sr_net_loss@6, s_store_id@7]
@@ -8880,8 +8880,8 @@ mod tests {
               │   PartitionIsolatorExec: tasks=3 partitions=6
               │     DataSourceExec: file_groups={6 groups: [[/testdata/tpcds/plans_sf1_partitions4/catalog_sales/part-0.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/catalog_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/catalog_sales/part-1.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/catalog_sales/part-2.parquet:<int>..<int>], [/testdata/tpcds/plans_sf1_partitions4/catalog_sales/part-2.parquet:<int>..<int>], ...]}, projection=[cs_sold_date_sk, cs_catalog_page_sk, cs_item_sk, cs_promo_sk, cs_order_number, cs_ext_sales_price, cs_net_profit], file_type=parquet, predicate=DynamicFilter [ empty ] AND DynamicFilter [ empty ] AND DynamicFilter [ empty ] AND DynamicFilter [ empty ]
               └──────────────────────────────────────────────────
-            ┌───── Stage 21 ── Tasks: t0:[p0..p5] t1:[p0..p5] t2:[p0..p5]
-            │ RepartitionExec: partitioning=Hash([web_site_id@0], 6), input_partitions=3
+            ┌───── Stage 21 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2]
+            │ RepartitionExec: partitioning=Hash([web_site_id@0], 3), input_partitions=3
             │   AggregateExec: mode=Partial, gby=[web_site_id@4 as web_site_id], aggr=[sum(web_sales.ws_ext_sales_price), sum(coalesce(web_returns.wr_return_amt,Int64(0))), sum(web_sales.ws_net_profit - coalesce(web_returns.wr_net_loss,Int64(0)))]
             │     ProjectionExec: expr=[CAST(wr_return_amt@2 AS Decimal128(22, 2)) as __common_expr_5, CAST(wr_net_loss@3 AS Decimal128(22, 2)) as __common_expr_6, ws_ext_sales_price@0 as ws_ext_sales_price, ws_net_profit@1 as ws_net_profit, web_site_id@4 as web_site_id]
             │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(ws_promo_sk@0, CAST(promotion.p_promo_sk AS Float64)@1)], projection=[ws_ext_sales_price@1, ws_net_profit@2, wr_return_amt@3, wr_net_loss@4, web_site_id@5]

--- a/tests/work_unit_feed.rs
+++ b/tests/work_unit_feed.rs
@@ -802,65 +802,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "ChildrenIsolatorUnionExec had a task count 3, which is greater than the sum of child task counts 2"]
-    async fn nested_union_budget_exceeds_children_sum() -> Result<(), Box<dyn std::error::Error>> {
-        let (plan, results) = run_query(
-            r#"
-            SET distributed.broadcast_joins = true;
-            SELECT b.tag, a.tag
-            FROM test_work_unit('big', 4, 'rows(1)', 'rows(1)', 'rows(1)', 'rows(1)') b
-            INNER JOIN (
-                SELECT * FROM test_work_unit('small_a', 1, 'rows(1)', 'rows(1)', 'rows(1)')
-                UNION ALL
-                SELECT * FROM test_work_unit('small_b', 1, 'rows(1)', 'rows(1)', 'rows(1)')
-            ) a ON a.letter = b.letter
-            ORDER BY a.tag, b.tag
-            "#,
-        )
-        .await?;
-
-        assert_snapshot!(plan + &results, @r"
-        ┌───── DistributedExec ── Tasks: t0:[p0]
-        │ SortPreservingMergeExec: [tag@1 ASC NULLS LAST, tag@0 ASC NULLS LAST]
-        │   [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
-        └──────────────────────────────────────────────────
-          ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
-          │ SortExec: expr=[tag@1 ASC NULLS LAST, tag@0 ASC NULLS LAST], preserve_partitioning=[true]
-          │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(letter@1, letter@1)], projection=[tag@0, tag@2]
-          │     CoalescePartitionsExec
-          │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=3
-          │     DistributedUnionExec: t0:[c0(0/2)] t1:[c0(1/2)] t2:[c1]
-          │       RowGeneratorExec: tag=small_a, tasks=1, partition_ops=[[rows(1)], [rows(1)], [rows(1)]]
-          │       RowGeneratorExec: tag=small_b, tasks=1, partition_ops=[[rows(1)], [rows(1)], [rows(1)]]
-          └──────────────────────────────────────────────────
-            ┌───── Stage 1 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
-            │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-            │   RowGeneratorExec: tag=big, tasks=4, partition_ops=[[rows(1)], [rows(1)], [rows(1)], [rows(1)]]
-            └──────────────────────────────────────────────────
-        +-----+---------+
-        | tag | tag     |
-        +-----+---------+
-        | big | small_a |
-        | big | small_a |
-        | big | small_a |
-        | big | small_a |
-        | big | small_a |
-        | big | small_a |
-        | big | small_b |
-        | big | small_b |
-        | big | small_b |
-        | big | small_b |
-        | big | small_b |
-        | big | small_b |
-        | big | small_b |
-        | big | small_b |
-        | big | small_b |
-        +-----+---------+
-        ");
-        Ok(())
-    }
-
-    #[tokio::test]
     async fn nested_union_budget_exceeds_children_sum() -> Result<(), Box<dyn std::error::Error>> {
         let (plan, results) = run_query(
             r#"

--- a/tests/work_unit_feed.rs
+++ b/tests/work_unit_feed.rs
@@ -860,6 +860,33 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn nested_union_budget_exceeds_children_sum() {
+        let res = run_query(
+            r#"
+            SET distributed.broadcast_joins = true;
+            SELECT b.tag, a.tag
+            FROM test_work_unit('big', 4, 'rows(1)', 'rows(1)', 'rows(1)', 'rows(1)') b
+            INNER JOIN (
+                SELECT * FROM test_work_unit('small_a', 1, 'rows(1)', 'rows(1)', 'rows(1)')
+                UNION ALL
+                SELECT * FROM test_work_unit('small_b', 1, 'rows(1)', 'rows(1)', 'rows(1)')
+            ) a ON a.letter = b.letter
+            "#,
+        )
+        .await;
+
+        let err = res.expect_err(
+            "expected the planner to reject the inconsistent CIU input (budget > children sum)",
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("ChildrenIsolatorUnionExec had a task count")
+                && msg.contains("greater than the sum of child task counts"),
+            "unexpected error message: {msg}"
+        );
+    }
+
     async fn run_query(sql: &str) -> Result<(String, String), DataFusionError> {
         let (mut ctx, _guard, _) = start_localhost_context(3, build_state).await;
         ctx.set_distributed_work_unit_feed(|p: &RowGeneratorExec| Some(&p.feed));

--- a/tests/work_unit_feed.rs
+++ b/tests/work_unit_feed.rs
@@ -177,7 +177,7 @@ mod tests {
         │   [Stage 1] => NetworkCoalesceExec: output_partitions=12, input_tasks=3
         └──────────────────────────────────────────────────
           ┌───── Stage 1 ── Tasks: t0:[p0..p3] t1:[p4..p7] t2:[p8..p11]
-          │ DistributedUnionExec: t0:[c0] t1:[c1(0/2)] t2:[c1(1/2)]
+          │ DistributedUnionExec: t0:[c0(0/2)] t1:[c0(1/2)] t2:[c1]
           │   SortExec: expr=[tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
           │     RowGeneratorExec: tag=left, tasks=2, partition_ops=[[rows(2)], [rows(1)], [rows(3)], [rows(1)]]
           │   SortExec: expr=[tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
@@ -189,15 +189,15 @@ mod tests {
         | left  | 0    | 0         | a      |
         | left  | 0    | 0         | b      |
         | left  | 0    | 1         | a      |
-        | left  | 0    | 2         | a      |
-        | left  | 0    | 2         | b      |
-        | left  | 0    | 2         | c      |
-        | left  | 0    | 3         | a      |
+        | left  | 1    | 0         | a      |
+        | left  | 1    | 0         | b      |
+        | left  | 1    | 0         | c      |
+        | left  | 1    | 1         | a      |
         | right | 0    | 0         | a      |
         | right | 0    | 1         | a      |
         | right | 0    | 1         | b      |
-        | right | 1    | 0         | a      |
-        | right | 1    | 1         | a      |
+        | right | 0    | 2         | a      |
+        | right | 0    | 3         | a      |
         +-------+------+-----------+--------+
         ",
         );
@@ -535,7 +535,7 @@ mod tests {
             ┌───── Stage 1 ── Tasks: t0:[p0..p5] t1:[p0..p5] t2:[p0..p5]
             │ RepartitionExec: partitioning=Hash([tag@0, letter@1], 6), input_partitions=4
             │   AggregateExec: mode=Partial, gby=[tag@0 as tag, letter@1 as letter], aggr=[count(Int64(1))]
-            │     DistributedUnionExec: t0:[c0] t1:[c1(0/2)] t2:[c1(1/2)]
+            │     DistributedUnionExec: t0:[c0(0/2)] t1:[c0(1/2)] t2:[c1]
             │       RowGeneratorExec: tag=left, tasks=2, partition_ops=[[rows(3)], [rows(2)], [rows(1)], [rows(2)]]
             │       RowGeneratorExec: tag=right, tasks=2, partition_ops=[[rows(2)], [rows(1)], [rows(1)], [rows(3)]]
             └──────────────────────────────────────────────────
@@ -778,7 +778,7 @@ mod tests {
         │   [Stage 1] => NetworkCoalesceExec: output_partitions=12, input_tasks=3
         └──────────────────────────────────────────────────
           ┌───── Stage 1 ── Tasks: t0:[p0..p3] t1:[p4..p7] t2:[p8..p11]
-          │ DistributedUnionExec: t0:[c0] t1:[c1(0/2)] t2:[c1(1/2)]
+          │ DistributedUnionExec: t0:[c0(0/2)] t1:[c0(1/2)] t2:[c1]
           │   SortExec: expr=[tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
           │     RowGeneratorExec: tag=fast, tasks=2, partition_ops=[[rows(1)], [rows(1)], [rows(1)], [rows(1)]]
           │   SortExec: expr=[tag@0 ASC NULLS LAST, task@1 ASC NULLS LAST, partition@2 ASC NULLS LAST, letter@3 ASC NULLS LAST], preserve_partitioning=[true]
@@ -789,12 +789,12 @@ mod tests {
         +------+------+-----------+--------+
         | fast | 0    | 0         | a      |
         | fast | 0    | 1         | a      |
-        | fast | 0    | 2         | a      |
-        | fast | 0    | 3         | a      |
+        | fast | 1    | 0         | a      |
+        | fast | 1    | 1         | a      |
         | slow | 0    | 0         | a      |
         | slow | 0    | 1         | a      |
-        | slow | 1    | 0         | a      |
-        | slow | 1    | 1         | a      |
+        | slow | 0    | 2         | a      |
+        | slow | 0    | 3         | a      |
         +------+------+-----------+--------+
         "
         );
@@ -861,8 +861,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn nested_union_budget_exceeds_children_sum() {
-        let res = run_query(
+    async fn nested_union_budget_exceeds_children_sum() -> Result<(), Box<dyn std::error::Error>> {
+        let (plan, results) = run_query(
             r#"
             SET distributed.broadcast_joins = true;
             SELECT b.tag, a.tag
@@ -872,19 +872,50 @@ mod tests {
                 UNION ALL
                 SELECT * FROM test_work_unit('small_b', 1, 'rows(1)', 'rows(1)', 'rows(1)')
             ) a ON a.letter = b.letter
+            ORDER BY a.tag, b.tag
             "#,
         )
-        .await;
+        .await?;
 
-        let err = res.expect_err(
-            "expected the planner to reject the inconsistent CIU input (budget > children sum)",
-        );
-        let msg = err.to_string();
-        assert!(
-            msg.contains("ChildrenIsolatorUnionExec had a task count")
-                && msg.contains("greater than the sum of child task counts"),
-            "unexpected error message: {msg}"
-        );
+        assert_snapshot!(plan + &results, @r"
+        ┌───── DistributedExec ── Tasks: t0:[p0]
+        │ SortPreservingMergeExec: [tag@1 ASC NULLS LAST, tag@0 ASC NULLS LAST]
+        │   [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+        └──────────────────────────────────────────────────
+          ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+          │ SortExec: expr=[tag@1 ASC NULLS LAST, tag@0 ASC NULLS LAST], preserve_partitioning=[true]
+          │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(letter@1, letter@1)], projection=[tag@0, tag@2]
+          │     CoalescePartitionsExec
+          │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=3
+          │     DistributedUnionExec: t0:[c0(0/2)] t1:[c0(1/2)] t2:[c1]
+          │       RowGeneratorExec: tag=small_a, tasks=1, partition_ops=[[rows(1)], [rows(1)], [rows(1)]]
+          │       RowGeneratorExec: tag=small_b, tasks=1, partition_ops=[[rows(1)], [rows(1)], [rows(1)]]
+          └──────────────────────────────────────────────────
+            ┌───── Stage 1 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+            │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+            │   RowGeneratorExec: tag=big, tasks=4, partition_ops=[[rows(1)], [rows(1)], [rows(1)], [rows(1)]]
+            └──────────────────────────────────────────────────
+        +-----+---------+
+        | tag | tag     |
+        +-----+---------+
+        | big | small_a |
+        | big | small_a |
+        | big | small_a |
+        | big | small_a |
+        | big | small_a |
+        | big | small_a |
+        | big | small_b |
+        | big | small_b |
+        | big | small_b |
+        | big | small_b |
+        | big | small_b |
+        | big | small_b |
+        | big | small_b |
+        | big | small_b |
+        | big | small_b |
+        +-----+---------+
+        ");
+        Ok(())
     }
 
     async fn run_query(sql: &str) -> Result<(String, String), DataFusionError> {


### PR DESCRIPTION
Stack of some PRs for fixing a bug in `ChildrenIsolatorUnionExec`:
- https://github.com/datafusion-contrib/datafusion-distributed/pull/455
- https://github.com/datafusion-contrib/datafusion-distributed/pull/456 <- you are here

---

## Summary

Fixes the planning error introduced when a `UnionExec`'s stage budget exceeds the sum of its children's task counts.

### Root cause

`ChildrenIsolatorUnionExec` was built with **hard task counts** per child. The planner passed each child's bottom-up task count as a fixed budget, but when a sibling subtree in the same stage drove the stage budget higher, `from_children_and_task_counts` would receive a `task_count_budget` larger than the sum of those hard counts and reject it with:

> ChildrenIsolatorUnionExec had a task count N, which is greater than the sum of child task counts M

### Fix

Replace the hard-task-count API with a **weight-based proportional allocation**:

- `from_children_and_task_counts` → `from_children_and_weights`, taking `Vec<ChildWeight>` where each `ChildWeight` carries a relative `f64` weight and an optional hard `max` cap (used to surface `Maximum(N)` annotations).
- The stage budget is distributed across children using the **Hare largest-remainder method**: `floor(budget × wᵢ / Σw)` for each child, with leftover slots going to the children with the largest fractional remainders.
- A child whose proportional share rounds to zero is **packed into the last occupied task slot** rather than stealing a slot from a heavier child — this also unifies the `budget < n` and `budget >= n` cases into a single code path.
- `Maximum(N)` caps are honoured: a capped child never receives more than `N` slots; excess budget flows to uncapped siblings, or leaves empty trailing slots if every child is capped.
- Weights are `f64`; `0.0` is valid (no share, packed); negative and non-finite values are rejected upfront.
