### PR TITLE
Fix with_new_children in leaf nodes

### DIFF
--- a/src/execution_plans/distributed_leaf.rs
+++ b/src/execution_plans/distributed_leaf.rs
@@ -150,9 +150,12 @@ impl ExecutionPlan for DistributedLeafExec {
 
     fn with_new_children(
         self: Arc<Self>,
-        _children: Vec<Arc<dyn ExecutionPlan>>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        not_impl_err!("DistributedLeafExec does not accept children")
+        if !children.is_empty() {
+            return not_impl_err!("DistributedLeafExec does not accept children");
+        }
+        Ok(self)
     }
 
     fn execute(

--- a/src/execution_plans/network_broadcast.rs
+++ b/src/execution_plans/network_broadcast.rs
@@ -222,7 +222,11 @@ impl ExecutionPlan for NetworkBroadcastExec {
             Stage::Local(local) => {
                 local.plan = require_one_child(children)?;
             }
-            Stage::Remote(_) => not_impl_err!("NetworkBoundary cannot accept children")?,
+            Stage::Remote(_) => {
+                if !children.is_empty() {
+                    not_impl_err!("NetworkBoundary cannot accept children")?
+                }
+            }
         }
         Ok(Arc::new(self_clone))
     }

--- a/src/execution_plans/network_coalesce.rs
+++ b/src/execution_plans/network_coalesce.rs
@@ -219,7 +219,11 @@ impl ExecutionPlan for NetworkCoalesceExec {
             Stage::Local(local) => {
                 local.plan = require_one_child(children)?;
             }
-            Stage::Remote(_) => not_impl_err!("NetworkBoundary cannot accept children")?,
+            Stage::Remote(_) => {
+                if !children.is_empty() {
+                    not_impl_err!("NetworkBoundary cannot accept children")?
+                }
+            }
         }
         Ok(Arc::new(self_clone))
     }

--- a/src/execution_plans/network_shuffle.rs
+++ b/src/execution_plans/network_shuffle.rs
@@ -197,7 +197,11 @@ impl ExecutionPlan for NetworkShuffleExec {
             Stage::Local(local) => {
                 local.plan = require_one_child(children)?;
             }
-            Stage::Remote(_) => not_impl_err!("NetworkBoundary cannot accept children")?,
+            Stage::Remote(_) => {
+                if !children.is_empty() {
+                    not_impl_err!("NetworkBoundary cannot accept children")?
+                }
+            }
         }
         Ok(Arc::new(self_clone))
     }


### PR DESCRIPTION
In some cases `with_new_children` will be called in leaf nodes with an empty set of `children`.

This is valid as long as `children` is empty, and today we fail in that scenario, even if we should be succeeding