### PR TITLE
Improve docs and examples

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,18 +8,33 @@ capabilities.
 These docs will guide you towards using the library for building your own Distributed DataFusion cluster, and
 how to contribute changes to the library yourself.
 
-.. _toc.guide:
+.. _toc.understand:
 .. toctree::
    :maxdepth: 2
-   :caption: User Guide
+   :caption: Understand
 
    user-guide/concepts
+   user-guide/how-a-distributed-plan-is-built
+
+.. _toc.cluster:
+.. toctree::
+   :maxdepth: 2
+   :caption: Set up a cluster
+
    user-guide/getting-started
    user-guide/worker
    user-guide/worker-resolver
    user-guide/channel-resolver
+
+.. _toc.customize:
+.. toctree::
+   :maxdepth: 2
+   :caption: Customize execution
+
    user-guide/task-estimator
-   user-guide/how-a-distributed-plan-is-built
+   user-guide/work-unit-feeds
+   user-guide/custom-distributed-plans
+   user-guide/metrics
 
 .. _toc.contributor-guide:
 .. toctree::

--- a/docs/source/user-guide/concepts.md
+++ b/docs/source/user-guide/concepts.md
@@ -15,10 +15,54 @@ Key terminology:
   children nodes.
 - `Worker`: a physical machine listening to serialized execution plans over an Arrow Flight interface. A task is
   executed by exactly one worker, but one worker executes many tasks concurrently.
+- `Leaf stage`: a bottom stage of the plan — one that reads source data (e.g. a `DataSourceExec`).
+- `Head stage`: the top stage, executed on a single task by the coordinator. Its output is what the client sees.
 
 ![concepts.png](../_static/images/concepts.png)
 
 You'll see these concepts mentioned extensively across the documentation and the code itself.
+
+# Coming from DataFusion?
+
+A distributed plan *is* a normal DataFusion physical plan with a few extra `ExecutionPlan` nodes inserted at
+stage boundaries. If you already know DataFusion, this table is most of what you need:
+
+| Vanilla DataFusion                                   | Distributed DataFusion                                                                      |
+|------------------------------------------------------|---------------------------------------------------------------------------------------------|
+| Partition (a thread on one machine)                  | Task (a machine), each running its own partitions                                           |
+| `RepartitionExec(Hash(..))`                          | [`NetworkShuffleExec`](how-a-distributed-plan-is-built.md) (repartitions across tasks)      |
+| `CoalescePartitionsExec` / `SortPreservingMergeExec` | [`NetworkCoalesceExec`](how-a-distributed-plan-is-built.md) (gathers tasks, no repartition) |
+| `BroadcastExec` \*                                   | `NetworkBroadcastExec`                                                                      |
+
+\* `BroadcastExec` is a normal **single-node** operator (not a network boundary), even though it ships with this
+project. It fills a gap in upstream DataFusion: broadcast repartitioning — copying every input partition to every
+output partition — which `RepartitionExec` cannot express. `NetworkBroadcastExec` is what distributes it across
+tasks.
+
+The network boundary nodes execute their child on a remote worker over gRPC instead of in-process; everything
+else is the DataFusion you already know.
+
+# What you need (and what's optional)
+
+To run distributed queries you need exactly three things:
+
+1. `with_distributed_planner()` on the coordinator's `SessionStateBuilder` — registers the `QueryPlanner` that
+   distributes the plan.
+2. A [`WorkerResolver`](worker-resolver.md) — tells the planner where the workers are.
+3. One or more [`Worker`](worker.md) gRPC servers running at those URLs.
+
+Everything else is optional and only needed for specific cases:
+
+- A [`ChannelResolver`](channel-resolver.md) — a sensible default already exists.
+- A [`TaskEstimator`](task-estimator.md) — only for **custom** leaf `ExecutionPlan`s; file-based `DataSourceExec`
+  is distributed out of the box.
+- [Work unit feeds](work-unit-feeds.md) — when a leaf's work is discovered at runtime.
+- [Manually injected network boundaries](custom-distributed-plans.md) — for custom stage topologies.
+- [Metrics collection](metrics.md) — on by default.
+
+> Any **custom** `ExecutionPlan` that crosses a network boundary must have its `PhysicalExtensionCodec`
+> registered on **both** the coordinator and every `Worker` (see [Spawn a Worker](worker.md)), since the node is
+> serialized on one side and deserialized on the other.
 
 # Public API
 

--- a/docs/source/user-guide/custom-distributed-plans.md
+++ b/docs/source/user-guide/custom-distributed-plans.md
@@ -1,0 +1,114 @@
+# Building Custom Distributed Plans
+
+By default, the [distributed planner](how-a-distributed-plan-is-built.md) decides where to place network
+boundaries: it walks your single-node physical plan and injects `NetworkShuffleExec`,
+`NetworkCoalesceExec`, and `NetworkBroadcastExec` nodes at the points it thinks make sense.
+
+You don't have to leave that decision to the planner. `NetworkShuffleExec` and `NetworkCoalesceExec` are
+**public, constructible nodes**, so you can place network boundaries yourself and build whatever stage
+topology your workload needs.
+
+## How it works
+
+The distributed planner runs as a query planner that post-processes the physical plan. Its first check
+is whether the plan **already** contains network boundaries:
+
+- If it does, the planner assumes you placed them deliberately. It does **not** try to distribute the
+  plan itself — it only finalises your boundaries (giving each stage a unique id and eliding any
+  boundary that turns out to connect a single producer task to a single consumer task) and wraps the
+  result in a `DistributedExec`.
+- If it doesn't, the planner runs its normal automatic distribution passes.
+
+So building a custom distributed plan is a matter of getting your network boundaries into the physical
+plan before the distributed planner sees it. The idiomatic way to do that is a DataFusion
+[`PhysicalOptimizerRule`](https://docs.rs/datafusion/latest/datafusion/physical_optimizer/trait.PhysicalOptimizerRule.html),
+which runs while the physical plan is being built:
+
+```rust
+let state = SessionStateBuilder::new()
+    .with_default_features()
+    // Your rule injects NetworkShuffleExec / NetworkCoalesceExec into the plan...
+    .with_physical_optimizer_rule(Arc::new(MyBoundaryInjectionRule))
+    // ...and the distributed planner finalises whatever boundaries it finds.
+    .with_distributed_worker_resolver(/* ... */)
+    .with_distributed_planner()
+    .with_distributed_user_codec(MyLeafCodec)
+    .build();
+```
+
+## The two boundary nodes
+
+Both nodes connect a *producer* stage (below, running on `producer_tasks` tasks) to a *consumer* stage
+(above). The placeholder stage ids they are constructed with are filled in for you during finalisation.
+
+### `NetworkShuffleExec`
+
+```rust
+NetworkShuffleExec::try_new(input: Arc<dyn ExecutionPlan>, producer_tasks: usize) -> Result<Self>
+```
+
+A network shuffle — the distributed equivalent of a `RepartitionExec`. It **repartitions** data across
+tasks: each consumer task gathers data from every producer task, hash-partitioned by key. Its `input`
+**must** be a `RepartitionExec` with `Hash` partitioning. Use it for shuffle-based aggregations and
+partitioned joins.
+
+### `NetworkCoalesceExec`
+
+```rust
+NetworkCoalesceExec::try_new(
+    input: Arc<dyn ExecutionPlan>,
+    producer_tasks: usize,
+    consumer_tasks: usize,
+) -> Result<Self>
+```
+
+A network coalesce — the distributed equivalent of a `CoalescePartitionsExec`. It **concatenates**
+partitions across tasks **without** repartitioning: each consumer task reads a contiguous group of
+producer tasks. It is meant to sit right above a partition-collecting node such as
+`CoalescePartitionsExec` or `SortPreservingMergeExec`. Use it to reduce the width of a stage (gather
+many tasks into fewer).
+
+> The caller is responsible for keeping the counts consistent: the `consumer_tasks` of one boundary must
+> match the `producer_tasks` of the boundary immediately above it.
+
+## Leaf data splitting still happens automatically
+
+Even when you inject the boundaries yourself, the distributed planner runs the registered
+[`TaskEstimator`](task-estimator.md) over each stage's leaves and calls `scale_up_leaf_node` with the
+stage's task count. So a parquet `DataSourceExec` is wrapped in a `DistributedLeafExec` (with one
+per-task file-group variant) by the default file-scan estimator, and a custom leaf is split by whatever
+`TaskEstimator` you registered for it — exactly as in the automatic path. You only place the boundaries;
+the leaves are scaled for you.
+
+This means a custom leaf node still needs its `TaskEstimator` (and its `scale_up_leaf_node` /
+`DistributedTaskContext`-based dispatch) registered, just as it would for automatic planning — you do
+**not** need to hand-build `DistributedLeafExec` in your boundary-injection rule.
+
+## Example: a progressive partial-reduction tree
+
+A common reason to build the topology yourself is to control how a stage fans in. Instead of gathering
+`N` leaf tasks into a single node with one wide coalesce, you can build a **reduction tree** that shrinks
+the data at every level:
+
+```text
+ Final            (1 task)   — finishes the aggregation
+   NetworkCoalesceExec  M → 1
+ PartialReduce    (M tasks)  — merges partial states, shrinking the data again
+   NetworkCoalesceExec  N → M
+ Partial          (N tasks)  — first partial reduce, one task per slice of the input
+   DistributedLeafExec
+```
+
+The node that makes this *progressive* (rather than just a fan-in of concatenations) is
+`AggregateExec` with `AggregateMode::PartialReduce`: it merges partial-aggregate states into fewer
+partial-aggregate states, so the volume crossing each network hop keeps dropping. A single `Final`
+aggregation on the root finishes the job — and because the merge happens on partial states, stateful
+aggregates like `avg(...)` stay correct.
+
+There is a complete, runnable example in the `examples/` folder:
+
+- [custom_distributed_partial_reduction_tree.rs](https://github.com/datafusion-contrib/datafusion-distributed/blob/main/examples/custom_distributed_partial_reduction_tree.rs) —
+  a `PhysicalOptimizerRule` that rewrites a `GROUP BY` aggregation over a parquet table into the tree
+  above (`Partial → NetworkCoalesce → PartialReduce → NetworkCoalesce → Final`). It only injects the
+  boundaries; the planner's `TaskEstimator` splits the parquet leaf across the leaf-stage tasks
+  automatically.

--- a/docs/source/user-guide/getting-started.md
+++ b/docs/source/user-guide/getting-started.md
@@ -58,6 +58,7 @@ let localhost_worker_resolver = LocalhostWorkerResolver {
 }
 
 let state = SessionStateBuilder::new()
+    .with_default_features()
     .with_distributed_worker_resolver(localhost_worker_resolver)
     .with_distributed_planner()
     .build();
@@ -67,7 +68,23 @@ let ctx = SessionContext::from(state);
 
 This will leave a DataFusion `SessionContext` ready for executing distributed queries.
 
+> NOTE: `with_distributed_planner()` wraps whatever query planner is already set, so call it **after** any
+> `with_query_planner(..)` and after registering your own physical optimizer rules — the distributed planner
+> runs last, on top of the fully-built physical plan.
+
 > NOTE: This example is not production-ready and is meant to showcase the basic concepts of the library.
+
+## Troubleshooting
+
+Common errors when first bringing up a cluster, and what they usually mean:
+
+| Symptom                                                                                   | Likely cause                                                                                                                                        |
+|-------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `WorkerResolver not present in the session config`                                        | Forgot `with_distributed_worker_resolver(..)` on the coordinator.                                                                                   |
+| A decode/deserialization error for one of your nodes at execution time                    | A custom `ExecutionPlan`'s `PhysicalExtensionCodec` isn't registered on **both** the coordinator and the workers (see [Spawn a Worker](worker.md)). |
+| `Physical input schema should be the same as the one converted from logical input schema` | A custom `TableProvider`/leaf ignores the `projection` passed to `scan()` — honor it (return only the projected columns).                           |
+| `Missing WorkUnit feed for id ...; Was the WorkUnitFeed registered?`                      | Forgot `with_distributed_work_unit_feed(..)`, or registered it on the wrong session (see [Work Unit Feeds](work-unit-feeds.md)).                    |
+| The query runs but isn't distributed (no `DistributedExec` in the plan)                   | `get_urls()` returned no workers, or a custom leaf has no [`TaskEstimator`](task-estimator.md) (custom leaves default to a single task).            |
 
 ## Next steps
 
@@ -81,6 +98,10 @@ Depending on your needs, your setup can get more complicated, for example:
 To learn how to do all that, it's recommended to:
 
 - [Continue reading this guide](worker.md)
+- Learn how to distribute your own execution plans with a [TaskEstimator](task-estimator.md), or stream
+  runtime-discovered work to them with [Work Unit Feeds](work-unit-feeds.md)
+- [Build custom distributed plans](custom-distributed-plans.md) by injecting network boundaries yourself
+- [Collect runtime metrics](metrics.md) (EXPLAIN ANALYZE) for distributed queries
 - [Look at examples in the project](https://github.com/datafusion-contrib/datafusion-distributed/tree/main/examples)
 - [Look at the integration tests for finer grained examples](https://github.com/datafusion-contrib/datafusion-distributed/tree/main/tests)
 

--- a/docs/source/user-guide/how-a-distributed-plan-is-built.md
+++ b/docs/source/user-guide/how-a-distributed-plan-is-built.md
@@ -2,18 +2,70 @@
 
 This page walks through how the distributed DataFusion planner transforms a query into a distributed execution plan.
 
-Everything starts with a simple single-node plan, for example:
+The transformation runs as a DataFusion `QueryPlanner` (registered by `with_distributed_planner()`) **after**
+normal physical planning. It takes the single-node physical plan, finds the points where data would cross a
+thread boundary in vanilla DataFusion, and inserts a network boundary node there instead — splitting the plan
+into *stages* that run on different *tasks* (machines).
 
-```shell
-ProjectionExec: expr=[...]
-  AggregateExec: mode=FinalPartitioned, gby=[...], aggr=[...]
-    CoalesceBatchesExec: target_batch_size=8192
-      RepartitionExec: partitioning=Hash([...], 12), input_partitions=12
-        AggregateExec: mode=Partial, gby=[...], aggr=[...]
-          DataSourceExec: files=[data1, data2, data3, data4]
+## The same plan, before and after
+
+Take `SELECT count(*), "RainToday" FROM weather GROUP BY "RainToday" ORDER BY count(*)` over a 3-file table on a
+3-worker cluster. Here is the ordinary single-node physical plan (file paths trimmed to `[...]`):
+
+```text
+SortPreservingMergeExec: [count(*)@0 ASC NULLS LAST]
+  SortExec: expr=[count(*)@0 ASC NULLS LAST], preserve_partitioning=[true]
+    ProjectionExec: expr=[count(Int64(1))@1 as count(*), RainToday@0 as RainToday]
+      AggregateExec: mode=FinalPartitioned, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))]
+        RepartitionExec: partitioning=Hash([RainToday@0], 4), input_partitions=3
+          AggregateExec: mode=Partial, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))]
+            DataSourceExec: file_groups={3 groups: [...]}, projection=[RainToday], file_type=parquet
 ```
 
-To better understand what happens with the plan in the distribution process, we will represent it graphically:
+And the distributed plan for the same query, rendered with `display_plan_ascii`:
+
+```text
+┌───── DistributedExec ── Tasks: t0:[p0]
+│ SortPreservingMergeExec: [count(*)@0 ASC NULLS LAST]
+│   [Stage 2] => NetworkCoalesceExec: output_partitions=8, input_tasks=2
+└──────────────────────────────────────────────────
+  ┌───── Stage 2 ── Tasks: t0:[p0..p3] t1:[p0..p3]
+  │ SortExec: expr=[count(*)@0 ASC NULLS LAST], preserve_partitioning=[true]
+  │   ProjectionExec: expr=[count(Int64(1))@1 as count(*), RainToday@0 as RainToday]
+  │     AggregateExec: mode=FinalPartitioned, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))]
+  │       [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=3
+  └──────────────────────────────────────────────────
+    ┌───── Stage 1 ── Tasks: t0:[p0..p7] t1:[p0..p7] t2:[p0..p7]
+    │ RepartitionExec: partitioning=Hash([RainToday@0], 8), input_partitions=3
+    │   AggregateExec: mode=Partial, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))]
+    │     DistributedLeafExec: DataSourceExec: file_groups={3 groups: [...]}, projection=[RainToday], file_type=parquet
+    └──────────────────────────────────────────────────
+```
+
+Same operators, same order. The planner only:
+
+- inserted a **`NetworkShuffleExec`** above the hash `RepartitionExec` (the shuffle now fans data across tasks),
+- inserted a **`NetworkCoalesceExec`** at the top to gather all tasks into the single head task,
+- wrapped the leaf in a **`DistributedLeafExec`** so each task scans its own slice of the files, and
+- grew the shuffle's partition count (4 → 8) because it now feeds multiple tasks.
+
+### Reading the output
+
+- `┌───── Stage 1 ── Tasks: t0:[p0..p7] t1:[p0..p7] t2:[p0..p7]` — a stage running on **3 tasks** (`t0`, `t1`,
+  `t2`), each on a different worker, each executing partitions `p0..p7`. Tasks are machines; partitions are the
+  threads within a task.
+- `[Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=3` — a **network boundary**: this node
+  streams the output of Stage 1 over Arrow Flight instead of from a child node. `input_tasks` is how many tasks
+  produced the data; `output_partitions` is how many partitions it exposes to its parent.
+- `DistributedExec` — the root and the only node the client executes. It hosts the **head stage**, which always
+  runs on a single task (the coordinator).
+- `DistributedLeafExec` — a transparent wrapper around the original leaf; `DistributedExec` swaps in the right
+  per-task variant before sending the stage to a worker.
+
+## Step by step
+
+The rest of this page walks the same transformation visually, on a four-file aggregation. To better understand
+what happens with the plan in the distribution process, we will represent it graphically:
 
 ![img.png](../_static/images/img.png)
 

--- a/docs/source/user-guide/metrics.md
+++ b/docs/source/user-guide/metrics.md
@@ -1,0 +1,84 @@
+# Collecting Runtime Metrics
+
+In vanilla DataFusion, the runtime metrics of an `ExecutionPlan` (rows produced, time spent, bytes,
+etc.) live on each node and can be inspected after execution. In a distributed query most of the plan
+runs on remote workers, so those metrics need to be gathered back to the coordinator before you can
+display them.
+
+Distributed DataFusion does this for you, and exposes two functions you can use to build your own
+EXPLAIN ANALYZE in application code.
+
+## Enabling collection
+
+Metrics collection across network boundaries is **on by default**. You can toggle it explicitly:
+
+```rust
+let state = SessionStateBuilder::new()
+    .with_default_features()
+    .with_distributed_worker_resolver(/* ... */)
+    .with_distributed_planner()
+    .with_distributed_metrics_collection(true) // default is true
+    .build();
+```
+
+When enabled, each worker streams the metrics for its tasks back to the coordinator on a dedicated
+channel, so they are not lost even if the result stream is dropped early (for example by a `LIMIT`).
+
+## Rendering a plan with metrics
+
+Two functions, both exported from the crate root, do the work:
+
+- `rewrite_distributed_plan_with_metrics(plan, format)` — folds every task's metrics back into the
+  coordinator's copy of the plan. It waits for all worker metrics to arrive, so the result is always
+  complete. The `format` is a `DistributedMetricsFormat`:
+    - `Aggregated` — metrics from all tasks of a stage are summed/aggregated into one value per node.
+    - `PerTask` — metric names are suffixed with the task id (`output_rows_0`, `output_rows_1`, …) so
+      you can see each task individually.
+- `display_plan_ascii(plan, show_metrics)` — renders the plan tree. Pass `true` to include the metrics
+  attached to each node.
+
+The order of operations matters: **the plan must be fully executed before its metrics are available.**
+
+```rust
+use datafusion::physical_plan::execute_stream;
+use datafusion_distributed::{
+    DistributedMetricsFormat, display_plan_ascii, rewrite_distributed_plan_with_metrics,
+};
+use futures::TryStreamExt;
+
+// 1. Plan the query.
+let plan = ctx.sql(sql).await?.create_physical_plan().await?;
+
+// 2. Execute it to completion (collect, or otherwise fully drain the stream).
+execute_stream(plan.clone(), ctx.task_ctx())?
+    .try_collect::<Vec<_>>()
+    .await?;
+
+// 3. Fold the per-task metrics back into the plan...
+let plan =
+    rewrite_distributed_plan_with_metrics(plan, DistributedMetricsFormat::Aggregated).await?;
+
+// 4. ...and render it.
+println!("{}", display_plan_ascii(plan.as_ref(), true));
+```
+
+This produces an EXPLAIN ANALYZE that spans the whole cluster — every stage and every node carries its
+runtime metrics, including network-level metrics on the boundaries:
+
+```
+┌───── DistributedExec ── Tasks: t0:[p0] plan_bytes_sent_0=8.07 K, plan_send_latency_avg_0=22.63ms, ...
+│ SortPreservingMergeExec: [count(*)@0 DESC], fetch=5, metrics=[output_rows=5, elapsed_compute=391.83µs, ...]
+│   [Stage 2] => NetworkCoalesceExec: output_partitions=32, input_tasks=2, metrics=[elapsed_compute=5.86ms, bytes_transferred=20.1 KB, network_latency_p50=366.00µs, network_latency_p95=603.43µs, ...]
+└──────────────────────────────────────────────────
+  ┌───── Stage 2 ── Tasks: t0:[p0..p15] t1:[p0..p15] plan_added_at_0=25.78ms, plan_finished_at_0=38.35ms, ...
+  │ AggregateExec: mode=FinalPartitioned, gby=[MinTemp@0 as MinTemp], aggr=[count(Int64(1))], metrics=[output_rows=180, elapsed_compute=5.44ms, ...]
+  │     [Stage 1] => NetworkShuffleExec: output_partitions=16, input_tasks=2, metrics=[bytes_transferred=15.0 KB, ...]
+  └──────────────────────────────────────────────────
+    ┌───── Stage 1 ── Tasks: t0:[p0..p31] t1:[p0..p31] ...
+    │ AggregateExec: mode=Partial, gby=[MinTemp@0 as MinTemp], aggr=[count(Int64(1))], metrics=[output_rows=249, ...]
+    │     DistributedLeafExec: DataSourceExec: ..., metrics=[output_rows=366, bytes_scanned=5.40 K, ...]
+    └──────────────────────────────────────────────────
+```
+
+> If `plan` is not a distributed plan (its root is not a `DistributedExec`),
+> `rewrite_distributed_plan_with_metrics` returns it unchanged, so it is always safe to call.

--- a/docs/source/user-guide/task-estimator.md
+++ b/docs/source/user-guide/task-estimator.md
@@ -2,17 +2,18 @@
 
 The `TaskEstimator` trait controls how many distributed tasks the planner allocates to each stage of the query plan.
 
-The number of tasks is assigned to the different stages in a bottom-up fashion. You can refer to the
-[Plan Annotation docs](https://github.com/datafusion-contrib/datafusion-distributed/blob/75b4e73e9052c6596b9d1744ce2bdfa6cbc010d3/src/distributed_planner/plan_annotator.rs)
-for an explanation on how this works. A `TaskEstimator` is what hints this process how many tasks should be
-used.
+The number of tasks is assigned to the different stages in a bottom-up fashion. See
+[How a Distributed Plan is Built](how-a-distributed-plan-is-built.md) for the overall picture, and the
+[
+`inject_network_boundaries`](https://github.com/datafusion-contrib/datafusion-distributed/blob/main/src/distributed_planner/inject_network_boundaries.rs)
+source for the details. A `TaskEstimator` is what hints this process how many tasks should be used.
 
 While a default implementation exists for file-based `DataSourceExec` nodes (those backed by `FileScanConfig`), you
 can provide custom `TaskEstimator` implementations for your own `ExecutionPlan` types.
 
 ## Providing your own TaskEstimator
 
-Providing a `TaskEstimator` allows you to do two things:
+Providing a `TaskEstimator` allows you to do three things:
 
 1. Tell the distributed planner how many tasks should be used for your own `ExecutionPlan`s
    (`task_estimation`).
@@ -26,9 +27,29 @@ Providing a `TaskEstimator` allows you to do two things:
    If your leaf node already handles task dispatch internally (e.g., by reading
    `DistributedTaskContext.task_index` in `execute()`), you can omit `DistributedLeafExec` and
    simply return the prepared plan directly from `scale_up_leaf_node`.
+3. Route each task to a specific worker URL (`route_tasks`) — see
+   [Routing tasks to specific workers](#routing-tasks-to-specific-workers) below.
 
 There's a complete example in the `examples/` folder:
 
 - [custom_execution_plan.rs](https://github.com/datafusion-contrib/datafusion-distributed/blob/main/examples/custom_execution_plan.rs) -
   A complete example showing how to implement a custom execution plan (`numbers(start, end)` table function)
   that works with distributed DataFusion, including a custom codec and TaskEstimator.
+
+> A `TaskEstimator` decides a leaf node's work **at planning time**. If your leaf's units of work are
+> only discovered **at runtime** (paginated APIs, queues, progressive discovery), see
+> [Work Unit Feeds](work-unit-feeds.md) for the complementary mechanism.
+
+## Routing tasks to specific workers
+
+By default, the planner spreads a stage's tasks across the available workers round-robin. When a task's
+data has a *home* — a worker that already holds it in a cache or on local disk — you can send the task
+**there** instead by implementing `TaskEstimator::route_tasks`, which returns the worker URL for each task
+(returning `None`, the default, keeps the round-robin behaviour). Routing pairs naturally with
+`scale_up_leaf_node`: that decides *what* data task `i` reads, and `route_tasks` decides *where* it runs.
+
+For a complete, runnable walkthrough — parquet files consistently routed to workers (by rendezvous
+hashing of the file path) so each worker can serve them from an in-memory cache on repeat queries — see
+the
+[custom_worker_url_routing.rs](https://github.com/datafusion-contrib/datafusion-distributed/blob/main/examples/custom_worker_url_routing.rs)
+example.

--- a/docs/source/user-guide/work-unit-feeds.md
+++ b/docs/source/user-guide/work-unit-feeds.md
@@ -1,0 +1,232 @@
+# Work Unit Feeds
+
+A **work unit feed** lets a leaf `ExecutionPlan` be driven by work that is discovered on the
+coordinator *at runtime* and streamed to the workers while the query executes, rather than being
+fully known at planning time.
+
+## When to use a work unit feed
+
+Distributed DataFusion already has a mechanism for splitting a leaf node's work across tasks: the
+[`TaskEstimator`](task-estimator.md). With a `TaskEstimator`, all of the work is decided **at planning
+time** — `scale_up_leaf_node` produces `N` per-task plan variants, each pre-loaded with the slice of
+data it is responsible for (e.g., a group of files). This is the right tool
+whenever the units of work are known before execution begins.
+
+A work unit feed solves the opposite problem: **the units of work are only discovered as the query
+runs**. Typical cases:
+
+- A paginated external API or message queue that hands out pages/offsets on demand.
+- A catalog or metadata service that returns object-store keys progressively.
+- A source where the *amount* of work per partition is not known until you start pulling from it.
+
+With a feed, the leaf node is planned without knowing its work. During execution the coordinator pulls
+work-unit descriptors from your provider and streams each one — over gRPC — to whichever worker
+owns that partition. The worker turns each descriptor into rows. Slow partitions don't block fast ones,
+and back-pressure is handled per partition.
+
+|                         | `TaskEstimator`                             | Work unit feed                                |
+|-------------------------|---------------------------------------------|-----------------------------------------------|
+| When work is known      | Planning time                               | Runtime                                       |
+| How work is distributed | Pre-built per-task plan variants            | Streamed per-partition from the coordinator   |
+| Good for                | Files, ranges, anything enumerable up front | Paginated APIs, queues, progressive discovery |
+
+The two mechanisms are complementary. A feed-backed leaf still provides a `TaskEstimator` to tell the
+planner how many tasks to use; the feed only governs *what work flows into each partition at runtime*.
+
+> **A `TaskEstimator` is always required for a feed-backed leaf.** The feed decides *what* work each
+> partition receives at runtime, but something still has to tell Distributed DataFusion the *desired task
+> count* for the node — that is the `TaskEstimator`'s job (`task_estimation`). Without it the leaf defaults
+> to a single task. See [Building a TaskEstimator](task-estimator.md).
+
+## How it works
+
+A feed produces one stream of work units per partition. Inside the node's `execute()`, each partition pulls
+its work units and turns them into `RecordBatch`es. In a single process that's a direct call into your
+provider:
+
+```text
+┌──────────────────────────────────────────────────────┐
+│                    ExecutionPlan                     │
+│                                                      │
+│                                                      │
+│┌────────────────────────────────────────────────────┐│
+││                    WorkUnitFeed                    ││
+││ ┌───────────┐     ┌───────────┐     ┌───────────┐  ││
+││ │ .feed(0)  │     │ .feed(1)  │     │ .feed(2)  │  ││
+││ └────┬──────┘     └──┬────────┘     └──┬────────┘  ││
+│└──────┼───────────────┼─────────────────┼───────────┘│  .─.
+│┌──────┼─────────┐┌────┼───────────┐┌───.▼.──────────┐│ (   ) WorkUnit
+││      │P0       ││   .▼. P1       ││  (   )P2       ││  `─'  (e.g., a file address)
+││     .▼.        ││  (   )         ││   `┬'          ││
+││    (   )       ││   `┬'          ││    │           ││
+││     `─'        ││    │           ││   .▼.          ││
+││      │         ││   .▼.          ││  (   )         ││
+││      │         ││  (   )         ││   `┬'          ││
+││      │         ││   `─'          ││    │           ││
+││      ▼         ││    ▼           ││    ▼           ││
+││  processing... ││  processing... ││  processing... ││
+││      │         ││    │           ││    │           ││
+││      │         ││    │           ││    │           ││
+│└──────┼─────────┘└────┼───────────┘└────┼───────────┘│
+└───────┼───────────────┼─────────────────┼────────────┘
+  ┌─────▼─────┐     ┌───▼───────┐      ┌──▼────────┐
+  │RecordBatch│     │RecordBatch│      │RecordBatch│
+  └───────────┘     └───────────┘      └───────────┘
+```
+
+Under distributed execution the picture is the same from the node's point of view, but the provider lives
+**only on the coordinator**. Each worker deserializes a *remote* `WorkUnitFeed` whose `.feed(partition)`
+pulls the work units the coordinator streams to it over gRPC — so `WorkUnitFeedProvider::feed` itself only
+ever runs on the coordinator:
+
+```text
+                                                                                                    ┌──────────────────┐
+                                                                                                    │Coordinating Stage│
+┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┴──────────────────┘
+                                                                                                                       │
+│
+ ┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐│
+││                                                    WorkUnitFeed                                                    │
+ │  ┌───────────┐     ┌───────────┐     ┌───────────┐            ┌───────────┐      ┌───────────┐    ┌───────────┐    ││
+││  │ .feed(0)  │     │ .feed(1)  │     │ .feed(2)  │            │ .feed(3)  │      │ .feed(4)  │    │ .feed(5)  │    │
+ │  └────┬──────┘     └──┬────────┘     └──┬────────┘            └─────┬─────┘      └──┬────────┘    └───┬───────┘    ││
+│└───────┼───────────────┼─────────────────┼───────────────────────────┼───────────────┼─────────────────┼────────────┘
+         │               │                 │                           │               │                .┴.            │
+└ ─ ─ ─ ─│─ ─ ─ ─ ─ ─ ─ ─│─ ─ ─ ─ ─ ─ ─ ─ ─│─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ .┴. ─ ─ ─ ─ ─ ─ ─│─ ─ ─ ─ ─ ─ ─ ─(   )─ ─ ─ ─ ─ ─
+         │              .┴.                │                         (   )             │                `┬'
+         │             (   )               │                          `┬'              │                .┴.
+        .┴.             `┬'               .┴.                          │               │               (   )
+       (   )             │               (   )                         │              .┴.               `┬'
+        `┬'             .┴.               `┬'────────────┐             │             (   )               │┌────────────┐
+         │             (   )               ││  Worker 1  │             │              `┬'                ││  Worker 2  │
+┌ ─ ─ ─ ─│─ ─ ─ ─ ─ ─ ─ `┬' ─ ─ ─ ─ ─ ─ ─ ─│┴────────────┘    ┌ ─ ─ ─ ─│─ ─ ─ ─ ─ ─ ─ ─│─ ─ ─ ─ ─ ─ ─ ─ ─│┴────────────┘
+ ┌───────┼───────────────┼─────────────────┼────────────┐│     ┌───────┼───────────────┼─────────────────┼────────────┐│
+││       │            ExecutionPlan        │            │     ││       │            ExecutionPlan        │            │
+ │       │               │                 │            ││     │       │               │                 │            ││
+││┌──────┼───────────────┼─────────────────┼───────────┐│     ││┌──────┼───────────────┼─────────────────┼───────────┐│
+ ││      │          RemoteWorkUnitFeed     │           │││     ││      │          RemoteWorkUnitFeed     │           │││
+│││ ┌────▼──────┐     ┌──▼────────┐     ┌──▼────────┐  ││     │││ ┌────▼──────┐     ┌──▼────────┐     ┌──▼────────┐  ││
+ ││ │ .feed(0)  │     │ .feed(1)  │     │ .feed(2)  │  │││     ││ │ .feed(0)  │     │ .feed(1)  │     │ .feed(2)  │  │││
+│││ └────┬──────┘     └──┬────────┘     └──┬────────┘  ││     │││ └────┬──────┘     └──┬────────┘     └──┬────────┘  ││
+ │└──────┼───────────────┼─────────────────┼───────────┘││     │└──────┼───────────────┼─────────────────┼───────────┘││
+││       │               │                 │            │     ││       │               │                 │            │
+ │┌──────┼─────────┐┌────┼───────────┐┌───.▼.──────────┐││     │┌──────┼─────────┐┌────┼───────────┐┌───.▼.──────────┐││
+│││      │P0       ││   .▼. P1       ││  (   )P2       ││     │││      │P0       ││   .▼. P1       ││  (   )P2       ││
+ ││     .▼.        ││  (   )         ││   `┬'          │││     ││     .▼.        ││  (   )         ││   `┬'          │││
+│││    (   )       ││   `┬'          ││    │           ││     │││    (   )       ││   `┬'          ││    │           ││
+ ││     `─'        ││    ┼           ││   .▼.          │││     ││     `─'        ││    ┼           ││   .▼.          │││
+│││      │         ││   .▼.          ││  (   )         ││     │││      │         ││   .▼.          ││  (   )         ││
+ ││      │         ││  (   )         ││   `┬'          │││     ││      │         ││  (   )         ││   `┬'          │││
+│││      │         ││   `─'          ││    │           ││     │││      │         ││   `─'          ││    │           ││
+ ││      ▼         ││                ││    ▼           │││     ││      ▼         ││                ││    ▼           │││
+│││  processing... ││  processing... ││  processing... ││     │││  processing... ││  processing... ││  processing... ││
+ ││      │         ││    │           ││    │           │││     ││      │         ││    │           ││    │           │││
+│││      │         ││    │           ││    │           ││     │││      │         ││    │           ││    │           ││
+ │└──────┼─────────┘└────┼───────────┘└────┼───────────┘││     │└──────┼─────────┘└────┼───────────┘└────┼───────────┘││
+│└───────┼───────────────┼─────────────────┼────────────┘     │└───────┼───────────────┼─────────────────┼────────────┘
+   ┌─────▼─────┐     ┌───▼───────┐      ┌──▼────────┐    │       ┌─────▼─────┐     ┌───▼───────┐      ┌──▼────────┐    │
+│  │RecordBatch│     │RecordBatch│      │RecordBatch│         │  │RecordBatch│     │RecordBatch│      │RecordBatch│
+   └───────────┘     └───────────┘      └───────────┘    │       └───────────┘     └───────────┘      └───────────┘    │
+└ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─     └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+```
+
+## The public API
+
+The feed API lives behind a handful of types exported from the crate root:
+
+```rust
+use datafusion_distributed::{
+    WorkUnitFeed, WorkUnitFeedProvider, WorkUnitFeedProto, DistributedExt,
+};
+```
+
+### `WorkUnitFeedProvider`
+
+You implement this trait on a type that produces work units, one stream per partition. It is only
+ever called **on the coordinator**.
+
+```rust
+pub trait WorkUnitFeedProvider: Send + Sync + Debug {
+    /// The work unit type. Any `prost` message works out of the box.
+    type WorkUnit: WorkUnit + Default;
+
+    /// Produce the stream of work units for `partition`. Called once per partition,
+    /// on the coordinator only.
+    fn feed(
+        &self,
+        partition: usize,
+        ctx: Arc<TaskContext>,
+    ) -> Result<BoxStream<'static, Result<Self::WorkUnit>>>;
+
+    /// Optional metrics surfaced on the coordinator while feeding.
+    fn metrics(&self) -> ExecutionPlanMetricsSet { ExecutionPlanMetricsSet::new() }
+}
+```
+
+The associated `WorkUnit` type is the descriptor that travels over the network. Any
+[`prost`](https://docs.rs/prost) message automatically satisfies the `WorkUnit` trait — you don't need
+to implement anything extra, just `#[derive(::prost::Message)]`.
+
+### `WorkUnitFeed<P>`
+
+A `WorkUnitFeed<P>` is the handle your custom `ExecutionPlan` stores. On the coordinator it wraps your
+provider; on a worker it is reconstructed as a *remote* handle that pulls work units from the network.
+
+```rust
+// On the coordinator, while planning:
+let feed = WorkUnitFeed::new(my_provider);
+
+// Inside ExecutionPlan::execute(), on either side:
+let mut stream = feed.feed(partition, ctx)?; // yields your WorkUnit type
+
+// In your codec:
+let proto: WorkUnitFeedProto = feed.to_proto();           // encode (just a handle/UUID)
+let feed = WorkUnitFeed::<P>::from_proto(proto)?;          // decode into a remote handle
+```
+
+`to_proto()` serializes only the feed *handle* (a UUID), never the provider itself. That is what makes
+runtime delivery work: the provider stays on the coordinator, and each worker receives a remote handle
+that the runtime connects to the matching coordinator-side stream.
+
+### Registering the feed
+
+Finally, you tell Distributed DataFusion how to locate the feed inside your custom node, so the planner
+can discover it while walking the plan and wire up coordinator → worker delivery:
+
+```rust
+let state = SessionStateBuilder::new()
+    .with_default_features()
+    .with_distributed_worker_resolver(/* ... */)
+    .with_distributed_planner()
+    .with_distributed_user_codec(MyExecCodec)        // so workers can deserialize the node
+    .with_distributed_task_estimator(MyTaskEstimator) // how many tasks the leaf gets
+    .with_distributed_work_unit_feed(|exec: &MyExec| Some(&exec.feed))
+    .build();
+```
+
+`with_distributed_work_unit_feed` (and its in-place sibling `set_distributed_work_unit_feed`) take a
+closure `Fn(&YourExec) -> Option<&WorkUnitFeed<P>>`. The planner calls it for every node in the plan;
+return `Some(&feed)` for the nodes that own a feed and `None` otherwise.
+
+## Putting it together
+
+A feed-backed leaf node therefore wires up four collaborating pieces, exactly like any other custom
+distributed node, plus the feed registration:
+
+1. A `WorkUnitFeedProvider` that produces the per-partition work-unit streams on the coordinator.
+2. A custom `ExecutionPlan` that holds a `WorkUnitFeed<P>` and, in `execute()`, consumes
+   `feed.feed(partition, ctx)?` to produce `RecordBatch`es.
+3. A `PhysicalExtensionCodec` that serializes the node, encoding the feed handle with `to_proto()` /
+   `from_proto()`.
+4. A `TaskEstimator` so the planner knows how many tasks the leaf stage should use.
+
+There is a complete, runnable example in the `examples/` folder:
+
+- [work_unit_feed.rs](https://github.com/datafusion-contrib/datafusion-distributed/blob/main/examples/work_unit_feed.rs) —
+  a `scan(...)` table function backed by a simulated external source that discovers chunks of work at
+  runtime and streams them to the workers.
+
+The integration tests are also a good reference for the range of plan shapes feeds support (unions,
+joins, aggregations, broadcast joins, error and back-pressure behaviour):
+
+- [tests/work_unit_feed.rs](https://github.com/datafusion-contrib/datafusion-distributed/blob/main/tests/work_unit_feed.rs)

--- a/docs/source/user-guide/worker-resolver.md
+++ b/docs/source/user-guide/worker-resolver.md
@@ -9,12 +9,11 @@ information is used in two different places:
    execution.
 
 You need to pass your own `WorkerResolver` to DataFusion's `SessionStateBuilder` so that it's available in the
-`SesionContext`:
+`SessionContext`:
 
 ```rust
 struct CustomWorkerResolver;
 
-#[async_trait]
 impl WorkerResolver for CustomWorkerResolver {
     fn get_urls(&self) -> Result<Vec<Url>, DataFusionError> {
         todo!()
@@ -36,17 +35,16 @@ async fn main() {
 
 This is the simplest approach, though it doesn't accommodate dynamic worker discovery. An example of this can be
 seen in the
-[localhost_worker.rs](https://github.com/datafusion-contrib/datafusion-distributed/blob/fad9fa222d65b7d2ddae92fbc20082b5c434e4ff/examples/localhost_run.rs)
+[localhost_run.rs](https://github.com/datafusion-contrib/datafusion-distributed/blob/main/examples/localhost_run.rs)
 example:
 
 ```rust
 #[derive(Clone)]
-struct LocalhostChannelResolver {
+struct LocalhostWorkerResolver {
     ports: Vec<u16>,
 }
 
-#[async_trait]
-impl WorkerResolver for LocalhostChannelResolver {
+impl WorkerResolver for LocalhostWorkerResolver {
     fn get_urls(&self) -> Result<Vec<Url>, DataFusionError> {
         Ok(self
             .ports

--- a/docs/source/user-guide/worker.md
+++ b/docs/source/user-guide/worker.md
@@ -75,6 +75,32 @@ It receives a `WorkerQueryContext` containing:
 - `headers`: HTTP headers from the incoming request (useful for passing metadata like authentication tokens or
   configuration)
 
+## Registering custom execution plans
+
+If your queries contain **custom** `ExecutionPlan` nodes that cross a network boundary, the coordinator
+serializes them and the worker deserializes them — so both sides need the same `PhysicalExtensionCodec`.
+Register it symmetrically:
+
+```rust
+// On the coordinator's SessionStateBuilder:
+let state = SessionStateBuilder::new()
+    .with_default_features()
+    .with_distributed_worker_resolver(/* ... */)
+    .with_distributed_planner()
+    .with_distributed_user_codec(MyExecCodec)
+    .build();
+
+// And on every Worker, via its session builder:
+async fn build_state(ctx: WorkerQueryContext) -> Result<SessionState, DataFusionError> {
+    Ok(ctx.builder.with_distributed_user_codec(MyExecCodec).build())
+}
+```
+
+Forgetting either side surfaces as a decode error at execution time. The same symmetry applies to
+[work unit feeds](work-unit-feeds.md) (the feed getter) and to a custom [`ChannelResolver`](channel-resolver.md).
+Built-in nodes (`DataSourceExec`, `AggregateExec`, the `Network*Exec` boundaries, …) are handled by the default
+codec and need no registration.
+
 ## Serving the Endpoint
 
 Convert the endpoint to a gRPC service and serve it:

--- a/examples/custom_distributed_partial_reduction_tree.md
+++ b/examples/custom_distributed_partial_reduction_tree.md
@@ -1,0 +1,104 @@
+# Custom Distributed Plan Example
+
+Demonstrates how to **build your own distributed plan by injecting network boundaries directly**,
+instead of relying on the automatic distributed planner to decide where the stages go.
+
+See the [Custom Distributed Plans user guide](../docs/source/user-guide/custom-distributed-plans.md)
+for the concepts.
+
+## What it shows
+
+`NetworkShuffleExec` and `NetworkCoalesceExec` are public, constructible nodes. If a physical plan
+already contains network boundaries when it reaches the distributed planner, the planner does **not**
+distribute it on its own — it just finalises the boundaries you placed and wraps the result in a
+`DistributedExec`. The natural place to inject them is a `PhysicalOptimizerRule`.
+
+This example builds a **progressive partial-reduction tree** for a `GROUP BY` aggregation over the
+`weather` parquet table. Instead of gathering every leaf task into a single node with one wide coalesce,
+it reduces the data at every level of the tree:
+
+```text
+ Final            (1 task)   <- finishes the aggregation
+   NetworkCoalesceExec  M -> 1
+ PartialReduce    (M tasks)  <- merges partial states, shrinking the data again
+   NetworkCoalesceExec  N -> M
+ Partial          (N tasks)  <- first partial reduce, one task per slice of files
+   DistributedLeafExec(weather)
+```
+
+The key node is `AggregateExec(mode=PartialReduce)`: unlike a plain coalesce, which only concatenates
+partition streams, `PartialReduce` merges partial-aggregate states into fewer partial-aggregate states,
+so less data crosses each network hop. A single `Final` aggregation on the root finishes the job. This
+works for stateful aggregates too — e.g. `avg(...)` merges its (sum, count) states correctly through
+the tree.
+
+## Components
+
+**PartialReductionTreeRule** – a `PhysicalOptimizerRule` that matches the finalising aggregate of a
+two-phase aggregation, reuses the group-by / aggregate expressions from the existing `Partial` node,
+and rebuilds the pipeline as `Partial → NetworkCoalesce(N→M) → PartialReduce → NetworkCoalesce(M→1) → Final`.
+
+**Leaf splitting (automatic)** – the rule leaves the parquet scan as a plain `DataSourceExec`. The
+distributed planner runs the registered `TaskEstimator` over each stage's leaves, so the default
+file-scan estimator wraps the leaf in a `DistributedLeafExec` and hands each leaf-stage task its own
+slice of the parquet files — no manual leaf handling in the example.
+
+## Usage
+
+This example uses the in-memory cluster used in integration testing, so it needs `--features integration`.
+Run it from the repo root so the `testdata/weather` files resolve.
+
+```bash
+cargo run \
+  --features integration \
+  --example custom_distributed_partial_reduction_tree \
+  'SELECT "RainToday", count(*) FROM weather GROUP BY "RainToday"' \
+  --show-distributed-plan
+```
+
+```
+┌───── DistributedExec ── Tasks: t0:[p0]
+│ ProjectionExec: expr=[RainToday@0 as RainToday, count(Int64(1))@1 as count(*)]
+│   AggregateExec: mode=Final, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))]
+│     CoalescePartitionsExec
+│       [Stage 2] => NetworkCoalesceExec: output_partitions=2, input_tasks=2
+└──────────────────────────────────────────────────
+  ┌───── Stage 2 ── Tasks: t0:[p0] t1:[p1]
+  │ AggregateExec: mode=PartialReduce, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))]
+  │   CoalescePartitionsExec
+  │     [Stage 1] => NetworkCoalesceExec: output_partitions=6, input_tasks=3
+  └──────────────────────────────────────────────────
+    ┌───── Stage 1 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+    │ AggregateExec: mode=Partial, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))]
+    │   DistributedLeafExec: DataSourceExec: file_groups={3 groups: [[.../weather/result-000000.parquet], [.../weather/result-000001.parquet], [.../weather/result-000002.parquet]]}, projection=[RainToday], file_type=parquet
+    └──────────────────────────────────────────────────
+```
+
+Stage 1 is the first partial reduce on 3 tasks; note the `DistributedLeafExec` — the planner's
+`TaskEstimator` wrapped the parquet scan automatically, even though we only injected the boundaries.
+Stage 2 gathers 3 → 2 and partially reduces again; the root gathers 2 → 1 and finishes the aggregation.
+Running it produces the answer:
+
+```bash
+cargo run --features integration --example custom_distributed_partial_reduction_tree \
+  'SELECT "RainToday", count(*) FROM weather GROUP BY "RainToday"'
+```
+
+```
++-----------+----------+
+| RainToday | count(*) |
++-----------+----------+
+| No        | 300      |
+| Yes       | 66       |
++-----------+----------+
+```
+
+The width of the tree is configurable, and a stateful aggregate works too:
+
+```bash
+cargo run \
+  --features integration \
+  --example custom_distributed_partial_reduction_tree \
+  'SELECT "RainToday", avg("MinTemp") FROM weather GROUP BY "RainToday"' \
+  --leaf-tasks 3 --mid-tasks 2
+```

--- a/examples/custom_distributed_partial_reduction_tree.rs
+++ b/examples/custom_distributed_partial_reduction_tree.rs
@@ -1,0 +1,282 @@
+//! This example demonstrates how to **build a custom distributed plan by injecting network
+//! boundaries yourself**, instead of relying on the automatic distributed planner to decide
+//! where the stages go.
+//!
+//! Distributed DataFusion exposes [`NetworkShuffleExec`] and [`NetworkCoalesceExec`] as
+//! public, constructible nodes. If a physical plan already contains network boundaries when it
+//! reaches the distributed planner, the planner does **not** try to distribute it on its own —
+//! it simply finalises the boundaries you placed (assigning each stage a unique id, eliding
+//! ones that aren't needed) and wraps the result in a `DistributedExec`. The natural place to
+//! inject them is a [`PhysicalOptimizerRule`], which runs while the physical plan is being
+//! built.
+//!
+//! Here we build a **progressive partial-reduction tree** for a `GROUP BY` aggregation over the
+//! `weather` parquet table. Rather than gathering every leaf task into a single node with one
+//! wide coalesce, we reduce the data at every level of the tree:
+//!
+//! ```text
+//!  Final            (1 task)   <- finishes the aggregation
+//!    NetworkCoalesceExec  M -> 1
+//!  PartialReduce    (M tasks)  <- merges partial states, shrinking the data again
+//!    NetworkCoalesceExec  N -> M
+//!  Partial          (N tasks)  <- first partial reduce, one task per slice of files
+//!    DistributedLeafExec(weather)
+//! ```
+//!
+//! The key node is [`AggregateMode::PartialReduce`]: unlike a plain coalesce, which only
+//! concatenates partition streams, `PartialReduce` merges partial-aggregate states into fewer
+//! partial-aggregate states. Chaining it at each level means less data crosses each network
+//! hop. A single `Final` aggregation on the root finishes the job.
+//!
+//! We only inject the boundaries; the leaf is left as a plain parquet scan. The distributed
+//! planner still runs the registered `TaskEstimator` over each stage's leaves, so the default
+//! file-scan estimator splits the parquet files across the leaf-stage tasks for us — no manual
+//! leaf handling needed.
+//!
+//! Run this example with (from the repo root, so the `testdata/weather` files resolve):
+//! ```bash
+//! cargo run --features integration --example custom_distributed_partial_reduction_tree "SELECT \"RainToday\", count(*) FROM weather GROUP BY \"RainToday\"" --show-distributed-plan
+//! cargo run --features integration --example custom_distributed_partial_reduction_tree "SELECT \"RainToday\", count(*) FROM weather GROUP BY \"RainToday\""
+//! cargo run --features integration --example custom_distributed_partial_reduction_tree "SELECT \"RainToday\", avg(\"MinTemp\") FROM weather GROUP BY \"RainToday\"" --leaf-tasks 3 --mid-tasks 2
+//! ```
+
+use arrow::util::pretty::pretty_format_batches;
+use datafusion::catalog::memory::DataSourceExec;
+use datafusion::common::Result;
+use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
+use datafusion::config::ConfigOptions;
+use datafusion::execution::SessionStateBuilder;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::aggregates::{AggregateExec, AggregateMode, PhysicalGroupBy};
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion::physical_plan::expressions::Column;
+use datafusion::prelude::{ParquetReadOptions, SessionContext};
+use datafusion_distributed::test_utils::in_memory_channel_resolver::{
+    InMemoryChannelResolver, InMemoryWorkerResolver,
+};
+use datafusion_distributed::{
+    DistributedExt, NetworkCoalesceExec, SessionStateBuilderExt, WorkerQueryContext,
+    display_plan_ascii,
+};
+use futures::TryStreamExt;
+use std::sync::Arc;
+use structopt::StructOpt;
+
+/// Injects a progressive partial-reduction tree in place of the standard two-phase aggregation.
+///
+/// A two-phase aggregate plan (after physical planning) looks roughly like:
+/// ```text
+/// AggregateExec(mode=FinalPartitioned)   <- the node we match and replace
+///   RepartitionExec(Hash)
+///     AggregateExec(mode=Partial)
+///       DataSourceExec(weather)          <- left as-is; the planner's TaskEstimator splits it
+/// ```
+///
+/// We reuse the group-by / aggregate expressions from the existing `Partial` node and rebuild
+/// the pipeline as `Partial → NetworkCoalesce(N→M) → PartialReduce → NetworkCoalesce(M→1) → Final`.
+#[derive(Debug)]
+struct PartialReductionTreeRule {
+    leaf_tasks: usize,
+    mid_tasks: usize,
+}
+
+impl PhysicalOptimizerRule for PartialReductionTreeRule {
+    fn name(&self) -> &str {
+        "partial_reduction_tree"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let result = plan.transform_down(|node| {
+            // Match the top (finalising) aggregate of a two-phase aggregation.
+            let Some(top_agg) = node.downcast_ref::<AggregateExec>() else {
+                return Ok(Transformed::no(node));
+            };
+            if matches!(
+                top_agg.mode(),
+                AggregateMode::Partial | AggregateMode::PartialReduce
+            ) {
+                return Ok(Transformed::no(node));
+            }
+
+            // Find the `Partial` aggregate and the parquet leaf beneath it.
+            let Some(partial_node) =
+                find_node(&node, |p| is_aggregate_mode(p, AggregateMode::Partial))
+            else {
+                return Ok(Transformed::no(node));
+            };
+            if find_node(&partial_node, is_data_source).is_none() {
+                return Ok(Transformed::no(node));
+            }
+            let partial = partial_node.downcast_ref::<AggregateExec>().unwrap();
+
+            // The partial-aggregate subtree (with its plain parquet leaf) is the producer stage,
+            // running on `leaf_tasks` tasks. We don't split the leaf ourselves: the distributed
+            // planner runs the registered `TaskEstimator` over each stage's leaves, and the
+            // default file-scan estimator splits the parquet files across the stage's tasks.
+            let producer = Arc::clone(&partial_node);
+
+            // Group-by/aggregate expressions reused for the merge stages. After a `Partial`
+            // aggregate, the group-by columns sit at the front of the output schema, so the
+            // merge stages reference them positionally (`Column::new(name, i)`).
+            let merge_group_by = positional_group_by(partial.group_expr());
+            let aggr = partial.aggr_expr().to_vec();
+            let filter = partial.filter_expr().to_vec();
+            let input_schema = partial.input_schema();
+
+            // Level 1: gather N leaf tasks down to M, then PartialReduce to shrink again.
+            let nc1: Arc<dyn ExecutionPlan> = Arc::new(NetworkCoalesceExec::try_new(
+                producer,
+                self.leaf_tasks,
+                self.mid_tasks,
+            )?);
+            let mid_collect: Arc<dyn ExecutionPlan> = Arc::new(CoalescePartitionsExec::new(nc1));
+            let partial_reduce: Arc<dyn ExecutionPlan> = Arc::new(AggregateExec::try_new(
+                AggregateMode::PartialReduce,
+                merge_group_by.clone(),
+                aggr.clone(),
+                filter.clone(),
+                mid_collect,
+                Arc::clone(&input_schema),
+            )?);
+
+            // Level 2: gather M tasks down to a single task, then finish the aggregation.
+            let nc2: Arc<dyn ExecutionPlan> = Arc::new(NetworkCoalesceExec::try_new(
+                partial_reduce,
+                self.mid_tasks,
+                1,
+            )?);
+            let root_collect: Arc<dyn ExecutionPlan> = Arc::new(CoalescePartitionsExec::new(nc2));
+            let final_agg: Arc<dyn ExecutionPlan> = Arc::new(AggregateExec::try_new(
+                AggregateMode::Final,
+                merge_group_by,
+                aggr,
+                filter,
+                root_collect,
+                input_schema,
+            )?);
+
+            // Replace the original finalising aggregate with our tree. `Jump` stops the walk
+            // from descending into the boundaries we just inserted.
+            Ok(Transformed::new(final_agg, true, TreeNodeRecursion::Jump))
+        })?;
+
+        Ok(result.data)
+    }
+}
+
+/// Rebuilds the group-by so each key references the partial-aggregate output column by position,
+/// which is what the `PartialReduce` and `Final` merge stages consume.
+fn positional_group_by(orig: &PhysicalGroupBy) -> PhysicalGroupBy {
+    PhysicalGroupBy::new(
+        orig.expr()
+            .iter()
+            .enumerate()
+            .map(|(i, (_, name))| (Arc::new(Column::new(name, i)) as _, name.clone()))
+            .collect(),
+        orig.null_expr()
+            .iter()
+            .enumerate()
+            .map(|(i, (_, name))| (Arc::new(Column::new(name, i)) as _, name.clone()))
+            .collect(),
+        orig.groups().to_vec(),
+        orig.has_grouping_set(),
+    )
+}
+
+fn is_aggregate_mode(plan: &Arc<dyn ExecutionPlan>, mode: AggregateMode) -> bool {
+    plan.downcast_ref::<AggregateExec>()
+        .is_some_and(|a| *a.mode() == mode)
+}
+
+fn is_data_source(plan: &Arc<dyn ExecutionPlan>) -> bool {
+    plan.is::<DataSourceExec>()
+}
+
+/// Returns a clone of the first node (top-down) matching `predicate`.
+fn find_node(
+    plan: &Arc<dyn ExecutionPlan>,
+    predicate: impl Fn(&Arc<dyn ExecutionPlan>) -> bool,
+) -> Option<Arc<dyn ExecutionPlan>> {
+    let mut found = None;
+    plan.apply(|node| {
+        if predicate(node) {
+            found = Some(Arc::clone(node));
+            Ok(TreeNodeRecursion::Stop)
+        } else {
+            Ok(TreeNodeRecursion::Continue)
+        }
+    })
+    .unwrap();
+    found
+}
+
+#[derive(StructOpt)]
+#[structopt(
+    name = "custom_distributed_partial_reduction_tree",
+    about = "Manually injected network boundaries"
+)]
+struct Args {
+    /// The SQL query to run (a `GROUP BY` aggregation over the `weather` table).
+    query: String,
+
+    /// Number of leaf tasks performing the first partial reduction.
+    #[structopt(long, default_value = "3")]
+    leaf_tasks: usize,
+
+    /// Number of intermediate tasks in the middle of the reduction tree.
+    #[structopt(long, default_value = "2")]
+    mid_tasks: usize,
+
+    /// Render the distributed plan instead of executing the query.
+    #[structopt(long)]
+    show_distributed_plan: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::from_args();
+
+    let worker_resolver = InMemoryWorkerResolver::new(args.leaf_tasks.max(args.mid_tasks).max(1));
+    // The plan is built from standard DataFusion nodes (DataSourceExec, AggregateExec, ...) plus
+    // the network boundaries, all handled by the built-in codec, so no custom codec is needed.
+    let channel_resolver =
+        InMemoryChannelResolver::from_session_builder(|ctx: WorkerQueryContext| async move {
+            Ok(ctx.builder.build())
+        });
+
+    let state = SessionStateBuilder::new()
+        .with_default_features()
+        // Our rule injects the network boundaries while the physical plan is built...
+        .with_physical_optimizer_rule(Arc::new(PartialReductionTreeRule {
+            leaf_tasks: args.leaf_tasks,
+            mid_tasks: args.mid_tasks,
+        }))
+        // ...and the distributed planner finalises the boundaries it finds.
+        .with_distributed_worker_resolver(worker_resolver)
+        .with_distributed_channel_resolver(channel_resolver)
+        .with_distributed_planner()
+        .build();
+
+    let ctx = SessionContext::from(state);
+    ctx.register_parquet("weather", "testdata/weather", ParquetReadOptions::default())
+        .await?;
+
+    let df = ctx.sql(&args.query).await?;
+    if args.show_distributed_plan {
+        let plan = df.create_physical_plan().await?;
+        println!("{}", display_plan_ascii(plan.as_ref(), false));
+    } else {
+        let batches = df.execute_stream().await?.try_collect::<Vec<_>>().await?;
+        println!("{}", pretty_format_batches(&batches)?);
+    }
+    Ok(())
+}

--- a/examples/custom_worker_url_routing.md
+++ b/examples/custom_worker_url_routing.md
@@ -1,0 +1,113 @@
+# Custom Worker URL Routing Example (cache affinity)
+
+Demonstrates **custom task routing** for **cache affinity**: consistently routing each parquet file
+to the *same* worker so that worker can serve it from an in-memory cache on repeat queries. This is
+the
+[`TaskEstimator::route_tasks`](../docs/source/user-guide/task-estimator.md#routing-tasks-to-specific-workers)
+API.
+
+## Scenario
+
+A team runs repeated analytical queries over a set of regional parquet files (e.g. for a dashboard
+or recurring report). Without cache affinity every query re-reads every file from disk. With it,
+each file is pinned to a worker, so the second and subsequent queries are served entirely from
+in-memory cache.
+
+## What it shows
+
+Rather than a custom execution plan, the example wraps DataFusion's native `FileScanConfig` inside
+a `CachedFileScanConfig` data source using a **`PhysicalOptimizerRule`**. Any `register_parquet`
+table gains caching transparently, with no changes to the table registration.
+
+Routing is a two-step pipeline:
+
+- `scale_up_leaf_node` flattens all files, hashes each file's path to a slot
+  (`hash(path) % task_count`), and builds one `DataSourceExec(CachedFileScanConfig)` variant per
+  slot. The same file always hashes to the same slot.
+- `route_tasks` sorts the available worker URLs and maps slot `i` to `sorted_urls[i % n_workers]`.
+  Each slot therefore always reaches the same worker.
+
+Together these guarantee that each worker consistently reads the same set of files and its cache
+stays warm across queries.
+
+The worker-level cache is an `Arc<DashMap>` injected as a **session extension** at worker startup.
+Since session extensions survive across task invocations (the `Arc` is cloned, not recreated), the
+cache is warm on the second query even though the plan is serialised and sent fresh each time.
+
+## Components
+
+**`CachedFileScanConfig`** — a `DataSource` wrapper around `FileScanConfig`. `open()` checks the
+worker's session extension cache first; on a miss it reads via the inner config and populates the
+cache asynchronously through a `RecordBatchReceiverStreamBuilder`.
+
+**`CachedFileScanConfigTaskEstimator`** — the `TaskEstimator`. `scale_up_leaf_node` produces one
+variant per task slot; `route_tasks` pins each slot to a worker by sorted-URL index.
+
+**`CachedFileScanCodec`** — a `PhysicalExtensionCodec` that round-trips `CachedFileScanConfig` by
+encoding the inner `FileScanConfig` as a plain `DataSourceExec` using DataFusion's default codec,
+then re-wrapping on decode. No custom proto schema is needed.
+
+**`CachedFileScanConfigRule`** — a `PhysicalOptimizerRule` that rewrites every leaf
+`DataSourceExec(FileScanConfig)` to `DataSourceExec(CachedFileScanConfig)`.
+
+Workers are spawned with `spawn_worker_service` and discovered with `LocalHostWorkerResolver`, both
+from the `integration` feature.
+
+## Usage
+
+```bash
+cargo run \
+  --features integration \
+  --example custom_worker_url_routing \
+  'SELECT "RainToday", COUNT(*) AS days, AVG("Rainfall") AS avg_mm FROM weather GROUP BY "RainToday"'
+```
+
+```
+=== cold pass done after 121ms ===
++-----------+------+----------------------+
+| RainToday | days | avg_mm               |
++-----------+------+----------------------+
+| Yes       | 66   | 7.663636363636365    |
+| No        | 300  | 0.056666666666666664 |
++-----------+------+----------------------+
+=== warm pass done after 9ms ===
++-----------+------+----------------------+
+| RainToday | days | avg_mm               |
++-----------+------+----------------------+
+| Yes       | 66   | 7.663636363636365    |
+| No        | 300  | 0.056666666666666664 |
++-----------+------+----------------------+
+```
+
+The warm pass returns the same rows in ~10× less time because `open()` returns them from the
+worker's `DashMap` cache rather than reading parquet off disk. Each worker owns a subset of the
+parquet files from `testdata/weather`, and the same files always route there on every query because
+the hash-based slot assignment is stable.
+
+To inspect the distributed plan:
+
+```bash
+cargo run --features integration --example custom_worker_url_routing \
+    'SELECT "RainToday", COUNT(*) AS days, AVG("Rainfall") AS avg_mm FROM weather GROUP BY "RainToday"' \
+    --show-distributed-plan
+```
+
+```
+┌───── DistributedExec ── Tasks: t0:[p0]
+│ CoalescePartitionsExec
+│   [Stage 2] => NetworkCoalesceExec: output_partitions=32, input_tasks=2
+└──────────────────────────────────────────────────
+  ┌───── Stage 2 ── Tasks: t0:[p0..p15] t1:[p0..p15]
+  │ ProjectionExec: expr=[RainToday@0 as RainToday, count(Int64(1))@1 as days, avg(weather.Rainfall)@2 as avg_mm]
+  │   AggregateExec: mode=FinalPartitioned, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1)), avg(weather.Rainfall)]
+  │     [Stage 1] => NetworkShuffleExec: output_partitions=16, input_tasks=3
+  └──────────────────────────────────────────────────
+    ┌───── Stage 1 ── Tasks: t0:[p0..p31] t1:[p0..p31] t2:[p0..p31]
+    │ RepartitionExec: partitioning=Hash([RainToday@0], 32), input_partitions=1
+    │   AggregateExec: mode=Partial, gby=[RainToday@1 as RainToday], aggr=[count(Int64(1)), avg(weather.Rainfall)]
+    │     DistributedLeafExec: DataSourceExec: file_groups={3 groups: [...]}, projection=[Rainfall, RainToday], file_type=parquet
+    └──────────────────────────────────────────────────
+```
+
+Stage 1 runs on all three workers (one parquet file per task, each pinned to its worker by the
+hash-based routing). Stage 2 runs the final aggregation on two workers after a hash-shuffle.

--- a/examples/custom_worker_url_routing.rs
+++ b/examples/custom_worker_url_routing.rs
@@ -1,0 +1,383 @@
+//! Demonstrates **custom task routing** for **cache affinity**: consistently routing each parquet
+//! file to the *same* worker so that worker can serve it from an in-memory cache on repeat queries.
+//!
+//! Rather than a custom data source, the example inserts a [`CacheExec`] node above every
+//! [`DataSourceExec`] via a [`PhysicalOptimizerRule`]. Any existing parquet table gains caching
+//! without changes to the table registration.
+//!
+//! Routing is a two-step pipeline:
+//! - [`CachedFileScanConfigTaskEstimator::scale_up_leaf_node`] assigns each file to a task slot by
+//!   hashing its path (mod task_count), so the same file always lands in the same slot.
+//! - [`CachedFileScanConfigTaskEstimator::route_tasks`] maps slot `i` to `sorted_urls[i % n]`,
+//!   so each slot always reaches the same worker URL.
+//!
+//! Together these guarantee that each worker consistently reads the same set of files and its
+//! in-memory cache stays warm on repeat queries.
+//!
+//! ```bash
+//! cargo run --features integration --example custom_worker_url_routing \
+//!     'SELECT "RainToday", COUNT(*) AS days, AVG("Rainfall") AS avg_mm FROM weather GROUP BY "RainToday"'
+//! cargo run --features integration --example custom_worker_url_routing \
+//!     'SELECT "RainToday", COUNT(*) AS days, AVG("Rainfall") AS avg_mm FROM weather GROUP BY "RainToday"' \
+//!     --show-distributed-plan
+//! ```
+
+use dashmap::DashMap;
+use datafusion::arrow::array::RecordBatch;
+use datafusion::arrow::util::pretty::pretty_format_batches;
+use datafusion::catalog::memory::DataSourceExec;
+use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode, TreeNodeRecursion};
+use datafusion::common::{Result, internal_err};
+use datafusion::config::ConfigOptions;
+use datafusion::datasource::physical_plan::{FileGroup, FileScanConfig};
+use datafusion::execution::{SendableRecordBatchStream, SessionStateBuilder, TaskContext};
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::stream::{
+    RecordBatchReceiverStreamBuilder, RecordBatchStreamAdapter,
+};
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use datafusion::prelude::{ParquetReadOptions, SessionContext};
+use datafusion_distributed::test_utils::localhost::{
+    LocalHostWorkerResolver, spawn_worker_service,
+};
+use datafusion_distributed::{
+    DistributedExt, DistributedLeafExec, SessionStateBuilderExt, TaskEstimation, TaskEstimator,
+    TaskRoutingContext, WorkerQueryContext, display_plan_ascii,
+};
+use datafusion_proto::physical_plan::PhysicalExtensionCodec;
+use datafusion_proto::protobuf;
+use futures::TryStreamExt;
+use prost::Message;
+use std::error::Error;
+use std::fmt;
+use std::hash::{DefaultHasher, Hasher};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use structopt::StructOpt;
+use tokio::net::TcpListener;
+use url::Url;
+
+/// Worker-level cache shared across all task invocations on the same worker, keyed by a stable
+/// hash of the file group being scanned.
+type WorkerFileCache = DashMap<usize, Vec<RecordBatch>>;
+
+/// [`ExecutionPlan`] that wraps a [`DataSourceExec`] and caches the batches it produces.
+/// The cache is stored in the worker's session extension so it persists across task invocations.
+#[derive(Debug)]
+struct CacheExec {
+    child: Arc<dyn ExecutionPlan>,
+}
+
+impl CacheExec {
+    fn new(child: Arc<dyn ExecutionPlan>) -> Arc<Self> {
+        Arc::new(Self { child })
+    }
+}
+
+impl DisplayAs for CacheExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "CacheExec")
+    }
+}
+
+impl ExecutionPlan for CacheExec {
+    fn name(&self) -> &str {
+        "CacheExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        self.child.properties()
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.child]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(CacheExec::new(children.remove(0)))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let schema = self.schema();
+        let cache = context.session_config().get_extension::<WorkerFileCache>();
+
+        // Compute the stable key from the child's file group.
+        let key = self
+            .child
+            .downcast_ref::<DataSourceExec>()
+            .and_then(|dse| dse.data_source().downcast_ref::<FileScanConfig>())
+            .map(|fsc| hash_key(&fsc.file_groups[partition]));
+
+        // Cache hit: return the previously accumulated batches.
+        let (Some(key), Some(cache)) = (key, cache.clone()) else {
+            return self.child.execute(partition, context);
+        };
+
+        if let Some(cached_batches) = cache.get(&key) {
+            return Ok(Box::pin(RecordBatchStreamAdapter::new(
+                schema,
+                futures::stream::iter(cached_batches.clone().into_iter().map(Ok)),
+            )));
+        }
+
+        // Cache miss: read from child and populate the cache while forwarding.
+        let mut stream = self.child.execute(partition, context)?;
+        let mut builder = RecordBatchReceiverStreamBuilder::new(schema, 1);
+        let tx = builder.tx();
+        builder.spawn(async move {
+            let mut accumulated = Vec::new();
+            while let Some(batch) = stream.try_next().await? {
+                accumulated.push(batch.clone());
+                if tx.send(Ok(batch)).await.is_err() {
+                    break;
+                }
+            }
+            cache.insert(key, accumulated);
+            Ok(())
+        });
+        Ok(builder.build())
+    }
+}
+
+/// Stable hash for a [`FileGroup`]: serialise each file's path via its protobuf representation so
+/// the key is independent of in-memory ordering.
+fn hash_key(file_group: &FileGroup) -> usize {
+    let mut hasher = DefaultHasher::new();
+    for file in file_group.files() {
+        let serialized: protobuf::PartitionedFile = file.try_into().unwrap();
+        hasher.write(&serialized.encode_to_vec());
+    }
+    hasher.finish() as usize
+}
+
+/// Assigns each parquet file to a task slot (by hashing its path) and pins each slot to a worker.
+#[derive(Debug)]
+struct CachedFileScanConfigTaskEstimator;
+
+impl TaskEstimator for CachedFileScanConfigTaskEstimator {
+    fn task_estimation(
+        &self,
+        plan: &Arc<dyn ExecutionPlan>,
+        _: &ConfigOptions,
+    ) -> Option<TaskEstimation> {
+        plan.downcast_ref::<CacheExec>()?;
+        Some(TaskEstimation::desired(usize::MAX))
+    }
+
+    fn scale_up_leaf_node(
+        &self,
+        plan: &Arc<dyn ExecutionPlan>,
+        task_count: usize,
+        cfg: &ConfigOptions,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        let Some(cache_exec) = plan.downcast_ref::<CacheExec>() else {
+            return Ok(None);
+        };
+        let Some(dse) = cache_exec.child.downcast_ref::<DataSourceExec>() else {
+            return Ok(None);
+        };
+        let Some(fsc) = dse.data_source().downcast_ref::<FileScanConfig>() else {
+            return Ok(None);
+        };
+
+        // Hash each file to a slot so that the same file always lands in the same variant
+        // regardless of the original file_groups layout.
+        let mut per_task_files: Vec<Vec<_>> = vec![vec![]; task_count];
+        for file in fsc.file_groups.iter().flat_map(|g| g.files()) {
+            let idx = hash_key(&FileGroup::new(vec![file.clone()])) % task_count;
+            per_task_files[idx].push(file.clone());
+        }
+
+        let target_partitions = cfg.execution.target_partitions;
+        let variants = (0..task_count)
+            .map(|i| {
+                let files = std::mem::take(&mut per_task_files[i]);
+                // Spread files across up to `target_partitions` FileGroups so DataFusion can
+                // read them in parallel within the task.
+                let n_groups = files.len().clamp(1, target_partitions);
+                let mut groups: Vec<Vec<_>> = vec![vec![]; n_groups];
+                for (j, file) in files.into_iter().enumerate() {
+                    groups[j % n_groups].push(file);
+                }
+                let mut new_fsc = fsc.clone();
+                new_fsc.file_groups = groups.into_iter().map(FileGroup::new).collect();
+                CacheExec::new(DataSourceExec::from_data_source(new_fsc)) as Arc<dyn ExecutionPlan>
+            })
+            .collect::<Vec<_>>();
+
+        Ok(Some(Arc::new(DistributedLeafExec::try_new(
+            Arc::clone(plan),
+            variants,
+        )?)))
+    }
+
+    fn route_tasks(&self, ctx: &TaskRoutingContext<'_>) -> Result<Option<Vec<Url>>> {
+        if ctx.available_urls.is_empty() {
+            return Ok(None);
+        }
+        let mut routed = None;
+        ctx.plan.apply(|node| {
+            if let Some(leaf) = node.downcast_ref::<DistributedLeafExec>()
+                && leaf.original().downcast_ref::<CacheExec>().is_some()
+            {
+                // Sort URLs so the slot→worker mapping is deterministic across planning passes.
+                let mut urls = ctx.available_urls.to_vec();
+                urls.sort();
+                routed = Some(
+                    (0..ctx.task_count)
+                        .map(|i| urls[i % urls.len()].clone())
+                        .collect(),
+                );
+                return Ok(TreeNodeRecursion::Stop);
+            }
+            Ok(TreeNodeRecursion::Continue)
+        })?;
+        Ok(routed)
+    }
+}
+
+/// Codec for [`CacheExec`]. The child (`DataSourceExec(FileScanConfig)`) is encoded by the
+/// framework as a standard plan node in `PhysicalExtensionNode.inputs`; `CacheExec` itself carries
+/// no extra bytes so encode is a no-op and decode just re-wraps the decoded child.
+#[derive(Debug)]
+struct CachedFileScanCodec;
+
+impl PhysicalExtensionCodec for CachedFileScanCodec {
+    fn try_decode(
+        &self,
+        _buf: &[u8],
+        inputs: &[Arc<dyn ExecutionPlan>],
+        _ctx: &TaskContext,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let [child] = inputs else {
+            return internal_err!("CacheExec expects exactly 1 child, got {}", inputs.len());
+        };
+        Ok(CacheExec::new(Arc::clone(child)))
+    }
+
+    fn try_encode(&self, node: Arc<dyn ExecutionPlan>, _buf: &mut Vec<u8>) -> Result<()> {
+        if node.downcast_ref::<CacheExec>().is_none() {
+            return internal_err!("Expected CacheExec, got {}", node.name());
+        }
+        Ok(())
+    }
+}
+
+/// [`PhysicalOptimizerRule`] that wraps every leaf `DataSourceExec(FileScanConfig)` in a
+/// [`CacheExec`]. Any `register_parquet` table gains caching transparently.
+#[derive(Debug)]
+struct CachedFileScanConfigRule;
+
+impl PhysicalOptimizerRule for CachedFileScanConfigRule {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // transform_up (post-order) visits children before their parent, so when we wrap a
+        // DataSourceExec in CacheExec the traversal has already finished with that subtree and
+        // won't descend into the new CacheExec's child again.
+        plan.transform_up(|node| {
+            let Some(dse) = node.downcast_ref::<DataSourceExec>() else {
+                return Ok(Transformed::no(node));
+            };
+            if dse.data_source().downcast_ref::<FileScanConfig>().is_none() {
+                return Ok(Transformed::no(node));
+            }
+            Ok(Transformed::yes(CacheExec::new(node)))
+        })
+        .data()
+    }
+
+    fn name(&self) -> &str {
+        "CachedFileScanConfigRule"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}
+
+#[derive(StructOpt)]
+#[structopt(
+    name = "custom_worker_url_routing",
+    about = "Cache-affine parquet scan: each file always routes to the same worker"
+)]
+struct Args {
+    /// SQL query to run against the `weather` table.
+    query: String,
+
+    /// Render the distributed plan instead of executing the query.
+    #[structopt(long)]
+    show_distributed_plan: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let args = Args::from_args();
+
+    // Spawn three workers. Each gets its own in-memory cache injected as a session extension so
+    // that the cache outlives individual task invocations.
+    let n_workers = 3;
+    let mut ports = Vec::new();
+    for _ in 0..n_workers {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        ports.push(listener.local_addr()?.port());
+        let cache = Arc::new(WorkerFileCache::new());
+        #[allow(clippy::disallowed_methods)]
+        tokio::spawn(spawn_worker_service(
+            move |ctx: WorkerQueryContext| {
+                let mut builder = ctx.builder;
+                let cfg = builder.config().get_or_insert_default();
+                cfg.set_distributed_user_codec(CachedFileScanCodec);
+                cfg.set_extension(Arc::clone(&cache));
+                async move { Ok(builder.build()) }
+            },
+            listener,
+        ));
+    }
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let mut state = SessionStateBuilder::new()
+        .with_default_features()
+        .with_physical_optimizer_rule(Arc::new(CachedFileScanConfigRule))
+        .with_distributed_worker_resolver(LocalHostWorkerResolver::new(ports))
+        .with_distributed_planner()
+        .with_distributed_user_codec(CachedFileScanCodec)
+        .with_distributed_task_estimator(CachedFileScanConfigTaskEstimator)
+        .build();
+    state
+        .config_mut()
+        .set_extension(Arc::new(WorkerFileCache::new()));
+
+    let ctx = SessionContext::from(state);
+    ctx.register_parquet("weather", "testdata/weather", ParquetReadOptions::default())
+        .await?;
+
+    if args.show_distributed_plan {
+        let plan = ctx.sql(&args.query).await?.create_physical_plan().await?;
+        println!("{}", display_plan_ascii(plan.as_ref(), false));
+        return Ok(());
+    }
+
+    // Run the same query twice: cold (files read from disk) then warm (served from cache).
+    for pass in ["cold", "warm"] {
+        let start = Instant::now();
+        let df = ctx.sql(&args.query).await?;
+        let batches = df.execute_stream().await?.try_collect::<Vec<_>>().await?;
+        let elapsed = start.elapsed();
+        println!(
+            "=== {pass} pass done after {}ms ===\n{}",
+            elapsed.as_millis(),
+            pretty_format_batches(&batches)?
+        );
+    }
+    Ok(())
+}

--- a/examples/work_unit_feed.md
+++ b/examples/work_unit_feed.md
@@ -1,0 +1,86 @@
+# Work Unit Feed Example
+
+Demonstrates a **work unit feed**: a distributed leaf node whose work is discovered on the
+coordinator *at runtime* and streamed to the workers as the query executes, instead of being fully
+known at planning time.
+
+See the [Work Unit Feeds user guide](../docs/source/user-guide/work-unit-feeds.md) for the concepts.
+
+## Scenario
+
+The example implements a `scan(...)` table function that models an external, paginated data source
+(think a message queue, a paginated HTTP API, or a catalog that hands out object-store keys on demand).
+While the query runs, the coordinator "discovers" chunks of work and streams a small descriptor for
+each chunk to whichever worker owns that partition. The worker turns each descriptor into rows.
+
+## Components
+
+**ChunkFeedProvider** – the coordinator-side `WorkUnitFeedProvider`. Its `feed(partition, ctx)` returns
+a stream of `Chunk` descriptors for that partition. (Here it sleeps briefly between chunks to simulate
+runtime discovery; a real connector would poll an external system.)
+
+**RemoteScanExec** – a custom leaf `ExecutionPlan` that holds a `WorkUnitFeed<ChunkFeedProvider>` and,
+in `execute()`, consumes `feed.feed(partition, ctx)?` and turns each `Chunk` into a `RecordBatch`.
+
+**RemoteScanExecCodec** – a `PhysicalExtensionCodec` that serializes the node across the network. Note
+it encodes only the feed *handle* via `WorkUnitFeed::to_proto()`; the provider stays on the coordinator.
+
+**RemoteScanTaskEstimator** – a `TaskEstimator` that tells the planner how many tasks the leaf stage
+should be distributed across.
+
+The feed is registered with `with_distributed_work_unit_feed(|exec: &RemoteScanExec| Some(&exec.feed))`
+so the planner can find it inside the plan and wire coordinator → worker delivery.
+
+## Usage
+
+This example uses the in-memory cluster used in integration testing, so it needs `--features integration`.
+
+The `scan(task_count, 'chunks_p0', 'chunks_p1', ...)` arguments are: the desired task count, then one
+comma-separated list of chunk sizes per partition. The number of partition arguments must be a multiple
+of the task count. The scan emits one row per row in each chunk, tagged with the producing task and
+partition.
+
+### Render the distributed plan
+
+```bash
+cargo run \
+  --features integration \
+  --example work_unit_feed \
+  "SELECT * FROM scan(2, '3,1', '2', '4', '1,1') ORDER BY task, partition" \
+  --show-distributed-plan
+```
+
+```
+┌───── DistributedExec ── Tasks: t0:[p0]
+│ SortPreservingMergeExec: [task@0 ASC NULLS LAST, partition@1 ASC NULLS LAST]
+│   [Stage 1] => NetworkCoalesceExec: output_partitions=4, input_tasks=2
+└──────────────────────────────────────────────────
+  ┌───── Stage 1 ── Tasks: t0:[p0..p1] t1:[p2..p3]
+  │ SortExec: expr=[task@0 ASC NULLS LAST, partition@1 ASC NULLS LAST], preserve_partitioning=[true]
+  │   RemoteScanExec: tasks=2, partition_chunks=[[3, 1], [2], [4], [1, 1]]
+  └──────────────────────────────────────────────────
+```
+
+The four partition arguments are split across the two requested tasks (two partitions each).
+
+### Execute a query
+
+```bash
+cargo run \
+  --features integration \
+  --example work_unit_feed \
+  "SELECT count(*) as cnt, task FROM scan(2, '3,1', '2', '4', '1,1') GROUP BY task ORDER BY task"
+```
+
+```
++-----+------+
+| cnt | task |
++-----+------+
+| 6   | 0    |
+| 6   | 1    |
++-----+------+
+```
+
+Task 0 owns partitions `[3,1]` and `[2]` (3+1+2 = 6 rows); task 1 owns `[4]` and `[1,1]` (4+1+1 = 6 rows).
+Every one of those rows is produced from a chunk descriptor the coordinator streamed to the worker while
+the query was running.

--- a/examples/work_unit_feed.rs
+++ b/examples/work_unit_feed.rs
@@ -1,0 +1,412 @@
+//! Demonstrates **work unit feeds**: a distributed leaf node whose work is discovered on the
+//! coordinator *at runtime* and streamed to the workers while the query runs, instead of being
+//! known at planning time (think a paginated API, a queue, or a catalog handing out keys).
+//!
+//! It wires up the four pieces a feed-backed leaf needs — a `WorkUnitFeedProvider`, a custom
+//! `ExecutionPlan` holding a `WorkUnitFeed`, a `PhysicalExtensionCodec`, and a `TaskEstimator` —
+//! plus `with_distributed_work_unit_feed` to register the feed so the planner can find it.
+//!
+//! Run with:
+//! ```bash
+//! cargo run --features integration --example work_unit_feed "SELECT count(*) AS cnt, task FROM scan(2, '3,1', '2', '4', '1,1') GROUP BY task ORDER BY task"
+//! cargo run --features integration --example work_unit_feed "SELECT * FROM scan(2, '3,1', '2', '4', '1,1') ORDER BY task, partition" --show-distributed-plan
+//! ```
+
+use arrow::array::{ArrayRef, Int64Array, RecordBatch};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::util::pretty::pretty_format_batches;
+use async_trait::async_trait;
+use datafusion::catalog::{Session, TableFunctionImpl};
+use datafusion::common::{DataFusionError, Result, ScalarValue, plan_err};
+use datafusion::datasource::{TableProvider, TableType};
+use datafusion::execution::{SendableRecordBatchStream, SessionStateBuilder, TaskContext};
+use datafusion::logical_expr::Expr;
+use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use datafusion::prelude::SessionContext;
+use datafusion_distributed::test_utils::in_memory_channel_resolver::{
+    InMemoryChannelResolver, InMemoryWorkerResolver,
+};
+use datafusion_distributed::{
+    DistributedExt, DistributedTaskContext, SessionStateBuilderExt, TaskEstimation, TaskEstimator,
+    WorkUnitFeed, WorkUnitFeedProto, WorkUnitFeedProvider, WorkerQueryContext, display_plan_ascii,
+};
+use datafusion_proto::physical_plan::PhysicalExtensionCodec;
+use datafusion_proto::protobuf::proto_error;
+use futures::stream::BoxStream;
+use futures::{StreamExt, TryStreamExt};
+use prost::Message;
+use std::fmt::Formatter;
+use std::sync::Arc;
+use std::time::Duration;
+use structopt::StructOpt;
+
+/// The work unit streamed from coordinator to worker. Any `prost` message is a valid `WorkUnit`.
+/// In a real connector this might carry a file URL, an object-store key, or a page token.
+#[derive(Clone, PartialEq, ::prost::Message)]
+struct Chunk {
+    #[prost(uint64, tag = "1")]
+    n_rows: u64,
+}
+
+/// Coordinator-side producer of work units, one stream per partition. `feed` is called only on
+/// the coordinator; here it "discovers" each chunk with a tiny delay to mimic polling a source.
+#[derive(Debug, Clone)]
+struct ChunkFeedProvider {
+    per_partition_chunks: Vec<Vec<u64>>,
+    task_count: usize,
+}
+
+impl WorkUnitFeedProvider for ChunkFeedProvider {
+    type WorkUnit = Chunk;
+
+    fn feed(
+        &self,
+        partition: usize,
+        _ctx: Arc<TaskContext>,
+    ) -> Result<BoxStream<'static, Result<Chunk>>> {
+        let chunks = self
+            .per_partition_chunks
+            .get(partition)
+            .cloned()
+            .unwrap_or_default();
+        Ok(futures::stream::iter(chunks)
+            .then(|n_rows| async move {
+                tokio::time::sleep(Duration::from_millis(1)).await; // pretend to poll a remote source
+                Ok(Chunk { n_rows })
+            })
+            .boxed())
+    }
+}
+
+fn scan_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("task", DataType::Int64, false),
+        Field::new("partition", DataType::Int64, false),
+    ]))
+}
+
+/// Leaf `ExecutionPlan` that holds a `WorkUnitFeed` and, in `execute`, turns the chunks it
+/// receives into `RecordBatch`es.
+#[derive(Debug, Clone)]
+struct RemoteScanExec {
+    feed: WorkUnitFeed<ChunkFeedProvider>,
+    projection: Option<Vec<usize>>,
+    properties: Arc<PlanProperties>,
+}
+
+impl RemoteScanExec {
+    fn new(
+        feed: WorkUnitFeed<ChunkFeedProvider>,
+        partitions: usize,
+        projection: Option<Vec<usize>>,
+    ) -> Self {
+        let schema = match &projection {
+            Some(p) => Arc::new(scan_schema().project(p).unwrap()),
+            None => scan_schema(),
+        };
+        Self {
+            feed,
+            projection,
+            properties: Arc::new(PlanProperties::new(
+                EquivalenceProperties::new(schema),
+                Partitioning::UnknownPartitioning(partitions),
+                EmissionType::Incremental,
+                Boundedness::Bounded,
+            )),
+        }
+    }
+}
+
+impl DisplayAs for RemoteScanExec {
+    fn fmt_as(&self, _: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "RemoteScanExec")?;
+        if let Some(p) = self.feed.inner() {
+            write!(
+                f,
+                ": tasks={}, partition_chunks={:?}",
+                p.task_count, p.per_partition_chunks
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl ExecutionPlan for RemoteScanExec {
+    fn name(&self) -> &str {
+        "RemoteScanExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        ctx: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        // On a worker this pulls from the network (the chunks the coordinator streamed for this
+        // partition); on the coordinator it pulls straight from the local provider.
+        let chunks = self.feed.feed(partition, Arc::clone(&ctx))?;
+        let task = DistributedTaskContext::from_ctx(&ctx).task_index as i64;
+        let partition = partition as i64;
+        let schema = self.schema();
+        let projection = self.projection.clone();
+
+        let stream = chunks.map(move |chunk| {
+            let n = chunk?.n_rows as usize;
+            // Each chunk produces `n` rows tagged with the task and partition that produced them.
+            let cols: Vec<ArrayRef> = vec![
+                Arc::new(Int64Array::from(vec![task; n])),
+                Arc::new(Int64Array::from(vec![partition; n])),
+            ];
+            let cols = match &projection {
+                Some(p) => p.iter().map(|&i| Arc::clone(&cols[i])).collect(),
+                None => cols,
+            };
+            Ok(RecordBatch::try_new(Arc::clone(&schema), cols)?)
+        });
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            self.schema(),
+            stream,
+        )))
+    }
+}
+
+/// Codec for `RemoteScanExec`. Only the feed *handle* (a UUID) is serialised via `to_proto()` —
+/// the provider stays on the coordinator, and `from_proto()` rebuilds a remote feed that reads
+/// its chunks from the network.
+#[derive(Debug)]
+struct RemoteScanExecCodec;
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+struct RemoteScanProto {
+    #[prost(uint64, tag = "1")]
+    partitions: u64,
+    #[prost(uint64, repeated, tag = "2")]
+    projection: Vec<u64>,
+    #[prost(message, optional, tag = "3")]
+    feed: Option<WorkUnitFeedProto>,
+}
+
+impl PhysicalExtensionCodec for RemoteScanExecCodec {
+    fn try_decode(
+        &self,
+        buf: &[u8],
+        _inputs: &[Arc<dyn ExecutionPlan>],
+        _ctx: &TaskContext,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let p = RemoteScanProto::decode(buf).map_err(|e| proto_error(format!("{e}")))?;
+        let feed = WorkUnitFeed::<ChunkFeedProvider>::from_proto(
+            p.feed.ok_or_else(|| proto_error("missing feed"))?,
+        )?;
+        let projection =
+            (!p.projection.is_empty()).then(|| p.projection.iter().map(|&i| i as usize).collect());
+        Ok(Arc::new(RemoteScanExec::new(
+            feed,
+            p.partitions as usize,
+            projection,
+        )))
+    }
+
+    fn try_encode(&self, node: Arc<dyn ExecutionPlan>, buf: &mut Vec<u8>) -> Result<()> {
+        let exec = node
+            .downcast_ref::<RemoteScanExec>()
+            .ok_or_else(|| proto_error(format!("expected RemoteScanExec, got {}", node.name())))?;
+        RemoteScanProto {
+            partitions: exec.properties.partitioning.partition_count() as u64,
+            projection: exec
+                .projection
+                .iter()
+                .flatten()
+                .map(|&i| i as u64)
+                .collect(),
+            feed: Some(exec.feed.to_proto()),
+        }
+        .encode(buf)
+        .map_err(|e| proto_error(format!("{e}")))
+    }
+}
+
+/// Tells the planner how many tasks the leaf stage gets, and rebuilds the leaf so each task
+/// advertises its share of the partitions.
+#[derive(Debug)]
+struct RemoteScanTaskEstimator;
+
+impl TaskEstimator for RemoteScanTaskEstimator {
+    fn task_estimation(
+        &self,
+        plan: &Arc<dyn ExecutionPlan>,
+        _: &datafusion::config::ConfigOptions,
+    ) -> Option<TaskEstimation> {
+        let task_count = plan
+            .downcast_ref::<RemoteScanExec>()?
+            .feed
+            .inner()?
+            .task_count;
+        Some(TaskEstimation::desired(task_count))
+    }
+
+    fn scale_up_leaf_node(
+        &self,
+        plan: &Arc<dyn ExecutionPlan>,
+        task_count: usize,
+        _: &datafusion::config::ConfigOptions,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        let Some(exec) = plan.downcast_ref::<RemoteScanExec>() else {
+            return Ok(None);
+        };
+        let partitions_per_task = exec.feed.try_inner()?.per_partition_chunks.len() / task_count;
+        Ok(Some(Arc::new(RemoteScanExec::new(
+            exec.feed.clone(),
+            partitions_per_task,
+            exec.projection.clone(),
+        ))))
+    }
+}
+
+/// `scan(task_count, 'chunks_p0', 'chunks_p1', ...)` — `task_count` tasks, with one
+/// comma-separated list of chunk sizes per partition. The partition count must be a multiple of
+/// `task_count`.
+#[derive(Debug)]
+struct ScanTableFunction;
+
+impl TableFunctionImpl for ScanTableFunction {
+    fn call(&self, exprs: &[Expr]) -> Result<Arc<dyn TableProvider>> {
+        if exprs.len() < 2 {
+            return plan_err!("scan(task_count, partitions...) needs at least 2 arguments");
+        }
+        let task_count = match &exprs[0] {
+            Expr::Literal(ScalarValue::Int64(Some(v)), _) => *v as usize,
+            Expr::Literal(ScalarValue::Int32(Some(v)), _) => *v as usize,
+            v => return plan_err!("task_count must be an integer literal, got {v:?}"),
+        };
+        let per_partition_chunks = exprs[1..]
+            .iter()
+            .map(|e| match e {
+                Expr::Literal(ScalarValue::Utf8(Some(s)), _) => parse_chunks(s),
+                v => plan_err!("partition args must be string literals, got {v:?}"),
+            })
+            .collect::<Result<Vec<_>>>()?;
+        if task_count == 0 || per_partition_chunks.len() % task_count != 0 {
+            return plan_err!(
+                "partition count ({}) must be a non-zero multiple of task_count ({task_count})",
+                per_partition_chunks.len()
+            );
+        }
+        Ok(Arc::new(ScanTableProvider {
+            task_count,
+            per_partition_chunks,
+        }))
+    }
+}
+
+fn parse_chunks(s: &str) -> Result<Vec<u64>> {
+    s.split(',')
+        .filter(|item| !item.trim().is_empty())
+        .map(|item| {
+            item.trim()
+                .parse::<u64>()
+                .map_err(|e| DataFusionError::Plan(format!("invalid chunk size {item:?}: {e}")))
+        })
+        .collect()
+}
+
+#[derive(Debug)]
+struct ScanTableProvider {
+    task_count: usize,
+    per_partition_chunks: Vec<Vec<u64>>,
+}
+
+#[async_trait]
+impl TableProvider for ScanTableProvider {
+    fn schema(&self) -> SchemaRef {
+        scan_schema()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        _: &[Expr],
+        _: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let feed = WorkUnitFeed::new(ChunkFeedProvider {
+            per_partition_chunks: self.per_partition_chunks.clone(),
+            task_count: self.task_count,
+        });
+        Ok(Arc::new(RemoteScanExec::new(
+            feed,
+            self.per_partition_chunks.len(),
+            projection.cloned(),
+        )))
+    }
+}
+
+#[derive(StructOpt)]
+#[structopt(name = "work_unit_feed", about = "Work unit feed example")]
+struct Args {
+    /// The SQL query to run.
+    query: String,
+
+    /// Render the distributed plan instead of executing the query.
+    #[structopt(long)]
+    show_distributed_plan: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::from_args();
+
+    // The worker session must know how to deserialize `RemoteScanExec` (and so its remote feed),
+    // so the codec is registered on both the coordinator and the worker session builder.
+    let channel_resolver =
+        InMemoryChannelResolver::from_session_builder(|ctx: WorkerQueryContext| async move {
+            Ok(ctx
+                .builder
+                .with_distributed_user_codec(RemoteScanExecCodec)
+                .build())
+        });
+
+    let state = SessionStateBuilder::new()
+        .with_default_features()
+        .with_distributed_worker_resolver(InMemoryWorkerResolver::new(4))
+        .with_distributed_channel_resolver(channel_resolver)
+        .with_distributed_planner()
+        .with_distributed_user_codec(RemoteScanExecCodec)
+        .with_distributed_task_estimator(RemoteScanTaskEstimator)
+        // For every `RemoteScanExec`, hand the planner the feed it must drive from the coordinator.
+        .with_distributed_work_unit_feed(|exec: &RemoteScanExec| Some(&exec.feed))
+        .build();
+
+    let ctx = SessionContext::from(state);
+    ctx.register_udtf("scan", Arc::new(ScanTableFunction));
+
+    let df = ctx.sql(&args.query).await?;
+    if args.show_distributed_plan {
+        let plan = df.create_physical_plan().await?;
+        println!("{}", display_plan_ascii(plan.as_ref(), false));
+    } else {
+        let batches = df.execute_stream().await?.try_collect::<Vec<_>>().await?;
+        println!("{}", pretty_format_batches(&batches)?);
+    }
+    Ok(())
+}

--- a/src/distributed_planner/distributed_query_planner.rs
+++ b/src/distributed_planner/distributed_query_planner.rs
@@ -1,3 +1,4 @@
+use crate::common::TreeNodeExt;
 use crate::distributed_planner::inject_network_boundaries::{
     CardinalityBasedNetworkBoundaryBuilder, inject_network_boundaries,
 };
@@ -5,9 +6,9 @@ use crate::distributed_planner::insert_broadcast::insert_broadcast_execs;
 use crate::distributed_planner::partial_reduce_below_network_shuffles::partial_reduce_below_network_shuffles;
 use crate::distributed_planner::prepare_network_boundaries::prepare_network_boundaries;
 use crate::distributed_planner::push_fetch_into_network_coalesce::push_fetch_into_network_coalesce;
-use crate::{DistributedConfig, DistributedExec, NetworkBoundaryExt};
+use crate::{DistributedConfig, DistributedExec, NetworkBoundaryExt, TaskEstimator};
 use async_trait::async_trait;
-use datafusion::common::tree_node::TreeNode;
+use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::execution::SessionState;
 use datafusion::execution::context::QueryPlanner;
 use datafusion::logical_expr::LogicalPlan;
@@ -69,13 +70,25 @@ impl QueryPlanner for DistributedQueryPlanner {
             return Ok(original_plan);
         }
 
-        let d_cfg = DistributedConfig::from_config_options(session_state.config_options())?;
+        let cfg = session_state.config_options().as_ref();
+        let d_cfg = DistributedConfig::from_config_options(cfg)?;
 
         // The plan already contains network boundaries set by the user. Just ensure they have nice
         // unique identifiers for each stage, and move forward with it.
         if original_plan.exists(|plan| Ok(plan.is_network_boundary()))? {
+            // Ensure the leafs are appropriately scaled up.
+            let scaled = original_plan.transform_down_with_task_count(1, |plan, task_count| {
+                if !plan.children().is_empty() {
+                    return Ok(Transformed::no(plan));
+                }
+                let task_estimator = &d_cfg.__private_task_estimator;
+                match task_estimator.scale_up_leaf_node(&plan, task_count, cfg)? {
+                    None => Ok(Transformed::no(plan)),
+                    Some(scaled) => Ok(Transformed::yes(scaled)),
+                }
+            })?;
             // Ensure the stages in the plan have nice unique identifiers.
-            let plan = prepare_network_boundaries(original_plan)?;
+            let plan = prepare_network_boundaries(scaled.data)?;
             if !plan.exists(|plan| Ok(plan.is_network_boundary()))? {
                 return Ok(plan);
             }

--- a/src/execution_plans/distributed_leaf.rs
+++ b/src/execution_plans/distributed_leaf.rs
@@ -107,6 +107,21 @@ impl DistributedLeafExec {
         })
     }
 
+    /// The plan this leaf was built from (the leaf passed to
+    /// [crate::TaskEstimator::scale_up_leaf_node]). Useful for recognising which `DistributedLeafExec`
+    /// you are looking at — e.g. by downcasting it to your own leaf type — before inspecting its
+    /// [DistributedLeafExec::variants].
+    pub fn original(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.original
+    }
+
+    /// The per-task variants, in task order: `variants()[i]` is the plan sent to task `i`. Useful
+    /// for inspecting per-task information (e.g. data locality) when routing tasks to workers via
+    /// [crate::TaskEstimator::route_tasks].
+    pub fn variants(&self) -> &[Arc<dyn ExecutionPlan>] {
+        &self.variants
+    }
+
     /// Returns the variant belonging to provided task index.
     pub(crate) fn to_task_specialized(&self, task_i: usize) -> Arc<dyn ExecutionPlan> {
         Arc::clone(&self.variants[task_i])


### PR DESCRIPTION
Adds documentation and three end-to-end examples covering the main extensibility APIs.

## Documentation

New and expanded user-guide pages:

- **Concepts** — glossary of stages, tasks, leaf vs. intermediate nodes
- **How a distributed plan is built** — walkthrough of the full planning pipeline
- **Custom distributed plans** — how to inject custom network boundaries and build multi-stage plans by hand
- **Work-unit feeds** — the `WorkUnitFeed` API for streaming per-partition inputs to workers at execution time
- **Task estimator** — expanded with routing, `scale_up_leaf_node`, and `route_tasks` examples
- **Metrics**, **Worker**, **Worker resolver** — new/expanded reference pages

## Examples

Three new runnable examples, each with a companion `.md`:

### `custom_distributed_partial_reduction_tree`
Custom multi-stage distributed plan with a hand-built partial reduction tree (map-side partial aggregation → shuffle → final aggregation). Shows how to cross stage boundaries with `NetworkShuffleExec` and `NetworkCoalesceExec`.

### `work_unit_feed`
Demonstrates `WorkUnitFeed` for streaming per-partition file assignments to workers instead of embedding them in the serialized plan. Useful when the file list is large or determined at execution time.

### `custom_worker_url_routing`
Cache-affinity routing: consistently pins each parquet file to the same worker so repeat queries are served from an in-memory `DashMap` cache. Uses a `PhysicalOptimizerRule` to insert a `CacheExec` node above every `DataSourceExec(FileScanConfig)`, a `TaskEstimator` to hash files to stable task slots, and `route_tasks` to map slots to sorted worker URLs. The codec is trivial because `CacheExec` carries no extra bytes — its child is encoded by the framework via `PhysicalExtensionNode.inputs`.

## Minor fixes
- `DistributedLeafExec` display improvements
- `DistributedQueryPlanner` documentation and cleanup