### PR TITLE
decorrelate shuffle size from target_batch_size

### DIFF
--- a/src/distributed_planner/distributed_config.rs
+++ b/src/distributed_planner/distributed_config.rs
@@ -49,7 +49,7 @@ extensions_options! {
         /// shuffle batch sizes independently of the global `datafusion.execution.batch_size`.
         ///
         /// Set to 0 (the default) to apply no override and inherit `datafusion.execution.batch_size`.
-        pub shuffle_batch_size: usize, default = 0
+        pub shuffle_batch_size: usize, default = 8192 * 4
         /// Maximum tasks that will be assigned per stage during distributed planning.
         /// If set to 0, this value is the number of workers returned by the provided `WorkerResolver`.
         /// It defaults to 0.

--- a/src/worker/impl_coordinator_channel.rs
+++ b/src/worker/impl_coordinator_channel.rs
@@ -66,7 +66,7 @@ impl Worker {
         let task_data = || async {
             let headers = grpc_headers.into_headers();
 
-            let mut cfg = SessionConfig::default()
+            let cfg = SessionConfig::default()
                 .with_extension(Arc::new(remote_work_unit_feed_registry.receivers))
                 .with_extension(Arc::new(DistributedTaskContext {
                     task_index: key.task_number as usize,
@@ -80,12 +80,14 @@ impl Worker {
                 .with_distributed_option_extension_from_headers::<DistributedConfig>(&headers)?;
 
             let d_cfg = DistributedConfig::from_config_options(cfg.options())?;
-            let shuffle_batch_size = d_cfg.shuffle_batch_size;
             let collect_metrics = d_cfg.collect_metrics;
-            if shuffle_batch_size != 0 {
-                cfg = cfg.with_batch_size(shuffle_batch_size);
-            }
-
+            /*
+                        let shuffle_batch_size = d_cfg.shuffle_batch_size;
+                        let collect_metrics = d_cfg.collect_metrics;
+                        if shuffle_batch_size != 0 {
+                            cfg = cfg.with_batch_size(shuffle_batch_size);
+                        }
+            */
             let session_state = self
                 .session_builder
                 .build_session_state(WorkerQueryContext {

--- a/src/worker/impl_coordinator_channel.rs
+++ b/src/worker/impl_coordinator_channel.rs
@@ -81,13 +81,6 @@ impl Worker {
 
             let d_cfg = DistributedConfig::from_config_options(cfg.options())?;
             let collect_metrics = d_cfg.collect_metrics;
-            /*
-                        let shuffle_batch_size = d_cfg.shuffle_batch_size;
-                        let collect_metrics = d_cfg.collect_metrics;
-                        if shuffle_batch_size != 0 {
-                            cfg = cfg.with_batch_size(shuffle_batch_size);
-                        }
-            */
             let session_state = self
                 .session_builder
                 .build_session_state(WorkerQueryContext {

--- a/src/worker/impl_execute_task.rs
+++ b/src/worker/impl_execute_task.rs
@@ -8,6 +8,7 @@ use crate::worker::spawn_select_all::spawn_select_all;
 use crate::worker::worker_service::{TaskDataEntries, Worker};
 use arrow_flight::encode::{DictionaryHandling, FlightDataEncoder, FlightDataEncoderBuilder};
 use arrow_flight::error::FlightError;
+use arrow_select::coalesce::BatchCoalescer;
 use arrow_select::dictionary::garbage_collect_any_dictionary;
 use datafusion::arrow::array::{Array, AsArray, RecordBatch, RecordBatchOptions};
 use datafusion::arrow::ipc::CompressionType;
@@ -110,6 +111,7 @@ pub(crate) async fn execute_remote_task(
     };
     let mut flight_streams = Vec::with_capacity(arrow_streams.len());
     for (partition, arrow_stream) in partition_range.zip(arrow_streams) {
+        let arrow_stream = coalesce_flight_stream(arrow_stream, &d_cfg);
         let flight_stream = build_flight_data_stream(arrow_stream, compression)?.map(move |msg| {
             // For each FlightData produced by this stream, mark it with the appropriate
             // partition. This stream will be merged with several others from other partitions,
@@ -204,4 +206,57 @@ fn garbage_collect_arrays(batch: RecordBatch) -> Result<RecordBatch, DataFusionE
         arrays,
         &RecordBatchOptions::new().with_row_count(Some(row_count)),
     )?)
+}
+
+/// Wraps `stream` in a coalescing adapter that buffers record batches until `target` rows
+/// are accumulated before yielding, reducing the number of Flight messages sent over the wire.
+fn coalesce_flight_stream(
+    stream: SendableRecordBatchStream,
+    d_cfg: &DistributedConfig,
+) -> SendableRecordBatchStream {
+    use futures::StreamExt as FuturesStreamExt;
+
+    if d_cfg.shuffle_batch_size == 0 {
+        return stream;
+    }
+    let schema = stream.schema();
+    let coalescer = Arc::new(std::sync::Mutex::new(BatchCoalescer::new(
+        Arc::clone(&schema),
+        d_cfg.shuffle_batch_size,
+    )));
+    let coalescer_for_flush = Arc::clone(&coalescer);
+
+    let batches = stream.flat_map(move |result| {
+        let mut coalescer = coalescer.lock().unwrap();
+        let ready: Vec<Result<RecordBatch>> = match result {
+            Err(e) => vec![Err(e)],
+            Ok(batch) => {
+                if let Err(e) = coalescer.push_batch(batch) {
+                    return futures::stream::iter(vec![Err(DataFusionError::from(e))]);
+                }
+                let mut completed = vec![];
+                while let Some(completed_batch) = coalescer.next_completed_batch() {
+                    completed.push(Ok(completed_batch));
+                }
+                completed
+            }
+        };
+        futures::stream::iter(ready)
+    });
+
+    // Once the upstream is exhausted, flush whatever partial batch remains in the coalescer.
+    let remaining = futures::stream::once(async move {
+        let mut coalescer = coalescer_for_flush.lock().unwrap();
+        coalescer
+            .finish_buffered_batch()
+            .map_err(DataFusionError::from)
+            .ok();
+        coalescer.next_completed_batch().map(Ok)
+    });
+    let remaining = FuturesStreamExt::filter_map(remaining, |opt| async move { opt });
+
+    Box::pin(RecordBatchStreamAdapter::new(
+        schema,
+        FuturesStreamExt::chain(batches, remaining),
+    ))
 }

--- a/src/worker/impl_execute_task.rs
+++ b/src/worker/impl_execute_task.rs
@@ -111,7 +111,7 @@ pub(crate) async fn execute_remote_task(
     };
     let mut flight_streams = Vec::with_capacity(arrow_streams.len());
     for (partition, arrow_stream) in partition_range.zip(arrow_streams) {
-        let arrow_stream = coalesce_flight_stream(arrow_stream, &d_cfg);
+        let arrow_stream = coalesce_flight_stream(arrow_stream, d_cfg);
         let flight_stream = build_flight_data_stream(arrow_stream, compression)?.map(move |msg| {
             // For each FlightData produced by this stream, mark it with the appropriate
             // partition. This stream will be merged with several others from other partitions,
@@ -220,10 +220,10 @@ fn coalesce_flight_stream(
         return stream;
     }
     let schema = stream.schema();
-    let coalescer = Arc::new(std::sync::Mutex::new(BatchCoalescer::new(
-        Arc::clone(&schema),
-        d_cfg.shuffle_batch_size,
-    )));
+    let coalescer = Arc::new(std::sync::Mutex::new(
+        BatchCoalescer::new(Arc::clone(&schema), d_cfg.shuffle_batch_size)
+            .with_biggest_coalesce_batch_size(Some(d_cfg.shuffle_batch_size)),
+    ));
     let coalescer_for_flush = Arc::clone(&coalescer);
 
     let batches = stream.flat_map(move |result| {


### PR DESCRIPTION
Currently `DistributedConfig.shuffle_batch_size` sets the `target_record_batch_size` for all operators in a datafusion plan. This helps for buffering record batches before being sent over the network but it may cause users to unintentionally change the `target_record_batch`. `target_record_batch` and `shuffle_batch_size` should be independent config values. (see other issue with this in #541)

This PR re-introduces coalesce batching to provide the same buffering of arrow-flight data before being sent over the wire to minimize overhead. the target size for batches is set to `shuffle_batch_size`.


As @gabotechs mentions in [#386](https://github.com/datafusion-contrib/datafusion-distributed/issues/386), coalescing has a cost. It copies rows from source arrays into a new destination buffer. Looking at [push_batch](https://github.com/apache/arrow-rs/blob/4b54fe6f5a03fe196447c95c86cfbde5e66dcc8c/arrow-select/src/coalesce.rs#L325), `in_progress_arrays` briefly holds a pointer to each source array via `set_source()`, and `copy_rows()` is called against it on every push. Despite the name, [copy_rows()](https://github.com/apache/arrow-rs/blob/4b54fe6f5a03fe196447c95c86cfbde5e66dcc8c/arrow-select/src/coalesce/generic.rs#L59) does mostly zero-copy work: it takes a zero-copy `slice()` of the source array and pushes it into a Vec. It's cheap metadata bookkeeping, not a buffer copy.

The actual copy is deferred to `finish_buffered_batch()`, which calls concat over all the buffered slices to write them into a single pre-allocated, contiguous buffer. Because this is one bulk copy into pre-sized memory, we only pay for the writes not re-sizing buffers. Modern CPUs do `memcpy`-style bulk copies extremely fast, especially when the data stays in cache.
The tuning insight is that as `shuffle_batch_size` outpaces `target_batch_size`, the number of separate coalesce-and-send cycles shrinks. 
Consider 12 incoming record batches of 8k rows each. With no coalescing, that's 12 Arrow Flight writes over the wire. If we set `shuffle_batch_size` to 32kb, we instead do 3 Flight writes, at the cost of coalescing 4 arrays into one buffer each time. That's a good trade: a handful of (possibly in-cache) CPU copies is cheaper than the per-message network overhead of sending many small batches over the wire.

**a tradeoff of**  local CPU/copy cost vs. the overhead of many small network packets.

At worst, this performs on par with what main currently does, with the added benefit of being clearer to users. A follow up to this PR is discussed in #542

context:
https://github.com/datafusion-contrib/datafusion-distributed/issues/541 


