### PR TITLE
Pass SessionConfig to Worker::add_on_plan_hook

### DIFF
--- a/docs/source/user-guide/worker.md
+++ b/docs/source/user-guide/worker.md
@@ -75,6 +75,27 @@ It receives a `WorkerQueryContext` containing:
 - `headers`: HTTP headers from the incoming request (useful for passing metadata like authentication tokens or
   configuration)
 
+## Plan hooks
+
+`Worker::add_on_plan_hook` registers callbacks that run after the worker session has been built and
+the physical plan has been decoded, but before the task plan is registered for execution.
+
+Each hook receives the decoded `ExecutionPlan` and the per-query `SessionConfig`:
+
+```rust
+worker.add_on_plan_hook(|plan, session_config| {
+    let rule = your_physical_optimizer_rule();
+    rule.optimize(plan, session_config.options())
+});
+```
+
+Hooks run in registration order. Treat them as trusted worker-local rewrites: transparent
+instrumentation wrappers and semantics-preserving physical optimizer rules are appropriate. The
+returned plan must preserve the coordinator-visible contract: row semantics, output schema,
+partitioning, and ordering requirements. Do not use hooks to add or remove rows or columns,
+repartition the stage, or re-plan distributed execution. If a hook returns an error, the distributed
+query fails when the coordinator tries to execute that task.
+
 ## Registering custom execution plans
 
 If your queries contain **custom** `ExecutionPlan` nodes that cross a network boundary, the coordinator

--- a/src/test_utils/in_memory_channel_resolver.rs
+++ b/src/test_utils/in_memory_channel_resolver.rs
@@ -7,7 +7,7 @@ use crate::{
 use async_trait::async_trait;
 use datafusion::common::DataFusionError;
 use datafusion::execution::SessionStateBuilder;
-use datafusion::prelude::SessionContext;
+use datafusion::prelude::{SessionConfig, SessionContext};
 use hyper_util::rt::TokioIo;
 use tonic::transport::{Endpoint, Server};
 use url::Url;
@@ -28,6 +28,14 @@ impl InMemoryChannelResolver {
     /// spawned by this method.
     pub fn from_session_builder(
         builder: impl WorkerSessionBuilder + Send + Sync + 'static,
+    ) -> Self {
+        Self::from_configured_worker(builder, |worker| worker)
+    }
+
+    /// Build an [InMemoryChannelResolver] with a custom [WorkerSessionBuilder] and worker setup.
+    pub fn from_configured_worker(
+        builder: impl WorkerSessionBuilder + Send + Sync + 'static,
+        configure_worker: impl Fn(Worker) -> Worker + Send + Sync + 'static,
     ) -> Self {
         let (client, server) = tokio::io::duplex(1024 * 1024);
 
@@ -50,6 +58,7 @@ impl InMemoryChannelResolver {
             let this = this.clone();
             Ok(builder.with_distributed_channel_resolver(this).build())
         }));
+        let endpoint = configure_worker(endpoint);
 
         #[allow(clippy::disallowed_methods)]
         tokio::spawn(async move {
@@ -110,6 +119,29 @@ pub async fn start_in_memory_context(
         .with_distributed_planner()
         .with_distributed_worker_resolver(InMemoryWorkerResolver::new(num_workers))
         .with_distributed_channel_resolver(channel_resolver)
+        .build();
+    SessionContext::from(state)
+}
+
+/// Creates a distributed session context backed by a configurable in-memory worker service.
+///
+/// Like [crate::test_utils::localhost::start_localhost_context], this uses tiny file-scan
+/// partitions so small test datasets still cross worker boundaries.
+pub async fn start_configured_in_memory_context(
+    num_workers: usize,
+    session_builder: impl WorkerSessionBuilder + Send + Sync + 'static,
+    configure_worker: impl Fn(Worker) -> Worker + Send + Sync + 'static,
+) -> SessionContext {
+    let channel_resolver =
+        InMemoryChannelResolver::from_configured_worker(session_builder, configure_worker);
+    let state = SessionStateBuilder::new()
+        .with_default_features()
+        .with_config(SessionConfig::new().with_target_partitions(num_workers))
+        .with_distributed_planner()
+        .with_distributed_worker_resolver(InMemoryWorkerResolver::new(num_workers))
+        .with_distributed_channel_resolver(channel_resolver)
+        .with_distributed_file_scan_config_bytes_per_partition(1)
+        .unwrap()
         .build();
     SessionContext::from(state)
 }

--- a/src/worker/impl_coordinator_channel.rs
+++ b/src/worker/impl_coordinator_channel.rs
@@ -96,7 +96,7 @@ impl Worker {
             let mut plan = proto_node.try_into_physical_plan(&task_ctx, &codec)?;
 
             for hook in self.hooks.on_plan.iter() {
-                plan = hook(plan)
+                plan = hook(plan, session_state.config())?;
             }
 
             // Initialize partition count to the number of partitions in the stage

--- a/src/worker/worker_service.rs
+++ b/src/worker/worker_service.rs
@@ -15,6 +15,7 @@ use async_trait::async_trait;
 use datafusion::common::DataFusionError;
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::physical_plan::ExecutionPlan;
+use datafusion::prelude::SessionConfig;
 use moka::future::Cache;
 use std::borrow::Cow;
 use std::sync::Arc;
@@ -25,10 +26,13 @@ use tonic::{Request, Response, Status, Streaming};
 const TASK_CACHE_TTI: Duration = Duration::from_mins(10);
 
 #[allow(clippy::type_complexity)]
+type OnPlanHook = dyn Fn(Arc<dyn ExecutionPlan>, &SessionConfig) -> Result<Arc<dyn ExecutionPlan>, DataFusionError>
+    + Sync
+    + Send;
+
 #[derive(Clone, Default)]
 pub(super) struct WorkerHooks {
-    pub(super) on_plan:
-        Vec<Arc<dyn Fn(Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> + Sync + Send>>,
+    pub(super) on_plan: Vec<Arc<OnPlanHook>>,
 }
 
 pub(crate) type ResultTaskData = Result<TaskData, Arc<DataFusionError>>;
@@ -82,12 +86,25 @@ impl Worker {
 
     /// Adds a callback for when an [ExecutionPlan] is received in the `set_plan` call.
     ///
-    /// The callback takes the plan and returns another plan that must be either the same,
-    /// or equivalent in terms of execution. Mutating the plan by adding nodes or removing them
-    /// will make the query blow up in unexpected ways.
+    /// The callback runs after worker session construction and plan decoding, and before task
+    /// registration and execution. It receives the per-query [SessionConfig], so it can use
+    /// propagated options or config extensions when rewriting the plan.
+    ///
+    /// The callback is trusted to preserve the worker stage contract already planned by the
+    /// coordinator: row semantics, output schema, partitioning, and ordering requirements. It is
+    /// intended for transparent wrappers, such as instrumentation, or semantics-preserving physical
+    /// rewrites. Do not use it to add or remove rows or columns, repartition the stage, or otherwise
+    /// re-plan distributed execution. Returned errors are propagated as worker plan-registration
+    /// failures.
     pub fn add_on_plan_hook(
         &mut self,
-        hook: impl Fn(Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> + Sync + Send + 'static,
+        hook: impl Fn(
+            Arc<dyn ExecutionPlan>,
+            &SessionConfig,
+        ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError>
+        + Sync
+        + Send
+        + 'static,
     ) {
         self.hooks.on_plan.push(Arc::new(hook));
     }

--- a/tests/worker_plan_hook.rs
+++ b/tests/worker_plan_hook.rs
@@ -1,0 +1,178 @@
+#[cfg(all(feature = "integration", test))]
+mod tests {
+    use arrow::array::Int32Array;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use arrow::util::pretty::pretty_format_batches;
+    use datafusion::common::{HashSet, Result, extensions_options, internal_err};
+    use datafusion::config::ConfigExtension;
+    use datafusion::error::DataFusionError;
+    use datafusion::execution::SessionState;
+    use datafusion::physical_plan::ExecutionPlan;
+    use datafusion::prelude::{SessionConfig, SessionContext};
+    use datafusion_distributed::test_utils::in_memory_channel_resolver::start_configured_in_memory_context;
+    use datafusion_distributed::test_utils::session_context::register_temp_parquet_table;
+    use datafusion_distributed::{DistributedExt, Worker, WorkerQueryContext};
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    const HOOK_LABEL: &str = "worker-session-value";
+
+    extensions_options! {
+        pub struct PlanHookOptions {
+            pub label: String, default = "".to_string()
+            pub fail_in_hook: bool, default = false
+        }
+    }
+
+    impl ConfigExtension for PlanHookOptions {
+        const PREFIX: &'static str = "plan_hook";
+    }
+
+    async fn build_state(ctx: WorkerQueryContext) -> Result<SessionState, DataFusionError> {
+        Ok(ctx
+            .builder
+            .with_distributed_option_extension_from_headers::<PlanHookOptions>(&ctx.headers)?
+            .build())
+    }
+
+    #[tokio::test]
+    async fn plan_hooks_receive_session_config_and_run_in_order()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let hook_calls = Arc::new(Mutex::new(HookCalls::default()));
+
+        let mut ctx = start_configured_in_memory_context(3, build_state, {
+            let hook_calls = Arc::clone(&hook_calls);
+            move |mut worker| {
+                add_first_hook(&mut worker, Arc::clone(&hook_calls));
+                add_second_hook(&mut worker, Arc::clone(&hook_calls));
+                worker
+            }
+        })
+        .await;
+
+        ctx.set_distributed_option_extension(PlanHookOptions {
+            label: HOOK_LABEL.to_string(),
+            fail_in_hook: false,
+        });
+
+        assert_eq!(
+            collect_hook_query(&ctx).await?,
+            "+----+\n\
+             | id |\n\
+             +----+\n\
+             | 2  |\n\
+             | 3  |\n\
+             +----+"
+        );
+
+        let hook_calls = hook_calls.lock().unwrap();
+        assert!(hook_calls.first > 0);
+        assert_eq!(hook_calls.first, hook_calls.second);
+        assert!(hook_calls.pending_plan_ids.is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn plan_hook_errors_propagate_to_query() -> Result<(), Box<dyn std::error::Error>> {
+        let mut ctx = start_configured_in_memory_context(3, build_state, move |mut worker| {
+            worker.add_on_plan_hook(move |plan, session_config| {
+                let options = plan_hook_options(session_config)?;
+                if options.fail_in_hook {
+                    return internal_err!("plan hook failed for {}", options.label);
+                }
+
+                Ok(plan)
+            });
+
+            worker
+        })
+        .await;
+
+        ctx.set_distributed_option_extension(PlanHookOptions {
+            label: HOOK_LABEL.to_string(),
+            fail_in_hook: true,
+        });
+
+        let err = collect_hook_query(&ctx)
+            .await
+            .expect_err("plan hook error should propagate to the query");
+
+        let err = err.to_string();
+        assert!(
+            err.contains("plan hook failed for worker-session-value"),
+            "{err}"
+        );
+
+        Ok(())
+    }
+
+    #[derive(Default)]
+    struct HookCalls {
+        pending_plan_ids: HashSet<usize>,
+        first: usize,
+        second: usize,
+    }
+
+    fn add_first_hook(worker: &mut Worker, calls: Arc<Mutex<HookCalls>>) {
+        worker.add_on_plan_hook(move |plan, session_config| {
+            let options = plan_hook_options(session_config)?;
+            if options.label != HOOK_LABEL {
+                return internal_err!("unexpected plan hook label {}", options.label);
+            }
+
+            let mut calls = calls.lock().unwrap();
+            calls.pending_plan_ids.insert(plan_identity(&plan));
+            calls.first += 1;
+            Ok(plan)
+        });
+    }
+
+    fn add_second_hook(worker: &mut Worker, calls: Arc<Mutex<HookCalls>>) {
+        worker.add_on_plan_hook(move |plan, session_config| {
+            let options = plan_hook_options(session_config)?;
+            if options.label != HOOK_LABEL {
+                return internal_err!("unexpected plan hook label {}", options.label);
+            }
+
+            let mut calls = calls.lock().unwrap();
+            if !calls.pending_plan_ids.remove(&plan_identity(&plan)) {
+                return internal_err!("second hook ran before first hook");
+            }
+
+            calls.second += 1;
+            Ok(plan)
+        });
+    }
+
+    fn plan_identity(plan: &Arc<dyn ExecutionPlan>) -> usize {
+        Arc::as_ptr(plan) as *const () as usize
+    }
+
+    async fn collect_hook_query(ctx: &SessionContext) -> Result<String> {
+        let _temp_file = register_hook_input_table(ctx).await?;
+        let batches = ctx
+            .sql("SELECT id FROM hook_input WHERE id > 1 ORDER BY id")
+            .await?
+            .collect()
+            .await?;
+        Ok(pretty_format_batches(&batches)?.to_string())
+    }
+
+    async fn register_hook_input_table(ctx: &SessionContext) -> Result<std::path::PathBuf> {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )?;
+        register_temp_parquet_table("hook_input", schema, vec![batch], ctx).await
+    }
+
+    fn plan_hook_options(session_config: &SessionConfig) -> Result<&PlanHookOptions> {
+        let Some(options) = session_config.options().extensions.get::<PlanHookOptions>() else {
+            return internal_err!("PlanHookOptions not found in worker SessionConfig");
+        };
+        Ok(options)
+    }
+}


### PR DESCRIPTION
Closes #498

## What

- Changes `Worker::add_on_plan_hook` so hooks receive the per-query `SessionConfig` and can return `DataFusionError`.
- Keeps the hook at the same lifecycle point: after the worker session is built and the physical plan is decoded, before task registration/execution.
- Propagates hook failures as worker plan-registration failures.
- Documents hook ordering, the execution-equivalent plan expectation, and error propagation.
- Adds an integration test covering propagated config extensions, using a fallible `PhysicalOptimizerRule`, hook ordering, and coordinator-visible hook errors.

## Why

The worker already has the final per-query `SessionConfig` when the plan hook runs, but the hook could only see the decoded plan. That makes tracing/instrumentation integrations awkward when their options come from session config or propagated config extensions reconstructed by `WorkerSessionBuilder`.

This is a breaking API change, but the migration is small:

```rust
worker.add_on_plan_hook(|plan, _session_config| Ok(plan));
```

## Tests

```text
cargo test --features integration --test worker_plan_hook -- --nocapture
```
