### PR TITLE
Collect worker metrics after stream drop

### DIFF
--- a/src/common/on_drop_stream.rs
+++ b/src/common/on_drop_stream.rs
@@ -5,6 +5,9 @@ use std::task::{Context, Poll};
 
 /// Wraps a stream and fires a callback when the stream is dropped.
 ///
+/// The wrapped stream is dropped before the callback runs. This lets callbacks
+/// observe state, such as metrics, that inner streams finalize in `Drop`.
+///
 /// This is useful for cleanup operations like releasing memory reservations,
 /// cancelling background tasks, or logging when a stream consumer stops early.
 ///
@@ -20,7 +23,7 @@ where
     F: FnOnce(),
 {
     OnDropStream {
-        inner,
+        inner: OnDropInner::Live(inner),
         on_drop: Some(on_drop),
     }
 }
@@ -29,8 +32,14 @@ where
 #[pin_project(PinnedDrop)]
 pub(crate) struct OnDropStream<S, F: FnOnce()> {
     #[pin]
-    inner: S,
+    inner: OnDropInner<S>,
     on_drop: Option<F>,
+}
+
+#[pin_project(project = OnDropInnerProj, project_replace = OnDropInnerProjOwn)]
+enum OnDropInner<S> {
+    Live(#[pin] S),
+    Dropped,
 }
 
 impl<S, F> Stream for OnDropStream<S, F>
@@ -41,11 +50,17 @@ where
     type Item = S::Item;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.project().inner.poll_next(cx)
+        match self.project().inner.project() {
+            OnDropInnerProj::Live(inner) => inner.poll_next(cx),
+            OnDropInnerProj::Dropped => Poll::Ready(None),
+        }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.inner.size_hint()
+        match &self.inner {
+            OnDropInner::Live(inner) => inner.size_hint(),
+            OnDropInner::Dropped => (0, Some(0)),
+        }
     }
 }
 
@@ -53,6 +68,7 @@ where
 impl<S, F: FnOnce()> PinnedDrop for OnDropStream<S, F> {
     fn drop(self: Pin<&mut Self>) {
         let this = self.project();
+        this.inner.project_replace(OnDropInner::Dropped);
         if let Some(on_drop) = this.on_drop.take() {
             on_drop();
         }
@@ -65,6 +81,24 @@ mod tests {
     use futures::StreamExt;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct DropFlagStream {
+        dropped: Arc<AtomicBool>,
+    }
+
+    impl Stream for DropFlagStream {
+        type Item = ();
+
+        fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Poll::Ready(None)
+        }
+    }
+
+    impl Drop for DropFlagStream {
+        fn drop(&mut self) {
+            self.dropped.store(true, Ordering::SeqCst);
+        }
+    }
 
     #[tokio::test]
     async fn fires_on_drop_when_fully_consumed() {
@@ -115,5 +149,25 @@ mod tests {
         assert!(!dropped.load(Ordering::SeqCst));
         drop(stream);
         assert!(dropped.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn fires_on_drop_after_inner_stream_is_dropped() {
+        let inner_dropped = Arc::new(AtomicBool::new(false));
+        let observed_inner_drop = Arc::new(AtomicBool::new(false));
+        let observed_inner_drop_clone = Arc::clone(&observed_inner_drop);
+        let inner_dropped_clone = Arc::clone(&inner_dropped);
+
+        let stream = DropFlagStream {
+            dropped: inner_dropped,
+        };
+        let stream = on_drop_stream(stream, move || {
+            observed_inner_drop_clone
+                .store(inner_dropped_clone.load(Ordering::SeqCst), Ordering::SeqCst);
+        });
+
+        drop(stream);
+
+        assert!(observed_inner_drop.load(Ordering::SeqCst));
     }
 }


### PR DESCRIPTION
## Summary

Worker task metrics are sent when the last partition stream for a task finishes or is dropped. Before this change, that happened from the generic `on_drop_stream` callback. That callback ran from `PinnedDrop`, before the wrapped inner stream field was actually dropped.

That ordering matters for execution plans whose metrics are finalized by stream `Drop`: the worker could snapshot and send task metrics before those drop-finalized metrics had been flushed. This is easiest to hit when a downstream operator stops early, for example because of a `LIMIT`.

This PR makes the shared `on_drop_stream` helper use the safer ordering: it drops the wrapped stream first, then runs the callback. The worker metrics path can keep using the common helper, but the callback now observes metrics finalized by the inner execution stream.

## Impact

This changes the timing of `on_drop_stream` callbacks, not the distributed metrics protocol. Workers still send the same `TaskMetrics` message to the coordinator, and the coordinator still rewrites/display metrics the same way. The difference is that the worker now takes its metrics snapshot after the wrapped stream has completed its own `Drop` logic.

For cleanup-oriented uses of `on_drop_stream`, the callback still runs when the wrapper is dropped. It just runs after the inner stream is dropped, which is the less surprising ordering for code that wants to observe final stream state.

## Rust Pinning Detail

`OnDropStream` stores an arbitrary inner stream, and streams are allowed to be `!Unpin`. In plain terms, that means Rust may require the stream to stay at the same memory address after polling starts. We cannot safely move the inner stream out of `OnDropStream` just to drop it before running the callback.

The nested enum plus `pin_project` is the small bit of machinery that makes this safe:

```rust
#[pin_project(project = OnDropInnerProj, project_replace = OnDropInnerProjOwn)]
enum OnDropInner<S> {
    Live(#[pin] S),
    Dropped,
}
```

`#[pin_project]` generates projection helpers for pinned fields. The `project_replace` helper lets `PinnedDrop` replace `Live(inner)` with `Dropped` without illegally moving a pinned stream. During that replacement, the old `Live(inner)` value is dropped, so the wrapped stream gets its `Drop` first. Only after that does `on_drop_stream` run the callback.

The new regression test uses a stream that flips a flag in its own `Drop`, then asserts the callback can already observe that flag. That test captures the intended ordering directly.

## Validation

- `cargo fmt`
- `cargo test common::on_drop_stream`
- `cargo test fires_on_drop_after_inner_stream_is_dropped`
- `cargo test --test metrics_collection`