### PR TITLE
Fix early worker partition drop in RemoteWorkerConnection demux

### DIFF
--- a/src/worker/worker_connection_pool.rs
+++ b/src/worker/worker_connection_pool.rs
@@ -348,7 +348,12 @@ impl RemoteWorkerConnection {
                 }
 
                 if o_tx.send(Ok((flight_data, flight_metadata))).is_err() {
-                    return; // channel closed
+                    // The receiver for this partition was dropped (e.g. a hash join partition
+                    // completed early without consuming its probe side). Don't exit: other
+                    // partitions multiplexed over the same gRPC stream still need their data.
+                    // Undo the memory reservation that was grown for this dropped batch.
+                    memory_reservation.shrink(size);
+                    continue;
                 };
             }
         }.with_elapsed_compute(elapsed_compute));


### PR DESCRIPTION
- When a `HashJoinExec` in Partitioned mode has an empty build side, DataFusion PR #21068 optimises away probe-side consumption. In a distributed setting this causes some partition streams to be dropped before they are ever polled, closing their channel receiver.
- The `RemoteWorkerConnection` demux task (which fans a single gRPC stream out to N per-partition channels) was calling `return` the moment any channel reported a send error. This killed the demux and silently dropped data for every remaining partition that was still multiplexed on the same gRPC connection.
- Fix: replace `return` with `continue` so the demux keeps routing batches to the partitions that are still open. The memory reservation that was grown for the dropped batch is shrunk back immediately so the back-pressure budget stays accurate.

