### PR TITLE
Improve worker resolver ergonomics

### DIFF
--- a/examples/custom_worker_url_routing.rs
+++ b/examples/custom_worker_url_routing.rs
@@ -41,8 +41,8 @@ use datafusion_distributed::test_utils::localhost::{
     LocalHostWorkerResolver, spawn_worker_service,
 };
 use datafusion_distributed::{
-    DistributedExt, DistributedLeafExec, SessionStateBuilderExt, TaskEstimation, TaskEstimator,
-    TaskRoutingContext, WorkerQueryContext, display_plan_ascii,
+    DistributedConfig, DistributedExt, DistributedLeafExec, SessionStateBuilderExt, TaskEstimation,
+    TaskEstimator, TaskRoutingContext, WorkerQueryContext, display_plan_ascii,
 };
 use datafusion_proto::physical_plan::PhysicalExtensionCodec;
 use datafusion_proto::protobuf;
@@ -219,16 +219,16 @@ impl TaskEstimator for CachedFileScanConfigTaskEstimator {
     }
 
     fn route_tasks(&self, ctx: &TaskRoutingContext<'_>) -> Result<Option<Vec<Url>>> {
-        if ctx.available_urls.is_empty() {
-            return Ok(None);
-        }
+        let d_cfg = DistributedConfig::from_task_context(&ctx.task_ctx)?;
+        let available_urls = d_cfg.worker_resolver().get_urls()?;
+
         let mut routed = None;
         ctx.plan.apply(|node| {
             if let Some(leaf) = node.downcast_ref::<DistributedLeafExec>()
                 && leaf.original().downcast_ref::<CacheExec>().is_some()
             {
                 // Sort URLs so the slot→worker mapping is deterministic across planning passes.
-                let mut urls = ctx.available_urls.to_vec();
+                let mut urls = available_urls.to_vec();
                 urls.sort();
                 routed = Some(
                     (0..ctx.task_count)

--- a/src/coordinator/query_coordinator.rs
+++ b/src/coordinator/query_coordinator.rs
@@ -375,18 +375,17 @@ impl<'a> StageCoordinator<'a> {
         let d_cfg = DistributedConfig::from_config_options(session_config.options())?;
         let worker_resolver = get_distributed_worker_resolver(session_config)?;
         let task_estimator = &d_cfg.__private_task_estimator;
-        let available_urls = worker_resolver.get_urls()?;
 
         let routed_urls = match task_estimator.route_tasks(&TaskRoutingContext {
             task_ctx: Arc::clone(self.task_ctx),
             plan: self.plan,
             task_count: self.task_count,
-            available_urls: &available_urls,
         }) {
             Ok(Some(routed_urls)) => routed_urls,
             // If the user has not defined custom routing with a `route_tasks` implementation, we
             // default to round-robin task assignation from a randomized starting point.
             Ok(None) => {
+                let available_urls = worker_resolver.get_urls()?;
                 let start_idx = rand::rng().random_range(0..available_urls.len());
                 (0..self.task_count)
                     .map(|i| available_urls[(start_idx + i) % available_urls.len()].clone())

--- a/src/distributed_ext.rs
+++ b/src/distributed_ext.rs
@@ -219,16 +219,10 @@ pub trait DistributedExt: Sized {
     ///     .with_distributed_planner()
     ///     .build();
     /// ```
-    fn with_distributed_worker_resolver<T: WorkerResolver + Send + Sync + 'static>(
-        self,
-        resolver: T,
-    ) -> Self;
+    fn with_distributed_worker_resolver<T: WorkerResolver + 'static>(self, resolver: T) -> Self;
 
     /// Same as [DistributedExt::with_distributed_channel_resolver] but with an in-place mutation.
-    fn set_distributed_worker_resolver<T: WorkerResolver + Send + Sync + 'static>(
-        &mut self,
-        resolver: T,
-    );
+    fn set_distributed_worker_resolver<T: WorkerResolver + 'static>(&mut self, resolver: T);
 
     /// This is what tells Distributed DataFusion how to build a Worker gRPC client out of a worker URL.
     ///
@@ -606,10 +600,7 @@ impl DistributedExt for SessionConfig {
         set_distributed_user_codec_arc(self, codec)
     }
 
-    fn set_distributed_worker_resolver<T: WorkerResolver + Send + Sync + 'static>(
-        &mut self,
-        resolver: T,
-    ) {
+    fn set_distributed_worker_resolver<T: WorkerResolver + 'static>(&mut self, resolver: T) {
         set_distributed_worker_resolver(self, resolver);
     }
 
@@ -751,7 +742,7 @@ impl DistributedExt for SessionConfig {
 
             #[call(set_distributed_worker_resolver)]
             #[expr($;self)]
-            fn with_distributed_worker_resolver<T: WorkerResolver + Send + Sync + 'static>(mut self, resolver: T) -> Self;
+            fn with_distributed_worker_resolver<T: WorkerResolver + 'static>(mut self, resolver: T) -> Self;
 
             #[call(set_distributed_channel_resolver)]
             #[expr($;self)]
@@ -840,10 +831,10 @@ impl DistributedExt for SessionStateBuilder {
             #[expr($;self)]
             fn with_distributed_user_codec_arc(mut self, codec: Arc<dyn PhysicalExtensionCodec>) -> Self;
 
-            fn set_distributed_worker_resolver<T: WorkerResolver + Send + Sync + 'static>(&mut self, resolver: T);
+            fn set_distributed_worker_resolver<T: WorkerResolver + 'static>(&mut self, resolver: T);
             #[call(set_distributed_worker_resolver)]
             #[expr($;self)]
-            fn with_distributed_worker_resolver<T: WorkerResolver + Send + Sync + 'static>(mut self, resolver: T) -> Self;
+            fn with_distributed_worker_resolver<T: WorkerResolver + 'static>(mut self, resolver: T) -> Self;
 
             fn set_distributed_channel_resolver<T: ChannelResolver + Send + Sync + 'static>(&mut self, resolver: T);
             #[call(set_distributed_channel_resolver)]
@@ -951,10 +942,10 @@ impl DistributedExt for SessionState {
             #[expr($;self)]
             fn with_distributed_user_codec_arc(mut self, codec: Arc<dyn PhysicalExtensionCodec>) -> Self;
 
-            fn set_distributed_worker_resolver<T: WorkerResolver + Send + Sync + 'static>(&mut self, resolver: T);
+            fn set_distributed_worker_resolver<T: WorkerResolver + 'static>(&mut self, resolver: T);
             #[call(set_distributed_worker_resolver)]
             #[expr($;self)]
-            fn with_distributed_worker_resolver<T: WorkerResolver + Send + Sync + 'static>(mut self, resolver: T) -> Self;
+            fn with_distributed_worker_resolver<T: WorkerResolver + 'static>(mut self, resolver: T) -> Self;
 
             fn set_distributed_channel_resolver<T: ChannelResolver + Send + Sync + 'static>(&mut self, resolver: T);
             #[call(set_distributed_channel_resolver)]
@@ -1062,10 +1053,10 @@ impl DistributedExt for SessionContext {
             #[expr($;self)]
             fn with_distributed_user_codec_arc(self, codec: Arc<dyn PhysicalExtensionCodec>) -> Self;
 
-            fn set_distributed_worker_resolver<T: WorkerResolver + Send + Sync + 'static>(&mut self, resolver: T);
+            fn set_distributed_worker_resolver<T: WorkerResolver + 'static>(&mut self, resolver: T);
             #[call(set_distributed_worker_resolver)]
             #[expr($;self)]
-            fn with_distributed_worker_resolver<T: WorkerResolver + Send + Sync + 'static>(self, resolver: T) -> Self;
+            fn with_distributed_worker_resolver<T: WorkerResolver + 'static>(self, resolver: T) -> Self;
 
             fn set_distributed_channel_resolver<T: ChannelResolver + Send + Sync + 'static>(&mut self, resolver: T);
             #[call(set_distributed_channel_resolver)]

--- a/src/distributed_planner/distributed_config.rs
+++ b/src/distributed_planner/distributed_config.rs
@@ -1,9 +1,11 @@
-use crate::TaskEstimator;
 use crate::distributed_planner::task_estimator::CombinedTaskEstimator;
 use crate::networking::{ChannelResolverExtension, WorkerResolverExtension};
 use crate::work_unit_feed::WorkUnitFeedRegistry;
+use crate::{TaskEstimator, WorkerResolver};
 use datafusion::common::{DataFusionError, extensions_options, not_impl_err, plan_err};
 use datafusion::config::{ConfigExtension, ConfigField, ConfigOptions, Visit};
+use datafusion::execution::TaskContext;
+use datafusion::prelude::SessionConfig;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
@@ -115,6 +117,21 @@ impl DistributedConfig {
             return plan_err!("DistributedConfig is not in ConfigOptions.extensions");
         };
         Ok(distributed_cfg)
+    }
+
+    /// Gets the [DistributedConfig] from the [ConfigOptions]'s in the provided [SessionConfig].
+    pub fn from_session_config(session_cfg: &SessionConfig) -> Result<&Self, DataFusionError> {
+        Self::from_config_options(session_cfg.options())
+    }
+
+    /// Gets the [DistributedConfig] from the [ConfigOptions]'s in the provided [TaskContext].
+    pub fn from_task_context(ctx: &Arc<TaskContext>) -> Result<&Self, DataFusionError> {
+        Self::from_session_config(ctx.session_config())
+    }
+
+    /// Returns the [WorkerResolver] currently in scope for this [DistributedConfig].
+    pub fn worker_resolver(&self) -> &Arc<dyn WorkerResolver> {
+        &self.__private_worker_resolver.0
     }
 }
 

--- a/src/distributed_planner/task_estimator.rs
+++ b/src/distributed_planner/task_estimator.rs
@@ -155,9 +155,6 @@ pub struct TaskRoutingContext<'a> {
     pub plan: &'a Arc<dyn ExecutionPlan>,
     /// The number of tasks to be assigned.
     pub task_count: usize,
-    /// Contains a list of URLs representing machines available to receive a task. These URLs are
-    /// sourced at execution time and thus should closely reflect the real state of the cluster.
-    pub available_urls: &'a [Url],
 }
 
 impl TaskEstimator for usize {

--- a/src/networking/worker_resolver.rs
+++ b/src/networking/worker_resolver.rs
@@ -2,11 +2,12 @@ use crate::DistributedConfig;
 use crate::config_extension_ext::set_distributed_option_extension;
 use datafusion::common::{DataFusionError, exec_err, not_impl_err};
 use datafusion::prelude::SessionConfig;
+use std::any::Any;
 use std::sync::Arc;
 use url::Url;
 
 /// Resolves a list of worker URLs in the cluster available for executing parts of the plan.
-pub trait WorkerResolver {
+pub trait WorkerResolver: Any + Send + Sync {
     /// Gets all available worker URLs in the cluster. Note how this method is not async, which
     /// means that any async operation involved in discovering worker URLs must happen on a
     /// background thread and be retrieved by this method synchronously.
@@ -22,7 +23,7 @@ pub trait WorkerResolver {
 
 pub(crate) fn set_distributed_worker_resolver(
     cfg: &mut SessionConfig,
-    worker_resolver: impl WorkerResolver + Send + Sync + 'static,
+    worker_resolver: impl WorkerResolver + 'static,
 ) {
     let opts = cfg.options_mut();
     let worker_resolver = WorkerResolverExtension(Arc::new(worker_resolver));
@@ -41,7 +42,7 @@ pub(crate) fn set_distributed_worker_resolver(
 
 pub fn get_distributed_worker_resolver(
     cfg: &SessionConfig,
-) -> Result<Arc<dyn WorkerResolver + Send + Sync>, DataFusionError> {
+) -> Result<Arc<dyn WorkerResolver>, DataFusionError> {
     let opts = cfg.options();
     let Some(distributed_cfg) = opts.extensions.get::<DistributedConfig>() else {
         return exec_err!("WorkerResolver not present in the session config");
@@ -50,9 +51,7 @@ pub fn get_distributed_worker_resolver(
 }
 
 #[derive(Clone)]
-pub(crate) struct WorkerResolverExtension(
-    pub(crate) Arc<dyn WorkerResolver + Send + Sync + 'static>,
-);
+pub(crate) struct WorkerResolverExtension(pub(crate) Arc<dyn WorkerResolver + 'static>);
 
 impl WorkerResolverExtension {
     pub(crate) fn not_implemented() -> Self {
@@ -66,7 +65,7 @@ impl WorkerResolverExtension {
     }
 }
 
-impl WorkerResolver for Arc<dyn WorkerResolver + Send + Sync> {
+impl WorkerResolver for Arc<dyn WorkerResolver> {
     fn get_urls(&self) -> Result<Vec<Url>, DataFusionError> {
         self.as_ref().get_urls()
     }

--- a/src/test_utils/routing.rs
+++ b/src/test_utils/routing.rs
@@ -24,7 +24,9 @@ use url::Url;
 
 use crate::execution_plans::DistributedLeafExec;
 use crate::worker::LocalWorkerContext;
-use crate::{DistributedTaskContext, TaskEstimation, TaskEstimator};
+use crate::{
+    DistributedConfig, DistributedTaskContext, TaskEstimation, TaskEstimator, WorkerResolver,
+};
 
 // Table function that creates a `URLEmitterExec` for testing task routing.
 #[derive(Debug)]
@@ -288,12 +290,11 @@ impl TaskEstimator for URLEmitterTaskEstimator {
         )?)))
     }
 
-    fn route_tasks(
-        &self,
-        routing_ctx: &crate::TaskRoutingContext<'_>,
-    ) -> datafusion::error::Result<Option<Vec<Url>>> {
+    fn route_tasks(&self, routing_ctx: &crate::TaskRoutingContext<'_>) -> Result<Option<Vec<Url>>> {
+        let d_cfg = DistributedConfig::from_task_context(&routing_ctx.task_ctx)?;
+        let mut routed_urls = d_cfg.worker_resolver().get_urls()?;
+
         // Trivial routing policy: Assign tasks to URLs in reverse order.
-        let mut routed_urls = routing_ctx.available_urls.to_vec();
         routed_urls.reverse();
         routed_urls.truncate(routing_ctx.task_count);
         Ok(Some(routed_urls))


### PR DESCRIPTION
Before, users had no way to access their own `WorkerResolver` from the context. This is actually useful for example if they want to retriever the worker URLs in methods like `scale_up_leaf_node`.

Additionally, they might have a specific implementation to which they might want to downcast, which is not possible today because `WorkerResolver` does not implement `Any`.

This PR adds two main things:
- A way for people to retrieve their `WorkerResolver` from the context
- A way for people to downcast to their own specific `WorkerResolver`