### PR TITLE
Chunk work unit feeds

### DIFF
--- a/src/coordinator/task_spawner.rs
+++ b/src/coordinator/task_spawner.rs
@@ -5,7 +5,7 @@ use crate::execution_plans::{ChildrenIsolatorUnionExec, DistributedLeafExec};
 use crate::passthrough_headers::get_passthrough_headers;
 use crate::protobuf::tonic_status_to_datafusion_error;
 use crate::stage::LocalStage;
-use crate::work_unit_feed::{build_work_unit_msg, set_work_unit_send_time};
+use crate::work_unit_feed::{build_work_unit_batch_msg, set_work_unit_send_time};
 use crate::worker::generated::worker as pb;
 use crate::worker::generated::worker::coordinator_to_worker_msg::Inner;
 use crate::worker::generated::worker::set_plan_request::WorkUnitFeedDeclaration;
@@ -39,6 +39,11 @@ use tonic::Request;
 use tonic::metadata::MetadataMap;
 use url::Url;
 use uuid::Uuid;
+
+/// How many [crate::WorkUnit] messages are allowed to be chunked synchronously together in order to
+/// send fewer bigger [crate::WorkUnit] batches over the wire, reducing the overhead of sending many
+/// small batches. See [StreamExt::ready_chunks] docs for more details about how chunking works.
+const WORK_UNIT_FEED_CHUNK_SIZE: usize = 256;
 
 /// Metrics that measure network details about communications between [DistributedExec] and a
 /// worker.
@@ -282,29 +287,29 @@ impl<'a> CoordinatorToWorkerTaskSpawner<'a> {
             };
             let t_ctx = Arc::new(task_ctx_with_extension(&ctx, dist_feed_ctx));
 
-            // There should be as many partition feeds as [num partitions] * [num tasks], so that
-            // each task index handles a non-overlapping set of partition feeds.
+            let mut feeds = Vec::with_capacity(end_partition - start_partition);
             for (partition, feed_idx) in (start_partition..end_partition).enumerate() {
-                // By calling `.take()` the respective partition feed is consumed, and further
-                // consumptions are allowed. Calling `.take()` on the same partition feed again
-                // will fail.
-                let mut work_unit_feed = wuf.feed(feed_idx, Arc::clone(&t_ctx))?;
-                let tx = tx.clone();
-                let id = wuf.id();
-                futures.push(Box::pin(async move {
-                    // At this point, the partition feed contains a stream of decoded messages,
-                    // so they must be encoded in order to send them over the wire.
-                    while let Some(data_or_err) = work_unit_feed.next().await {
-                        if tx
-                            .send(build_work_unit_msg(&id, partition, data_or_err?))
-                            .is_err()
-                        {
-                            break; // channel closed.
-                        };
-                    }
-                    Ok::<_, DataFusionError>(())
-                }));
+                let feed = wuf
+                    .feed(feed_idx, Arc::clone(&t_ctx))?
+                    .map(move |el| (partition, el));
+                feeds.push(feed);
             }
+            let interleaved_feed = futures::stream::select_all(feeds);
+            let mut chunked_interleaved_feed =
+                interleaved_feed.ready_chunks(WORK_UNIT_FEED_CHUNK_SIZE);
+
+            let id = wuf.id();
+            let tx = tx.clone();
+            futures.push(Box::pin(async move {
+                // At this point, the partition feed contains a stream of decoded messages,
+                // so they must be encoded in order to send them over the wire.
+                while let Some(chunk) = chunked_interleaved_feed.next().await {
+                    if tx.send(build_work_unit_batch_msg(&id, chunk)?).is_err() {
+                        break; // channel closed.
+                    };
+                }
+                Ok::<_, DataFusionError>(())
+            }));
             Ok(TreeNodeRecursion::Continue)
         })?;
         self.join_set.spawn(async move {

--- a/src/work_unit_feed/mod.rs
+++ b/src/work_unit_feed/mod.rs
@@ -6,7 +6,7 @@ mod work_unit_feed_provider;
 mod work_unit_feed_registry;
 
 pub(crate) use remote_work_unit_feed::{
-    RemoteWorkUnitFeedRegistry, build_work_unit_msg, set_work_unit_received_time,
+    RemoteWorkUnitFeedRegistry, build_work_unit_batch_msg, set_work_unit_received_time,
     set_work_unit_send_time,
 };
 pub(crate) use work_unit_feed_registry::{WorkUnitFeedRegistry, set_distributed_work_unit_feed};

--- a/src/work_unit_feed/remote_work_unit_feed.rs
+++ b/src/work_unit_feed/remote_work_unit_feed.rs
@@ -47,34 +47,42 @@ impl RemoteWorkUnitFeedRegistry {
     }
 }
 
-pub(crate) fn build_work_unit_msg(
+pub(crate) fn build_work_unit_batch_msg(
     id: &Uuid,
-    partition: usize,
-    work_unit: Box<dyn WorkUnit>,
-) -> pb::CoordinatorToWorkerMsg {
-    pb::CoordinatorToWorkerMsg {
-        inner: Some(pb::coordinator_to_worker_msg::Inner::WorkUnit(
-            pb::WorkUnit {
-                id: serialize_uuid(id),
-                partition: partition as u64,
-                body: work_unit.encode_to_bytes(),
-                created_timestamp_unix_nanos: now_ns(),
-                sent_timestamp_unix_nanos: 0,
-                received_timestamp_unix_nanos: 0,
-                processed_timestamp_unix_nanos: 0,
+    work_unit_batch: Vec<(usize, Result<Box<dyn WorkUnit>>)>,
+) -> Result<pb::CoordinatorToWorkerMsg> {
+    Ok(pb::CoordinatorToWorkerMsg {
+        inner: Some(pb::coordinator_to_worker_msg::Inner::WorkUnitBatch(
+            pb::WorkUnitBatch {
+                batch: work_unit_batch
+                    .into_iter()
+                    .map(|(partition, work_unit)| {
+                        Ok(pb::WorkUnit {
+                            id: serialize_uuid(id),
+                            partition: partition as u64,
+                            body: work_unit?.encode_to_bytes(),
+                            created_timestamp_unix_nanos: now_ns(),
+                            sent_timestamp_unix_nanos: 0,
+                            received_timestamp_unix_nanos: 0,
+                            processed_timestamp_unix_nanos: 0,
+                        })
+                    })
+                    .collect::<Result<_>>()?,
             },
         )),
-    }
+    })
 }
 
 pub(crate) fn set_work_unit_send_time(
     mut msg: pb::CoordinatorToWorkerMsg,
 ) -> pb::CoordinatorToWorkerMsg {
     if let pb::CoordinatorToWorkerMsg {
-        inner: Some(pb::coordinator_to_worker_msg::Inner::WorkUnit(work_unit)),
+        inner: Some(pb::coordinator_to_worker_msg::Inner::WorkUnitBatch(work_unit_batch)),
     } = &mut msg
     {
-        work_unit.sent_timestamp_unix_nanos = now_ns();
+        for work_unit in &mut work_unit_batch.batch {
+            work_unit.sent_timestamp_unix_nanos = now_ns();
+        }
     }
     msg
 }
@@ -83,10 +91,12 @@ pub(crate) fn set_work_unit_received_time(
     mut msg: pb::CoordinatorToWorkerMsg,
 ) -> pb::CoordinatorToWorkerMsg {
     if let pb::CoordinatorToWorkerMsg {
-        inner: Some(pb::coordinator_to_worker_msg::Inner::WorkUnit(work_unit)),
+        inner: Some(pb::coordinator_to_worker_msg::Inner::WorkUnitBatch(work_unit_batch)),
     } = &mut msg
     {
-        work_unit.received_timestamp_unix_nanos = now_ns();
+        for work_unit in &mut work_unit_batch.batch {
+            work_unit.received_timestamp_unix_nanos = now_ns();
+        }
     }
     msg
 }

--- a/src/worker/generated/worker.rs
+++ b/src/worker/generated/worker.rs
@@ -12,11 +12,11 @@ pub mod coordinator_to_worker_msg {
         /// The plan is identified by a TaskKey.
         #[prost(message, tag = "1")]
         SetPlanRequest(super::SetPlanRequest),
-        /// A single message from a work unit feed belonging to one partition from one node from the plan set in
+        /// A batch of messages from a work unit feed belonging to different partitions from one node from the plan set in
         /// set_plan_request. A work unit feed is a per-partition stream of information that tells the node what should
         /// be executed within a partition, for example, a stream of file addresses that should be read.
         #[prost(message, tag = "2")]
-        WorkUnit(super::WorkUnit),
+        WorkUnitBatch(super::WorkUnitBatch),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -96,6 +96,12 @@ pub mod set_plan_request {
         pub partitions: u64,
     }
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct WorkUnitBatch {
+    /// A batch of WorkUnits.
+    #[prost(message, repeated, tag = "1")]
+    pub batch: ::prost::alloc::vec::Vec<WorkUnit>,
+}
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct WorkUnit {
     /// Identifier of the node to which this work unit feed belongs to.
@@ -107,16 +113,16 @@ pub struct WorkUnit {
     /// Arbitrary user-defined data (e.g., a file address) necessary during execution.
     #[prost(bytes = "vec", tag = "3")]
     pub body: ::prost::alloc::vec::Vec<u8>,
-    /// Unix timestamp in nanoseconds at which this message was created.
+    /// Unix timestamp in nanoseconds at which this message was created in the coordinator.
     #[prost(uint64, tag = "4")]
     pub created_timestamp_unix_nanos: u64,
-    /// Unix timestamp in nanoseconds at which this message was sent.
+    /// Unix timestamp in nanoseconds at which this message was sent by the coordinator.
     #[prost(uint64, tag = "5")]
     pub sent_timestamp_unix_nanos: u64,
-    /// Unix timestamp in nanoseconds at which this message was received.
+    /// Unix timestamp in nanoseconds at which this message was received by a worker.
     #[prost(uint64, tag = "6")]
     pub received_timestamp_unix_nanos: u64,
-    /// Unix timestamp in nanoseconds at which this message was processed.
+    /// Unix timestamp in nanoseconds at which this message started being processed.
     #[prost(uint64, tag = "7")]
     pub processed_timestamp_unix_nanos: u64,
 }

--- a/src/worker/impl_coordinator_channel.rs
+++ b/src/worker/impl_coordinator_channel.rs
@@ -120,22 +120,26 @@ impl Worker {
         })?;
 
         // Continue reading remaining messages (work unit feed data) in the background.
-        let work_unit_senders = remote_work_unit_feed_registry.senders;
+        let mut work_unit_senders = remote_work_unit_feed_registry.senders;
         #[allow(clippy::disallowed_methods)]
         tokio::spawn(async move {
             let mut body = body.map_ok(set_work_unit_received_time);
             while let Some(Ok(msg)) = body.next().await {
-                let Some(Inner::WorkUnit(msg)) = msg.inner else {
+                let Some(Inner::WorkUnitBatch(msg)) = msg.inner else {
                     continue;
                 };
-                let Ok(id) = deserialize_uuid(&msg.id) else {
-                    continue;
-                };
-                let Some(tx) = work_unit_senders.get(&(id, msg.partition as usize)) else {
-                    continue;
-                };
-                if tx.send(Ok(msg)).is_err() {
-                    break; // channel closed
+                for msg in msg.batch {
+                    let Ok(id) = deserialize_uuid(&msg.id) else {
+                        continue;
+                    };
+                    let partition = msg.partition as usize;
+                    let Some(tx) = work_unit_senders.get(&(id, partition)) else {
+                        continue;
+                    };
+                    if tx.send(Ok(msg)).is_err() {
+                        work_unit_senders.remove(&(id, partition));
+                        continue;
+                    }
                 }
             }
         });

--- a/src/worker/worker.proto
+++ b/src/worker/worker.proto
@@ -17,10 +17,10 @@ message CoordinatorToWorkerMsg {
     // Sends a subplan to a worker so that a future ExecuteTask call can actually execute it.
     // The plan is identified by a TaskKey.
     SetPlanRequest set_plan_request = 1;
-    // A single message from a work unit feed belonging to one partition from one node from the plan set in
+    // A batch of messages from a work unit feed belonging to different partitions from one node from the plan set in
     // set_plan_request. A work unit feed is a per-partition stream of information that tells the node what should
     // be executed within a partition, for example, a stream of file addresses that should be read.
-    WorkUnit work_unit = 2;
+    WorkUnitBatch work_unit_batch = 2;
   }
 }
 
@@ -77,6 +77,11 @@ message SetPlanRequest {
   // Unix nanos when the query started as reported by the coordinator. Used for collecting temporal metrics
   // relative to when the query was fired in the coordinator.
   uint64 query_start_time_ns = 6;
+}
+
+message WorkUnitBatch {
+  // A batch of WorkUnits.
+  repeated WorkUnit batch = 1;
 }
 
 message WorkUnit {


### PR DESCRIPTION
## Summary

- Previously, each work unit from each partition feed was sent as an individual `WorkUnit` message over the gRPC stream. This caused high per-message overhead when many small work units were being dispatched.
- This PR introduces a `WorkUnitBatch` wrapper in the protobuf schema that groups multiple work units together into a single message.
- On the coordinator side, per-partition feeds are now interleaved via `select_all` and then chunked with `ready_chunks(256)`, meaning up to 256 ready work units (potentially from different partitions) are batched into a single `WorkUnitBatch` message before being sent over the wire.
- On the worker side, the receiver iterates over the batch and dispatches each work unit to its respective partition sender.

## Why

Sending one small protobuf message per work unit pays a fixed per-message cost (framing, syscall, etc.) that dominates when work units are cheap. Batching amortises that overhead across up to 256 units per send, reducing the coordinator-to-worker feed latency under high partition counts.
