### PR TITLE
Lazily set the producer head at execution time

### DIFF
--- a/src/distributed_planner/mod.rs
+++ b/src/distributed_planner/mod.rs
@@ -11,6 +11,7 @@ mod task_estimator;
 
 pub use distributed_config::DistributedConfig;
 pub use network_boundary::{NetworkBoundary, NetworkBoundaryExt};
+pub(crate) use network_boundary::{ProducerHead, insert_producer_head};
 pub use session_state_builder_ext::SessionStateBuilderExt;
 pub(crate) use task_estimator::set_distributed_task_estimator;
 pub use task_estimator::{TaskCountAnnotation, TaskEstimation, TaskEstimator, TaskRoutingContext};

--- a/src/distributed_planner/network_boundary.rs
+++ b/src/distributed_planner/network_boundary.rs
@@ -1,6 +1,8 @@
-use crate::{NetworkBroadcastExec, NetworkCoalesceExec, NetworkShuffleExec, Stage};
+use crate::{BroadcastExec, NetworkBroadcastExec, NetworkCoalesceExec, NetworkShuffleExec, Stage};
 use datafusion::common::Result;
-use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_expr::Partitioning;
+use datafusion::physical_plan::repartition::RepartitionExec;
+use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 use std::sync::Arc;
 
 /// This trait represents a node that introduces the necessity of a network boundary in the plan.
@@ -15,6 +17,22 @@ pub trait NetworkBoundary: ExecutionPlan {
 
     /// Returns the assigned input [Stage], if any.
     fn input_stage(&self) -> &Stage;
+
+    /// Defines what head node should the producer stage feeding this [NetworkBoundary]
+    /// implementation have. This information is used during planning an executing for ensuring
+    /// the head of a stage has the appropriate shape for consumption.
+    fn producer_head(&self, consumer_tasks: usize) -> ProducerHead;
+}
+
+/// Defines what shape should the head node of a stage have upon getting executed. Depending
+/// on the [NetworkBoundary] implementation, the stage below should have different head nodes.
+pub enum ProducerHead {
+    /// No specific head node is necessary.
+    None,
+    /// The head node should be a [BroadcastExec].
+    BroadcastExec { output_partitions: usize },
+    /// The head node should be a [RepartitionExec].
+    RepartitionExec { partitioning: Partitioning },
 }
 
 /// Extension trait for downcasting dynamic types to [NetworkBoundary].
@@ -41,38 +59,28 @@ impl NetworkBoundaryExt for dyn ExecutionPlan {
     }
 }
 
-/// Scales up the head node of the input stage of a network boundary. Different network boundaries
-/// have different needs for scaling up their input, like for example, scaling up a RepartitionExec
-/// during shuffles.
-pub(crate) fn network_boundary_scale_input(
+/// Ensures the head of the provided plan complies with the passed [ProducerHead] definition. This
+/// can be called both during planning and lazily at runtime.
+pub(crate) fn insert_producer_head(
     input: Arc<dyn ExecutionPlan>,
-    consumer_partitions: usize,
-    consumer_task_count: usize,
+    head: ProducerHead,
 ) -> Result<Arc<dyn ExecutionPlan>> {
-    let transformed = NetworkShuffleExec::scale_input(
-        Arc::clone(&input),
-        consumer_partitions,
-        consumer_task_count,
-    )?;
-    if transformed.transformed {
-        return Ok(transformed.data);
-    }
-    let transformed = NetworkBroadcastExec::scale_input(
-        Arc::clone(&input),
-        consumer_partitions,
-        consumer_task_count,
-    )?;
-    if transformed.transformed {
-        return Ok(transformed.data);
-    }
-    let transformed = NetworkCoalesceExec::scale_input(
-        Arc::clone(&input),
-        consumer_partitions,
-        consumer_task_count,
-    )?;
-    if transformed.transformed {
-        return Ok(transformed.data);
-    }
-
-    Ok(input)
+    let input = if let Some(r_exec) = input.downcast_ref::<RepartitionExec>() {
+        Arc::clone(r_exec.input())
+    } else if let Some(b_exec) = input.downcast_ref::<BroadcastExec>() {
+        Arc::clone(b_exec.input())
+    } else {
+        input
+    };
+    let plan = match head {
+        ProducerHead::None => input,
+        ProducerHead::BroadcastExec { output_partitions } => {
+            let partitions = input.output_partitioning().partition_count();
+            Arc::new(BroadcastExec::new(input, output_partitions / partitions))
+        }
+        ProducerHead::RepartitionExec { partitioning } => {
+            Arc::new(RepartitionExec::try_new(input, partitioning)?)
+        }
+    };
+    Ok(plan)
 }

--- a/src/distributed_planner/prepare_network_boundaries.rs
+++ b/src/distributed_planner/prepare_network_boundaries.rs
@@ -1,5 +1,5 @@
 use crate::common::TreeNodeExt;
-use crate::distributed_planner::network_boundary::network_boundary_scale_input;
+use crate::distributed_planner::network_boundary::insert_producer_head;
 use crate::stage::LocalStage;
 use crate::{NetworkBoundaryExt, Stage};
 use datafusion::common::Result;
@@ -35,11 +35,8 @@ pub(crate) fn prepare_network_boundaries(
 
         // 2) Scale up the head node of the input stage in order to account for the amount of partition
         //    and consumer count above it.
-        let plan = network_boundary_scale_input(
-            Arc::clone(&input_stage.plan),
-            nb.properties().partitioning.partition_count(),
-            task_count,
-        )?;
+        let plan =
+            insert_producer_head(Arc::clone(&input_stage.plan), nb.producer_head(task_count))?;
 
         // 3) Make sure the input stage can be uniquely identified with a stage index and query id.
         //    If there were already some `query_id` and `num` that's fine.

--- a/src/execution_plans/benchmarks/shuffle_bench.rs
+++ b/src/execution_plans/benchmarks/shuffle_bench.rs
@@ -223,7 +223,7 @@ impl ShuffleFixture {
             let shuffle = NetworkShuffleExec {
                 properties: Arc::new(PlanProperties::new(
                     EquivalenceProperties::new(Arc::clone(&self.schema)),
-                    Partitioning::UnknownPartitioning(self.bench.partitions),
+                    Partitioning::Hash(vec![Arc::new(Column::new("id", 0))], self.bench.partitions),
                     EmissionType::Incremental,
                     Boundedness::Bounded,
                 )),

--- a/src/execution_plans/benchmarks/transport_bench.rs
+++ b/src/execution_plans/benchmarks/transport_bench.rs
@@ -273,7 +273,7 @@ impl TransportFixture {
             let shuffle = NetworkShuffleExec {
                 properties: Arc::new(PlanProperties::new(
                     EquivalenceProperties::new(Arc::clone(&self.schema)),
-                    Partitioning::UnknownPartitioning(self.bench.partitions),
+                    Partitioning::RoundRobinBatch(self.bench.partitions),
                     EmissionType::Incremental,
                     Boundedness::Bounded,
                 )),

--- a/src/execution_plans/broadcast.rs
+++ b/src/execution_plans/broadcast.rs
@@ -104,6 +104,10 @@ impl BroadcastExec {
     pub fn consumer_task_count(&self) -> usize {
         self.consumer_task_count
     }
+
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
 }
 
 impl DisplayAs for BroadcastExec {

--- a/src/execution_plans/network_broadcast.rs
+++ b/src/execution_plans/network_broadcast.rs
@@ -1,9 +1,8 @@
 use crate::common::require_one_child;
-use crate::distributed_planner::NetworkBoundary;
+use crate::distributed_planner::{NetworkBoundary, ProducerHead};
 use crate::stage::{LocalStage, Stage};
 use crate::worker::WorkerConnectionPool;
 use crate::{BroadcastExec, DistributedTaskContext};
-use datafusion::common::tree_node::Transformed;
 use datafusion::common::{Result, not_impl_err, plan_err};
 use datafusion::error::DataFusionError;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -123,21 +122,6 @@ pub struct NetworkBroadcastExec {
 }
 
 impl NetworkBroadcastExec {
-    pub(crate) fn scale_input(
-        plan: Arc<dyn ExecutionPlan>,
-        _consumer_partitions: usize,
-        consumer_task_count: usize,
-    ) -> Result<Transformed<Arc<dyn ExecutionPlan>>> {
-        let Some(broadcast) = plan.downcast_ref::<BroadcastExec>() else {
-            return Ok(Transformed::no(plan));
-        };
-
-        Ok(Transformed::yes(Arc::new(BroadcastExec::new(
-            require_one_child(broadcast.children())?,
-            consumer_task_count,
-        ))))
-    }
-
     pub(crate) fn from_stage(input_stage: Stage, input_properties: Arc<PlanProperties>) -> Self {
         let input_partition_count = input_properties.partitioning.partition_count();
         let properties = Arc::new(
@@ -185,6 +169,13 @@ impl NetworkBoundary for NetworkBroadcastExec {
 
     fn input_stage(&self) -> &Stage {
         &self.input_stage
+    }
+
+    fn producer_head(&self, consumer_task_count: usize) -> ProducerHead {
+        let partition_count = self.properties.output_partitioning().partition_count();
+        ProducerHead::BroadcastExec {
+            output_partitions: partition_count * consumer_task_count,
+        }
     }
 }
 
@@ -247,7 +238,8 @@ impl ExecutionPlan for NetworkBroadcastExec {
         };
 
         let task_context = DistributedTaskContext::from_ctx(&context);
-        let off = self.properties.partitioning.partition_count() * task_context.task_index;
+        let out_partitions = self.properties.partitioning.partition_count();
+        let off = out_partitions * task_context.task_index;
         let mut streams = Vec::with_capacity(self.input_stage.task_count());
 
         for input_task_index in 0..self.input_stage.task_count() {
@@ -255,6 +247,7 @@ impl ExecutionPlan for NetworkBroadcastExec {
                 remote_stage,
                 off..(off + self.properties.partitioning.partition_count()),
                 input_task_index,
+                self.producer_head(task_context.task_count),
                 &context,
             )?;
 

--- a/src/execution_plans/network_coalesce.rs
+++ b/src/execution_plans/network_coalesce.rs
@@ -1,10 +1,9 @@
 use crate::DistributedTaskContext;
 use crate::common::require_one_child;
-use crate::distributed_planner::NetworkBoundary;
+use crate::distributed_planner::{NetworkBoundary, ProducerHead};
 use crate::execution_plans::common::scale_partitioning_props;
 use crate::stage::{LocalStage, Stage};
 use crate::worker::WorkerConnectionPool;
-use datafusion::common::tree_node::Transformed;
 use datafusion::common::{exec_err, not_impl_err, plan_err};
 use datafusion::error::Result;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -81,16 +80,6 @@ pub struct NetworkCoalesceExec {
 }
 
 impl NetworkCoalesceExec {
-    /// Does nothing, but it's here for explicitly stating that this network boundary does not
-    /// need to mutate the input plan in other to account for more consumer tasks.
-    pub(crate) fn scale_input(
-        plan: Arc<dyn ExecutionPlan>,
-        _consumer_partitions: usize,
-        _consumer_task_count: usize,
-    ) -> Result<Transformed<Arc<dyn ExecutionPlan>>> {
-        Ok(Transformed::no(plan))
-    }
-
     pub(crate) fn from_stage(
         input_stage: Stage,
         input_properties: Arc<PlanProperties>,
@@ -186,6 +175,10 @@ impl NetworkBoundary for NetworkCoalesceExec {
         self_clone.worker_connections = WorkerConnectionPool::new(input_stage.task_count());
         self_clone.input_stage = input_stage;
         Ok(Arc::new(self_clone))
+    }
+
+    fn producer_head(&self, _consumer_task_count: usize) -> ProducerHead {
+        ProducerHead::None
     }
 }
 
@@ -299,6 +292,7 @@ impl ExecutionPlan for NetworkCoalesceExec {
             remote_stage,
             0..partitions_per_task,
             target_task,
+            self.producer_head(task_context.task_count),
             &context,
         )?;
 

--- a/src/execution_plans/network_shuffle.rs
+++ b/src/execution_plans/network_shuffle.rs
@@ -1,9 +1,9 @@
 use crate::common::require_one_child;
+use crate::distributed_planner::ProducerHead;
 use crate::execution_plans::common::scale_partitioning;
 use crate::stage::{LocalStage, Stage};
 use crate::worker::WorkerConnectionPool;
 use crate::{DistributedTaskContext, NetworkBoundary};
-use datafusion::common::tree_node::{Transformed, TreeNodeRecursion};
 use datafusion::common::{Result, not_impl_err, plan_err};
 use datafusion::error::DataFusionError;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -105,26 +105,6 @@ pub struct NetworkShuffleExec {
 }
 
 impl NetworkShuffleExec {
-    pub(crate) fn scale_input(
-        plan: Arc<dyn ExecutionPlan>,
-        consumer_partitions: usize,
-        consumer_task_count: usize,
-    ) -> Result<Transformed<Arc<dyn ExecutionPlan>>> {
-        let Some(repartition_exec) = plan.downcast_ref::<RepartitionExec>() else {
-            return Ok(Transformed::no(plan));
-        };
-
-        let child = require_one_child(repartition_exec.children())?;
-        let partitioning = scale_partitioning(repartition_exec.partitioning(), |_| {
-            consumer_partitions * consumer_task_count
-        });
-
-        // Scale the input RepartitionExec to account for all the tasks to which it will
-        // need to fan data out.
-        let scaled = Arc::new(RepartitionExec::try_new(child, partitioning)?);
-        Ok(Transformed::new(scaled, true, TreeNodeRecursion::Stop))
-    }
-
     pub(crate) fn from_stage(input_stage: Stage, input_properties: Arc<PlanProperties>) -> Self {
         Self {
             properties: input_properties,
@@ -169,6 +149,14 @@ impl NetworkBoundary for NetworkShuffleExec {
         self_clone.worker_connections = WorkerConnectionPool::new(input_stage.task_count());
         self_clone.input_stage = input_stage;
         Ok(Arc::new(self_clone))
+    }
+
+    fn producer_head(&self, consumer_task_count: usize) -> ProducerHead {
+        ProducerHead::RepartitionExec {
+            partitioning: scale_partitioning(&self.properties.partitioning, |prev| {
+                prev * consumer_task_count
+            }),
+        }
     }
 }
 
@@ -233,6 +221,7 @@ impl ExecutionPlan for NetworkShuffleExec {
                 remote_stage,
                 off..(off + self.properties.partitioning.partition_count()),
                 input_task_index,
+                self.producer_head(task_context.task_count),
                 &context,
             )?;
 

--- a/src/observability/service.rs
+++ b/src/observability/service.rs
@@ -96,7 +96,7 @@ impl ObservabilityService for ObservabilityServiceImpl {
                 let total_partitions = task_data.total_partitions() as u64;
                 let remaining = task_data.num_partitions_remaining() as u64;
                 let completed_partitions = total_partitions.saturating_sub(remaining);
-                let output_rows = output_rows_from_plan(&task_data.plan);
+                let output_rows = output_rows_from_plan(&task_data.base_plan);
 
                 tasks.push(TaskProgress {
                     task_key: Some((*internal_key).clone()),

--- a/src/protobuf/mod.rs
+++ b/src/protobuf/mod.rs
@@ -1,5 +1,6 @@
 mod distributed_codec;
 mod errors;
+mod producer_head;
 mod user_codec;
 
 pub use distributed_codec::DistributedCodec;

--- a/src/protobuf/producer_head.rs
+++ b/src/protobuf/producer_head.rs
@@ -1,0 +1,63 @@
+use crate::DistributedCodec;
+use crate::distributed_planner::ProducerHead;
+use crate::worker::generated::worker::{
+    BroadcastExecHead, NoneHead, RepartitionExecHead, execute_task_request as pb,
+};
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::common::Result;
+use datafusion::execution::TaskContext;
+use datafusion_proto::physical_plan::from_proto::parse_protobuf_partitioning;
+use datafusion_proto::physical_plan::to_proto::serialize_partitioning;
+use datafusion_proto::physical_plan::{DefaultPhysicalProtoConverter, PhysicalPlanDecodeContext};
+use datafusion_proto::protobuf;
+use datafusion_proto::protobuf::proto_error;
+use prost::Message;
+use std::sync::Arc;
+
+impl ProducerHead {
+    pub(crate) fn from_proto(
+        proto: pb::ProducerHead,
+        input_schema: &SchemaRef,
+        ctx: &Arc<TaskContext>,
+    ) -> Result<Self> {
+        Ok(match proto {
+            pb::ProducerHead::None(_) => ProducerHead::None,
+            pb::ProducerHead::Broadcast(v) => ProducerHead::BroadcastExec {
+                output_partitions: v.output_partitions as usize,
+            },
+            pb::ProducerHead::Repartition(v) => {
+                let proto_partitioning = protobuf::Partitioning::decode(v.partitioning.as_slice())
+                    .map_err(|e| proto_error(e.to_string()))?;
+                let codec = DistributedCodec::new_combined_with_user(ctx.session_config());
+                let decode_ctx = PhysicalPlanDecodeContext::new(ctx, &codec);
+                let partitioning = parse_protobuf_partitioning(
+                    Some(&proto_partitioning),
+                    &decode_ctx,
+                    input_schema,
+                    &DefaultPhysicalProtoConverter {},
+                )?
+                .ok_or_else(|| proto_error("Could not parse partitioning"))?;
+
+                ProducerHead::RepartitionExec { partitioning }
+            }
+        })
+    }
+
+    pub(crate) fn to_proto(&self, ctx: &Arc<TaskContext>) -> Result<pb::ProducerHead> {
+        Ok(match self {
+            ProducerHead::None => pb::ProducerHead::None(NoneHead {}),
+            ProducerHead::BroadcastExec { output_partitions } => {
+                pb::ProducerHead::Broadcast(BroadcastExecHead {
+                    output_partitions: *output_partitions as u64,
+                })
+            }
+            ProducerHead::RepartitionExec { partitioning } => {
+                let codec = DistributedCodec::new_combined_with_user(ctx.session_config());
+                let partitioning =
+                    serialize_partitioning(partitioning, &codec, &DefaultPhysicalProtoConverter {})
+                        .map(|v| v.encode_to_vec())?;
+                pb::ProducerHead::Repartition(RepartitionExecHead { partitioning })
+            }
+        })
+    }
+}

--- a/src/worker/generated/worker.rs
+++ b/src/worker/generated/worker.rs
@@ -131,6 +131,52 @@ pub struct ExecuteTaskRequest {
     /// The end of the partition range of the specified task that is going to be executed.
     #[prost(uint64, tag = "3")]
     pub target_partition_end: u64,
+    /// The head node the requested task should have. Depending on the network boundary executing
+    /// the task, the head node should be prepared differently, for example:
+    ///
+    /// * A RepartitionExecHead implies a RepartitionExec at the head of the task.
+    /// * A BroadcastExecHead implies a BroadcastExec at the head of the task.
+    /// * A NoneHead does not need any specific head.
+    #[prost(oneof = "execute_task_request::ProducerHead", tags = "6, 7, 8")]
+    pub producer_head: ::core::option::Option<execute_task_request::ProducerHead>,
+}
+/// Nested message and enum types in `ExecuteTaskRequest`.
+pub mod execute_task_request {
+    /// The head node the requested task should have. Depending on the network boundary executing
+    /// the task, the head node should be prepared differently, for example:
+    ///
+    /// * A RepartitionExecHead implies a RepartitionExec at the head of the task.
+    /// * A BroadcastExecHead implies a BroadcastExec at the head of the task.
+    /// * A NoneHead does not need any specific head.
+    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
+    pub enum ProducerHead {
+        /// The boundary executing the task is a NetworkCoalesceExec.
+        #[prost(message, tag = "6")]
+        None(super::NoneHead),
+        /// The boundary executing the task is a NetworkBroadcastExec.
+        #[prost(message, tag = "7")]
+        Broadcast(super::BroadcastExecHead),
+        /// The boundary executing the task is a NetworkShuffleExec.
+        #[prost(message, tag = "8")]
+        Repartition(super::RepartitionExecHead),
+    }
+}
+/// Head needed by a NetworkCoalesceExec.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct NoneHead {}
+/// Head needed by a NetworkBroadcastExec.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct BroadcastExecHead {
+    /// The amount of output partitions
+    #[prost(uint64, tag = "1")]
+    pub output_partitions: u64,
+}
+/// Head needed by a NetworkShuffleExec.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct RepartitionExecHead {
+    /// `Partitioning` message from datafusion.proto
+    #[prost(bytes = "vec", tag = "1")]
+    pub partitioning: ::prost::alloc::vec::Vec<u8>,
 }
 /// A key that uniquely identifies a task in a query.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]

--- a/src/worker/impl_coordinator_channel.rs
+++ b/src/worker/impl_coordinator_channel.rs
@@ -18,8 +18,8 @@ use datafusion::prelude::SessionConfig;
 use datafusion_proto::physical_plan::AsExecutionPlan;
 use datafusion_proto::protobuf::PhysicalPlanNode;
 use futures::{FutureExt, StreamExt, TryStreamExt};
-use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
+use std::sync::{Arc, OnceLock};
 use tokio::sync::oneshot;
 use tonic::{Request, Response, Status, Streaming};
 use url::Url;
@@ -102,7 +102,8 @@ impl Worker {
             // Initialize partition count to the number of partitions in the stage
             let total_partitions = plan.properties().partitioning.partition_count();
             Ok::<_, DataFusionError>(TaskData {
-                plan,
+                base_plan: plan,
+                final_plan: Arc::new(OnceLock::new()),
                 task_ctx,
                 num_partitions_remaining: Arc::new(AtomicUsize::new(total_partitions)),
                 metrics_tx: match collect_metrics {

--- a/src/worker/impl_execute_task.rs
+++ b/src/worker/impl_execute_task.rs
@@ -48,6 +48,9 @@ pub(crate) async fn execute_local_task(
     let Some(key) = body.task_key.as_ref().cloned() else {
         return internal_err!("Missing task_key in LocalWorkerConnection");
     };
+    let Some(producer_head) = body.producer_head.as_ref().cloned() else {
+        return internal_err!("Missing producer_head");
+    };
     let entry = task_data_entries
         .get_with(key.clone(), async { Default::default() })
         .await;
@@ -61,7 +64,7 @@ pub(crate) async fn execute_local_task(
         .map_err(DataFusionError::Shared)?;
     task_data.task_data_metrics.mark_execution_started_once();
 
-    let plan = task_data.plan;
+    let plan = task_data.plan(producer_head)?;
     let task_ctx = task_data.task_ctx;
     let d_cfg = DistributedConfig::from_config_options(task_ctx.session_config().options())?;
     let d_ctx = *DistributedTaskContext::from_ctx(&task_ctx).as_ref();

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -17,6 +17,5 @@ pub use session_builder::{
     DefaultSessionBuilder, MappedWorkerSessionBuilder, MappedWorkerSessionBuilderExt,
     WorkerQueryContext, WorkerSessionBuilder,
 };
-pub use worker_service::Worker;
-
 pub use task_data::TaskData;
+pub use worker_service::Worker;

--- a/src/worker/task_data.rs
+++ b/src/worker/task_data.rs
@@ -1,11 +1,13 @@
 use crate::MaxLatencyMetric;
-use crate::common::now_ns;
+use crate::common::{OnceLockResult, now_ns};
+use crate::distributed_planner::{ProducerHead, insert_producer_head};
 use crate::worker::generated::worker as pb;
+use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
 use datafusion::physical_expr_common::metrics::CustomMetricValue;
-use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 use std::sync::Arc;
-use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use tokio::sync::oneshot;
 
@@ -15,8 +17,8 @@ use tokio::sync::oneshot;
 pub struct TaskData {
     /// Task context suitable for execute different partitions from the same task.
     pub(super) task_ctx: Arc<TaskContext>,
-    /// Plan to be executed.
-    pub(crate) plan: Arc<dyn ExecutionPlan>,
+    pub(crate) base_plan: Arc<dyn ExecutionPlan>,
+    pub(crate) final_plan: Arc<OnceLockResult<Arc<dyn ExecutionPlan>>>,
     /// `num_partitions_remaining` is initialized to the total number of partitions in the task (not
     /// only tasks in the partition group). This is decremented for each request to the endpoint
     /// for this task. Once this count is zero, the task is likely complete. The task may not be
@@ -109,12 +111,40 @@ impl TaskDataMetrics {
 impl TaskData {
     /// Returns the number of partitions remaining to be processed.
     pub(crate) fn num_partitions_remaining(&self) -> usize {
-        self.num_partitions_remaining
-            .load(std::sync::atomic::Ordering::Relaxed)
+        self.num_partitions_remaining.load(Ordering::SeqCst)
     }
 
     /// Returns the total number of partitions in this task.
     pub(crate) fn total_partitions(&self) -> usize {
-        self.plan.properties().partitioning.partition_count()
+        match self.final_plan.get() {
+            Some(Ok(plan)) => plan.output_partitioning().partition_count(),
+            _ => self
+                .base_plan
+                .properties()
+                .output_partitioning()
+                .partition_count(),
+        }
+    }
+
+    pub(crate) fn plan(
+        &self,
+        producer_head: pb::execute_task_request::ProducerHead,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let result = self.final_plan.get_or_init(|| {
+            let producer_head =
+                ProducerHead::from_proto(producer_head, &self.base_plan.schema(), &self.task_ctx)?;
+
+            let plan = insert_producer_head(Arc::clone(&self.base_plan), producer_head)?;
+
+            self.num_partitions_remaining.store(
+                plan.output_partitioning().partition_count(),
+                Ordering::SeqCst,
+            );
+            Ok(plan)
+        });
+        match result {
+            Ok(plan) => Ok(Arc::clone(plan)),
+            Err(err) => Err(DataFusionError::Shared(Arc::clone(err))),
+        }
     }
 }

--- a/src/worker/test_utils/worker_handles.rs
+++ b/src/worker/test_utils/worker_handles.rs
@@ -215,7 +215,8 @@ pub async fn register_plan_on_worker(
     swmr_task_data
         .write(Ok(TaskData {
             task_ctx,
-            plan,
+            base_plan: plan,
+            final_plan: Default::default(),
             num_partitions_remaining: Arc::new(AtomicUsize::new(partition_count)),
             metrics_tx: Arc::new(std::sync::Mutex::new(Some(metrics_tx))),
             task_data_metrics: Arc::new(TaskDataMetrics::new(0)),

--- a/src/worker/worker.proto
+++ b/src/worker/worker.proto
@@ -103,6 +103,35 @@ message ExecuteTaskRequest {
   uint64 target_partition_start = 2;
   // The end of the partition range of the specified task that is going to be executed.
   uint64 target_partition_end = 3;
+
+  // The head node the requested task should have. Depending on the network boundary executing
+  // the task, the head node should be prepared differently, for example:
+  // - A RepartitionExecHead implies a RepartitionExec at the head of the task.
+  // - A BroadcastExecHead implies a BroadcastExec at the head of the task.
+  // - A NoneHead does not need any specific head.
+  oneof producer_head {
+    // The boundary executing the task is a NetworkCoalesceExec.
+    NoneHead none = 6;
+    // The boundary executing the task is a NetworkBroadcastExec.
+    BroadcastExecHead broadcast = 7;
+    // The boundary executing the task is a NetworkShuffleExec.
+    RepartitionExecHead repartition = 8;
+  }
+}
+
+// Head needed by a NetworkCoalesceExec.
+message NoneHead {}
+
+// Head needed by a NetworkBroadcastExec.
+message BroadcastExecHead {
+  // The amount of output partitions
+  uint64 output_partitions = 1;
+}
+
+// Head needed by a NetworkShuffleExec.
+message RepartitionExecHead {
+  // `Partitioning` message from datafusion.proto
+  bytes partitioning = 1;
 }
 
 // A key that uniquely identifies a task in a query.

--- a/src/worker/worker_connection_pool.rs
+++ b/src/worker/worker_connection_pool.rs
@@ -1,4 +1,5 @@
 use crate::common::{OnceLockResult, on_drop_stream, serialize_uuid};
+use crate::distributed_planner::ProducerHead;
 use crate::metrics::LatencyMetricExt;
 use crate::networking::get_distributed_channel_resolver;
 use crate::passthrough_headers::get_passthrough_headers;
@@ -16,7 +17,9 @@ use dashmap::DashMap;
 use datafusion::arrow::array::RecordBatch;
 use datafusion::common::instant::Instant;
 use datafusion::common::runtime::SpawnedTask;
-use datafusion::common::{DataFusionError, Result, internal_datafusion_err, internal_err};
+use datafusion::common::{
+    DataFusionError, Result, exec_err, internal_datafusion_err, internal_err,
+};
 use datafusion::execution::TaskContext;
 use datafusion::execution::memory_pool::{MemoryConsumer, MemoryReservation};
 use datafusion::physical_expr_common::metrics::{ExecutionPlanMetricsSet, MetricValue};
@@ -88,6 +91,7 @@ impl WorkerConnectionPool {
         input_stage: &RemoteStage,
         target_partitions: Range<usize>,
         target_task: usize,
+        producer_head: ProducerHead,
         ctx: &Arc<TaskContext>,
     ) -> Result<&(dyn WorkerConnection + Sync + Send)> {
         let Some(worker_connection) = self.connections.get(target_task) else {
@@ -105,19 +109,23 @@ impl WorkerConnectionPool {
                 && &lw_ctx.self_url == target_url
             {
                 // Instead of making a gRPC call to ourselves, better to just use local comms.
-                Ok(Box::new(LocalWorkerConnection::init(
+                LocalWorkerConnection::init(
                     input_stage,
                     target_partitions,
                     target_task,
-                    lw_ctx,
+                    producer_head,
+                    ctx,
                     &self.metrics,
-                )) as Box<_>)
+                )
+                .map(|v| Box::new(v) as Box<_>)
+                .map_err(Arc::new)
             } else {
                 // We are trying to reach a URL different from ours, so use normal gRPC streams.
                 RemoteWorkerConnection::init(
                     input_stage,
                     target_partitions,
                     target_task,
+                    producer_head,
                     ctx,
                     &self.metrics,
                 )
@@ -174,6 +182,7 @@ impl RemoteWorkerConnection {
         input_stage: &RemoteStage,
         target_partition_range: Range<usize>,
         target_task: usize,
+        producer_head: ProducerHead,
         ctx: &Arc<TaskContext>,
         metrics: &ExecutionPlanMetricsSet,
     ) -> Result<Self> {
@@ -223,6 +232,7 @@ impl RemoteWorkerConnection {
                     stage_id: input_stage.num as u64,
                     task_number: target_task as u64,
                 }),
+                producer_head: Some(producer_head.to_proto(ctx)?),
             },
         );
 
@@ -456,12 +466,16 @@ impl LocalWorkerConnection {
         input_stage: &RemoteStage,
         target_partition_range: Range<usize>,
         target_task: usize,
-        lw_ctx: Arc<LocalWorkerContext>,
+        producer_head: ProducerHead,
+        ctx: &Arc<TaskContext>,
         metrics: &ExecutionPlanMetricsSet,
-    ) -> Self {
+    ) -> Result<Self> {
         MetricBuilder::new(metrics)
             .global_counter("local_connections_used")
             .add(1);
+        let Some(lw_ctx) = ctx.session_config().get_extension::<LocalWorkerContext>() else {
+            return exec_err!("Missing LocalWorkerContext extension");
+        };
 
         let task_key = TaskKey {
             query_id: serialize_uuid(&input_stage.query_id),
@@ -476,6 +490,7 @@ impl LocalWorkerConnection {
                 task_key: Some(task_key.clone()),
                 target_partition_start: partition_i as u64,
                 target_partition_end: (partition_i + 1) as u64,
+                producer_head: Some(producer_head.to_proto(ctx)?),
             };
 
             let task_data_entries = Arc::clone(&lw_ctx.task_data_entries);
@@ -506,10 +521,10 @@ impl LocalWorkerConnection {
             local_streams.push(Mutex::new(Some(stream)));
         }
 
-        Self {
+        Ok(Self {
             partition_start,
             local_streams,
-        }
+        })
     }
 }
 


### PR DESCRIPTION
This is one PR from the following stack of PRs:
- https://github.com/datafusion-contrib/datafusion-distributed/pull/477
- https://github.com/datafusion-contrib/datafusion-distributed/pull/463
- https://github.com/datafusion-contrib/datafusion-distributed/pull/464
- https://github.com/datafusion-contrib/datafusion-distributed/pull/478 <- you are here
- https://github.com/datafusion-contrib/datafusion-distributed/pull/479
- https://github.com/datafusion-contrib/datafusion-distributed/pull/486
- https://github.com/datafusion-contrib/datafusion-distributed/pull/432

---

Introduces the `ProducerHead` type:

```rust
pub enum ProducerHead {
    /// No specific head node is necessary.
    None,
    /// The head node should be a [BroadcastExec].
    BroadcastExec { output_partitions: usize },
    /// The head node should be a [RepartitionExec].
    RepartitionExec { partitioning: Partitioning },
}
```

Which is passed over the network while remotely executing tasks in order to set the appropriate node at the head of a stage.

Today, this is a noop because the right head node in stages is ensured statically at planning time, but in follow up PRs, network boundaries can get swamped and reorganized arbitrarily.

One example that happens in AQE:

1. A JOIN is planned as a CollectLeft

```js
HashJoinExec: mode=CollectLeft
  CoalescePartitionsExec:
    [Stage 1] => NetworkBroadcastExec
      BroadcastExec
        DistributedLeafExec: unknown size
  DistributedLeafExec: unknown size
```

2. While collecting runtime statistics, it happens that `Stage 1` is huge, and during AQE the JOINs are swapped

```js
HashJoinExec: mode=CollectLeft
  DistributedLeafExec: small size
  CoalescePartitionsExec:
    [Stage 1] => NetworkBroadcastExec
      BroadcastExec
        DistributedLeafExec: big size
```

3. The `Stage 1` is now on the probe side, so it needs to be rewritten to a `NetworkShuffleExec`, otherwise duplicate data will be returned:

```js
HashJoinExec: mode=CollectLeft
  DistributedLeafExec: small size
  CoalescePartitionsExec:
    [Stage 1] => NetworkShuffleExec
      RepartitionExec // <- dynamically swapped at runtime based on the passed `ProducerHead`
        DistributedLeafExec: big size
```

Passing a `ProducerHead` at execution time unlocks two things:
1. dynamically set the fanout width accounting for a dynamically scaled upper stage
2. dynamically set the correct operator `BroadcastExec` or `RepartitionExec` based on the network boundary above, which might have changed because of AQE
