### PR TITLE
Fix benchmarks build: remove nonexistent with_distributed_dynamic_task_count call

### DIFF
--- a/benchmarks/src/run.rs
+++ b/benchmarks/src/run.rs
@@ -105,10 +105,6 @@ pub struct RunOpt {
     #[structopt(long, default_value = "0")]
     max_tasks_per_stage: usize,
 
-    /// Activate dynamic task count
-    #[structopt(long)]
-    dynamic: bool,
-
     /// Number of iterations of each test run
     #[structopt(short = "i", long = "iterations", default_value = "5")]
     iterations: usize,
@@ -209,7 +205,6 @@ impl RunOpt {
             .with_distributed_cardinality_effect_task_scale_factor(
                 self.cardinality_task_sf.unwrap_or(1.0),
             )?
-            .with_distributed_dynamic_task_count(self.dynamic)?
             .with_distributed_compression(match self.compression.as_str() {
                 "zstd" => Some(CompressionType::ZSTD),
                 "lz4" => Some(CompressionType::LZ4_FRAME),


### PR DESCRIPTION
## Summary

- Commit `0d4e239` (Benchmarks housekeeping) introduced a `dynamic: bool` field in `RunOpt` and called `.with_distributed_dynamic_task_count(self.dynamic)?` in `RunOpt::run_local`
- That method was never implemented in `distributed_ext.rs`, so the `dfbench` binary has been broken since that commit
- This PR removes the two dead lines (the struct field and the call site)

## Verification

Checked out to `0d4e239` and confirmed the compile error:
```
error[E0599]: no method named `with_distributed_dynamic_task_count` found for struct `SessionStateBuilder`
  --> benchmarks/src/run.rs:212:14
```

After this fix, `cargo build -p datafusion-distributed-benchmarks --bin dfbench` compiles cleanly.