### PR TITLE
Fix deadlock when a HashJoinExec drops its network probe side unread (DF #21068)

### DIFF
--- a/src/execution_plans/benchmarks/shuffle_bench.rs
+++ b/src/execution_plans/benchmarks/shuffle_bench.rs
@@ -17,7 +17,7 @@ use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::{ExecutionPlan, PlanProperties};
 use futures::TryStreamExt;
 use std::fmt::{Display, Formatter};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tokio::task::JoinSet;
 use url::Url;
 use uuid::Uuid;
@@ -229,6 +229,7 @@ impl ShuffleFixture {
                 )),
                 input_stage: input_stage.clone(),
                 worker_connections: WorkerConnectionPool::new(self.bench.producer_tasks),
+                join_set: Arc::new(Mutex::new(Default::default())),
             };
             let task_ctx = Arc::new(task_ctx_with_extension(
                 &self.task_ctx,

--- a/src/execution_plans/benchmarks/transport_bench.rs
+++ b/src/execution_plans/benchmarks/transport_bench.rs
@@ -16,7 +16,7 @@ use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::{ExecutionPlan, PlanProperties};
 use futures::TryStreamExt;
 use std::fmt::{Display, Formatter};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tokio::task::JoinSet;
 use url::Url;
 use uuid::Uuid;
@@ -281,6 +281,7 @@ impl TransportFixture {
                 worker_connections: crate::worker::WorkerConnectionPool::new(
                     self.bench.producer_tasks,
                 ),
+                join_set: Arc::new(Mutex::new(Default::default())),
             };
             let task_ctx = Arc::new(task_ctx_with_extension(
                 &self.task_ctx,

--- a/src/execution_plans/network_shuffle.rs
+++ b/src/execution_plans/network_shuffle.rs
@@ -3,6 +3,7 @@ use crate::execution_plans::common::scale_partitioning;
 use crate::stage::{LocalStage, Stage};
 use crate::worker::WorkerConnectionPool;
 use crate::{DistributedTaskContext, NetworkBoundary};
+use datafusion::common::runtime::JoinSet;
 use datafusion::common::tree_node::{Transformed, TreeNodeRecursion};
 use datafusion::common::{Result, not_impl_err, plan_err};
 use datafusion::error::DataFusionError;
@@ -12,9 +13,12 @@ use datafusion::physical_expr_common::metrics::MetricsSet;
 use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use futures::{Stream, StreamExt};
 use std::any::Any;
 use std::fmt::Formatter;
-use std::sync::Arc;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
 use uuid::Uuid;
 
 /// [ExecutionPlan] implementation that shuffles data across the network in a distributed context.
@@ -103,6 +107,7 @@ pub struct NetworkShuffleExec {
     pub(crate) properties: Arc<PlanProperties>,
     pub(crate) input_stage: Stage,
     pub(crate) worker_connections: WorkerConnectionPool,
+    pub(crate) join_set: Arc<Mutex<JoinSet<()>>>,
 }
 
 impl NetworkShuffleExec {
@@ -131,6 +136,7 @@ impl NetworkShuffleExec {
             properties: input_stage.plan.properties().clone(),
             worker_connections: WorkerConnectionPool::new(0),
             input_stage: Stage::Local(input_stage),
+            join_set: Arc::new(Mutex::new(Default::default())),
         }
     }
 
@@ -241,13 +247,69 @@ impl ExecutionPlan for NetworkShuffleExec {
             streams.push(stream);
         }
 
+        // Wrap in `drain_on_drop` so that if a downstream operator abandons this
+        // partition without consuming it (e.g. a `HashJoinExec` that short-circuits
+        // its probe side because the build side is empty — DataFusion #21068), the
+        // partition is still drained from the upstream (shared) `RepartitionExec`.
+        // Otherwise, that undrained partition latches RepartitionExec's distributor
+        // gate and deadlocks every sibling consumer of the same shuffle.
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             self.schema(),
-            futures::stream::select_all(streams),
+            drain_on_drop(
+                futures::stream::select_all(streams),
+                Arc::clone(&self.join_set),
+            ),
         )))
     }
 
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.worker_connections.metrics.clone_inner())
+    }
+}
+
+pub(crate) struct DrainOnDrop<T: Stream + Unpin + Send + 'static> {
+    inner: Option<T>,
+    join_set: Arc<Mutex<JoinSet<()>>>,
+}
+
+/// See [`DrainOnDrop`].
+pub(crate) fn drain_on_drop<T: Stream + Unpin + Send + 'static>(
+    inner: T,
+    join_set: Arc<Mutex<JoinSet<()>>>,
+) -> DrainOnDrop<T> {
+    DrainOnDrop {
+        inner: Some(inner),
+        join_set,
+    }
+}
+
+impl<T: Stream + Unpin + Send + 'static> Stream for DrainOnDrop<T> {
+    type Item = T::Item;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let Some(inner) = self.inner.as_mut() else {
+            return Poll::Ready(None);
+        };
+        let poll = inner.poll_next_unpin(cx);
+        if matches!(poll, Poll::Ready(None)) {
+            self.inner = None;
+        }
+        poll
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.as_ref().map_or((0, Some(0)), |s| s.size_hint())
+    }
+}
+
+impl<T: Stream + Unpin + Send + 'static> Drop for DrainOnDrop<T> {
+    fn drop(&mut self) {
+        // If fully consumed already, then nothing upstream is left to wedge.
+        if let Some(mut inner) = self.inner.take() {
+            self.join_set
+                .lock()
+                .unwrap()
+                .spawn(async move { while inner.next().await.is_some() {} });
+        };
     }
 }

--- a/src/protobuf/distributed_codec.rs
+++ b/src/protobuf/distributed_codec.rs
@@ -28,7 +28,7 @@ use datafusion_proto::protobuf;
 use datafusion_proto::protobuf::proto_error;
 use itertools::Itertools;
 use prost::Message;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use url::Url;
 
 /// DataFusion [PhysicalExtensionCodec] implementation that allows serializing and
@@ -459,6 +459,7 @@ fn new_network_hash_shuffle_exec(
         )),
         worker_connections: WorkerConnectionPool::new(input_stage.task_count()),
         input_stage,
+        join_set: Arc::new(Mutex::new(Default::default())),
     }
 }
 


### PR DESCRIPTION
## Summary

Partitioned hash joins can deadlock the entire query after the DF54 upgrade. When a `HashJoinExec` partition has an **empty build side**, DataFusion [#21068](https://github.com/apache/datafusion/commit/6c5e241e62) ("Skip probe-side consumption when hash join build side is empty") short-circuits it to `Completed` and **drops its probe-side input without ever reading it**. When that probe side is a `NetworkShuffleExec`, the partition is never drained from the upstream (shared) `RepartitionExec`, whose distributor gate then latches and blocks every other consumer of the same shuffle.

## Background: how the shuffle gate works

A stage's head is a `RepartitionExec` that fans its input out into N output partitions, shared by N downstream consumers. Its distributor keeps a **global gate**: the pump keeps producing while *at least one* output queue is empty, but the moment *every* queue is non-empty it blocks until some consumer drains one.

(data flows bottom -> top)

```
       consumer      consumer      consumer      consumer     (e.g. HashJoin probe sides)
          ^             ^             ^             ^
        [ p0 ]        [ p1 ]        [ p2 ]        [ p3 ]       per-partition queues
          ^             ^             ^             ^
          +-------------+------+------+-------------+
                               |  fan-out (route rows by hash)
                        RepartitionExec     (1 input -> N partitions, shared by N consumers)

   gate OPEN  : at least one queue empty  -> pump keeps flowing
   gate CLOSED: ALL queues non-empty      -> pump blocks until someone drains
```

As long as every consumer keeps draining its partition, the gate never stays closed.

## The deadlock

`#21068` lets one consumer (a HashJoin with an empty build side) **abandon** its probe partition — it's never read. In distributed mode the remote request is issued lazily on first poll, so dropping the stream before the first poll means the request is *never even sent*, and nothing ever drains that queue:

```
       reads         reads      [ABANDONED]        reads
       p0            p1         HashJoin probe,     p3
        ^             ^         build EMPTY ->       ^
        |             |         #21068 drops it      |
        |             |         unread (never        |
        |             |         polled / requested)  |
      [ p0 ]        [ p1 ]      [ p2 ]             [ p3 ]
       full          full      ##### never          full
        ^             ^         drained              ^
        +-------------+-----+---+------------------+
                            |
                     RepartitionExec   (pump BLOCKED -- gate latched: all queues non-empty)
```

`p2` fills and stays full; once `p0/p1/p3` are also non-empty the gate latches, the pump blocks, and the consumers that *do* want their data starve forever.

(Distinct from #473: there a demux was already running and a receiver dropped mid-stream — fixed with `continue`-on-closed-channel. Here the request for `p2` is never issued, so the demux never starts and there is nothing to keep alive.)

## The fix

Wrap the stream returned by `NetworkShuffleExec::execute` in a small `DrainOnDrop`. If it's dropped before exhaustion, it parks the inner stream in a `JoinSet` owned by the `NetworkShuffleExec` and drains it to completion — forcing the request to be issued and the upstream partition to be consumed, so the gate can never latch.

```
   gate stays open  (p2 gets drained, never latches)
        ^
   p2 drained to EOF
        ^
   JoinSet.spawn(drain p2)        (JoinSet owned by NetworkShuffleExec -> cancelled with the plan)
        ^
   DrainOnDrop::drop fires
        ^
   HashJoin drops probe(p2) unread
```

The drain tasks live in the `NetworkShuffleExec`'s `JoinSet`, so they're cancelled when the plan node is dropped (no detached tasks left running).

## Notes

- Draining an abandoned partition still pulls its data over the network and then discards it, so this does not recover #21068's saving in distributed mode. Fully skipping the work would require per-partition cancellation at the producer's `RepartitionExec`.
- Verified: with #21068 active, the `custom_routing_join*` tests in `task_estimator_test` (which deadlocked) now pass; reverting `6c5e241e62` also fixes them.
