### PR TITLE
FFI Query Planner on 54.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 /.idea
 /target
+/.pi/
+/.pi-subagents/
+python/.venv/
+**/__pycache__/
+*.py[cod]
+*.so
 /benchmarks/data/
 testdata/tpch/*
 !testdata/tpch/queries

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +426,7 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 dependencies = [
+ "bitflags 2.11.1",
  "serde_core",
  "serde_json",
 ]
@@ -463,6 +473,12 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "async-ffi"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4de21c0feef7e5a556e51af767c953f0501f7f300ba785cc99c47bdc8081a50"
 
 [[package]]
 name = "async-lock"
@@ -1863,6 +1879,58 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
+dependencies = [
+ "arrow",
+ "arrow-schema",
+ "async-trait",
+ "bzip2",
+ "chrono",
+ "datafusion-catalog 54.0.0",
+ "datafusion-catalog-listing 54.0.0",
+ "datafusion-common 54.0.0",
+ "datafusion-common-runtime 54.0.0",
+ "datafusion-datasource 54.0.0",
+ "datafusion-datasource-arrow 54.0.0",
+ "datafusion-datasource-avro 54.0.0",
+ "datafusion-datasource-csv 54.0.0",
+ "datafusion-datasource-json 54.0.0",
+ "datafusion-datasource-parquet 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-expr-common 54.0.0",
+ "datafusion-functions 54.0.0",
+ "datafusion-functions-aggregate 54.0.0",
+ "datafusion-functions-nested 54.0.0",
+ "datafusion-functions-table 54.0.0",
+ "datafusion-functions-window 54.0.0",
+ "datafusion-optimizer 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-adapter 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "datafusion-physical-optimizer 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "datafusion-session 54.0.0",
+ "datafusion-sql 54.0.0",
+ "flate2",
+ "futures",
+ "indexmap",
+ "itertools 0.14.0",
+ "liblzma",
+ "log",
+ "object_store",
+ "parking_lot",
+ "parquet",
+ "sqlparser",
+ "tempfile",
+ "tokio",
+ "url",
+ "uuid",
+ "zstd",
+]
+
+[[package]]
+name = "datafusion"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "997a31e15872606a49478e670c58302094c97cb96abb0a7d60720f8e92170040"
 dependencies = [
@@ -1871,32 +1939,32 @@ dependencies = [
  "async-trait",
  "bzip2",
  "chrono",
- "datafusion-catalog",
- "datafusion-catalog-listing",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-datasource-arrow",
- "datafusion-datasource-avro",
- "datafusion-datasource-csv",
- "datafusion-datasource-json",
- "datafusion-datasource-parquet",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-functions",
- "datafusion-functions-aggregate",
- "datafusion-functions-nested",
- "datafusion-functions-table",
- "datafusion-functions-window",
- "datafusion-optimizer",
- "datafusion-physical-expr",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-expr-common",
- "datafusion-physical-optimizer",
- "datafusion-physical-plan",
- "datafusion-session",
- "datafusion-sql",
+ "datafusion-catalog 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-catalog-listing 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common-runtime 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource-arrow 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource-avro 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource-csv 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource-json 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource-parquet 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-aggregate 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-nested 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-table 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-window 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-optimizer 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-adapter 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-optimizer 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-session 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-sql 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2",
  "futures",
  "indexmap",
@@ -1917,20 +1985,43 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "dashmap",
+ "datafusion-common 54.0.0",
+ "datafusion-common-runtime 54.0.0",
+ "datafusion-datasource 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "datafusion-session 54.0.0",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-catalog"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7dd61161508f8f5fa1107774ea687bd753c22d83a32eebf963549f89de14139"
 dependencies = [
  "arrow",
  "async-trait",
  "dashmap",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common-runtime 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-session 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "itertools 0.14.0",
  "log",
@@ -1942,20 +2033,41 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "datafusion-catalog 54.0.0",
+ "datafusion-common 54.0.0",
+ "datafusion-datasource 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-adapter 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+]
+
+[[package]]
+name = "datafusion-catalog-listing"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897c70f871277f9ce99aa38347be0d679bbe3e617156c4d2a8378cec8a2a0891"
 dependencies = [
  "arrow",
  "async-trait",
- "datafusion-catalog",
- "datafusion-common",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
+ "datafusion-catalog 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-adapter 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "itertools 0.14.0",
  "log",
@@ -1974,8 +2086,8 @@ dependencies = [
  "aws-credential-types",
  "chrono",
  "clap 4.6.1",
- "datafusion",
- "datafusion-common",
+ "datafusion 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs",
  "env_logger",
  "futures",
@@ -1988,6 +2100,30 @@ dependencies = [
  "rustyline",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "datafusion-common"
+version = "54.0.0"
+dependencies = [
+ "arrow",
+ "arrow-ipc",
+ "arrow-schema",
+ "chrono",
+ "foldhash 0.2.0",
+ "half",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "itertools 0.14.0",
+ "libc",
+ "log",
+ "object_store",
+ "parquet",
+ "recursive",
+ "sqlparser",
+ "tokio",
+ "uuid",
+ "web-time",
 ]
 
 [[package]]
@@ -2020,12 +2156,55 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
+dependencies = [
+ "futures",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-common-runtime"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "981b9dae74f78ee3d9f714fb49b01919eab975461b56149510c3ba9ea11287d1"
 dependencies = [
  "futures",
  "log",
  "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource"
+version = "54.0.0"
+dependencies = [
+ "arrow",
+ "async-compression",
+ "async-trait",
+ "bytes",
+ "bzip2",
+ "chrono",
+ "datafusion-common 54.0.0",
+ "datafusion-common-runtime 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-adapter 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "datafusion-session 54.0.0",
+ "flate2",
+ "futures",
+ "glob",
+ "itertools 0.14.0",
+ "liblzma",
+ "log",
+ "object_store",
+ "parking_lot",
+ "rand 0.9.4",
+ "tokio",
+ "tokio-util",
+ "url",
+ "zstd",
 ]
 
 [[package]]
@@ -2040,15 +2219,15 @@ dependencies = [
  "bytes",
  "bzip2",
  "chrono",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common-runtime 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-adapter 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-session 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2",
  "futures",
  "glob",
@@ -2067,6 +2246,28 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
+dependencies = [
+ "arrow",
+ "arrow-ipc",
+ "async-trait",
+ "bytes",
+ "datafusion-common 54.0.0",
+ "datafusion-common-runtime 54.0.0",
+ "datafusion-datasource 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "datafusion-session 54.0.0",
+ "futures",
+ "itertools 0.14.0",
+ "object_store",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-arrow"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552b0b3f342f7ec41b3fbd70f6339dc82a30cfd0349e7f280e7852528085349f"
 dependencies = [
@@ -2074,18 +2275,35 @@ dependencies = [
  "arrow-ipc",
  "async-trait",
  "bytes",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common-runtime 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-session 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "itertools 0.14.0",
  "object_store",
  "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-avro"
+version = "54.0.0"
+dependencies = [
+ "arrow",
+ "arrow-avro",
+ "async-trait",
+ "bytes",
+ "datafusion-common 54.0.0",
+ "datafusion-datasource 54.0.0",
+ "datafusion-physical-expr-adapter 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "datafusion-session 54.0.0",
+ "futures",
+ "object_store",
 ]
 
 [[package]]
@@ -2098,13 +2316,34 @@ dependencies = [
  "arrow-avro",
  "async-trait",
  "bytes",
- "datafusion-common",
- "datafusion-datasource",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-adapter 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-session 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "object_store",
+]
+
+[[package]]
+name = "datafusion-datasource-csv"
+version = "54.0.0"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "datafusion-common 54.0.0",
+ "datafusion-common-runtime 54.0.0",
+ "datafusion-datasource 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "datafusion-session 54.0.0",
+ "futures",
+ "object_store",
+ "regex",
+ "tokio",
 ]
 
 [[package]]
@@ -2116,18 +2355,39 @@ dependencies = [
  "arrow",
  "async-trait",
  "bytes",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common-runtime 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-session 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "object_store",
  "regex",
  "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-json"
+version = "54.0.0"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "datafusion-common 54.0.0",
+ "datafusion-common-runtime 54.0.0",
+ "datafusion-datasource 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "datafusion-session 54.0.0",
+ "futures",
+ "object_store",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -2139,18 +2399,47 @@ dependencies = [
  "arrow",
  "async-trait",
  "bytes",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common-runtime 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-session 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "object_store",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "datafusion-datasource-parquet"
+version = "54.0.0"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "datafusion-common 54.0.0",
+ "datafusion-common-runtime 54.0.0",
+ "datafusion-datasource 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-functions 54.0.0",
+ "datafusion-functions-aggregate-common 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-adapter 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "datafusion-pruning 54.0.0",
+ "datafusion-session 54.0.0",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "parking_lot",
+ "parquet",
+ "tokio",
 ]
 
 [[package]]
@@ -2162,19 +2451,19 @@ dependencies = [
  "arrow",
  "async-trait",
  "bytes",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-functions",
- "datafusion-functions-aggregate-common",
- "datafusion-physical-expr",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-pruning",
- "datafusion-session",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common-runtime 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-aggregate-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-adapter 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-pruning 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-session 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "itertools 0.14.0",
  "log",
@@ -2198,8 +2487,9 @@ dependencies = [
  "chrono",
  "crossbeam-queue",
  "dashmap",
- "datafusion",
+ "datafusion 54.0.0",
  "datafusion-distributed-benchmarks",
+ "datafusion-ffi",
  "datafusion-proto",
  "delegate",
  "futures",
@@ -2239,7 +2529,7 @@ dependencies = [
  "axum 0.7.9",
  "built",
  "criterion",
- "datafusion",
+ "datafusion 54.0.0",
  "datafusion-distributed",
  "env_logger",
  "futures",
@@ -2266,7 +2556,7 @@ name = "datafusion-distributed-cli"
 version = "0.1.0"
 dependencies = [
  "clap 4.6.1",
- "datafusion",
+ "datafusion 54.0.0",
  "datafusion-cli",
  "datafusion-distributed",
  "dirs",
@@ -2282,7 +2572,7 @@ dependencies = [
  "async-trait",
  "color-eyre",
  "crossterm",
- "datafusion",
+ "datafusion 54.0.0",
  "datafusion-distributed",
  "datafusion-distributed-benchmarks",
  "futures",
@@ -2295,10 +2585,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-distributed-ffi-test"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "datafusion 54.0.0",
+ "datafusion-ffi",
+ "datafusion-functions-aggregate 54.0.0",
+ "datafusion-functions-window 54.0.0",
+ "datafusion-proto",
+ "datafusion-python-util",
+ "pyo3",
+ "pyo3-build-config",
+ "pyo3-log",
+]
+
+[[package]]
+name = "datafusion-distributed-python"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "datafusion 54.0.0",
+ "datafusion-distributed",
+ "datafusion-ffi",
+ "datafusion-proto",
+ "pyo3",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "url",
+]
+
+[[package]]
+name = "datafusion-doc"
+version = "54.0.0"
+
+[[package]]
 name = "datafusion-doc"
 version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb9e7e5d11130c48c8bd4e80c79a9772dd28ce6dc330baca9246205d245b9e2e"
+
+[[package]]
+name = "datafusion-execution"
+version = "54.0.0"
+dependencies = [
+ "arrow",
+ "arrow-buffer",
+ "async-trait",
+ "dashmap",
+ "datafusion-common 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "futures",
+ "log",
+ "object_store",
+ "parking_lot",
+ "rand 0.9.4",
+ "tempfile",
+ "url",
+]
 
 [[package]]
 name = "datafusion-execution"
@@ -2310,9 +2656,9 @@ dependencies = [
  "arrow-buffer",
  "async-trait",
  "dashmap",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-physical-expr-common",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "log",
  "object_store",
@@ -2326,6 +2672,27 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
+dependencies = [
+ "arrow",
+ "arrow-schema",
+ "async-trait",
+ "chrono",
+ "datafusion-common 54.0.0",
+ "datafusion-doc 54.0.0",
+ "datafusion-expr-common 54.0.0",
+ "datafusion-functions-aggregate-common 54.0.0",
+ "datafusion-functions-window-common 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "indexmap",
+ "itertools 0.14.0",
+ "recursive",
+ "serde_json",
+ "sqlparser",
+]
+
+[[package]]
+name = "datafusion-expr"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6932f4d71eed9c8d9341476a2b845aadfabde5495d08dbcd8fc23881f49fa7a0"
 dependencies = [
@@ -2333,12 +2700,12 @@ dependencies = [
  "arrow-schema",
  "async-trait",
  "chrono",
- "datafusion-common",
- "datafusion-doc",
- "datafusion-expr-common",
- "datafusion-functions-aggregate-common",
- "datafusion-functions-window-common",
- "datafusion-physical-expr-common",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-doc 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-aggregate-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-window-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap",
  "itertools 0.14.0",
  "recursive",
@@ -2349,13 +2716,84 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
+dependencies = [
+ "arrow",
+ "datafusion-common 54.0.0",
+ "indexmap",
+ "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-expr-common"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0225491839a31b1f7d2cb8092c2d50792e2fe1c1724e4e6d08e011f5feaf4ed2"
 dependencies = [
  "arrow",
- "datafusion-common",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap",
  "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-ffi"
+version = "54.0.0"
+dependencies = [
+ "arrow",
+ "arrow-schema",
+ "async-ffi",
+ "async-trait",
+ "chrono",
+ "datafusion-catalog 54.0.0",
+ "datafusion-common 54.0.0",
+ "datafusion-datasource 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-functions-aggregate-common 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "datafusion-physical-optimizer 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "datafusion-proto",
+ "datafusion-proto-common",
+ "datafusion-session 54.0.0",
+ "futures",
+ "libloading",
+ "log",
+ "prost",
+ "semver",
+ "stabby",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-functions"
+version = "54.0.0"
+dependencies = [
+ "arrow",
+ "arrow-buffer",
+ "base64",
+ "blake2",
+ "blake3",
+ "chrono",
+ "chrono-tz",
+ "datafusion-common 54.0.0",
+ "datafusion-doc 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-expr-common 54.0.0",
+ "datafusion-macros 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "hex",
+ "itertools 0.14.0",
+ "log",
+ "md-5 0.11.0",
+ "memchr",
+ "num-traits",
+ "rand 0.9.4",
+ "regex",
+ "sha2 0.11.0",
+ "uuid",
 ]
 
 [[package]]
@@ -2371,13 +2809,13 @@ dependencies = [
  "blake3",
  "chrono",
  "chrono-tz",
- "datafusion-common",
- "datafusion-doc",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-macros",
- "datafusion-physical-expr-common",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-doc 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-macros 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "itertools 0.14.0",
  "log",
@@ -2393,18 +2831,37 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
+dependencies = [
+ "arrow",
+ "datafusion-common 54.0.0",
+ "datafusion-doc 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-functions-aggregate-common 54.0.0",
+ "datafusion-macros 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "foldhash 0.2.0",
+ "half",
+ "log",
+ "num-traits",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75a2ca14e1b609be21e657e2d3130b2f446456b08393b377bb721a33952d2e09"
 dependencies = [
  "arrow",
- "datafusion-common",
- "datafusion-doc",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-functions-aggregate-common",
- "datafusion-macros",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-doc 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-aggregate-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-macros 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "foldhash 0.2.0",
  "half",
  "log",
@@ -2414,13 +2871,46 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
+dependencies = [
+ "arrow",
+ "datafusion-common 54.0.0",
+ "datafusion-expr-common 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate-common"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ece74ba09092d2ef9c9b54a38445450aea292a1f8b04faf531936b723a24b3c"
 dependencies = [
  "arrow",
- "datafusion-common",
- "datafusion-expr-common",
- "datafusion-physical-expr-common",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "datafusion-functions-nested"
+version = "54.0.0"
+dependencies = [
+ "arrow",
+ "arrow-ord",
+ "datafusion-common 54.0.0",
+ "datafusion-doc 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-expr-common 54.0.0",
+ "datafusion-functions 54.0.0",
+ "datafusion-functions-aggregate 54.0.0",
+ "datafusion-functions-aggregate-common 54.0.0",
+ "datafusion-macros 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
+ "itoa",
+ "log",
+ "memchr",
 ]
 
 [[package]]
@@ -2431,16 +2921,16 @@ checksum = "3f3e3f9ee8ca59bf70518802107de6f1b88a9509efdc629fadc5de9d6b2d5ef5"
 dependencies = [
  "arrow",
  "arrow-ord",
- "datafusion-common",
- "datafusion-doc",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-functions",
- "datafusion-functions-aggregate",
- "datafusion-functions-aggregate-common",
- "datafusion-macros",
- "datafusion-physical-expr-common",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-doc 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-aggregate 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-aggregate-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-macros 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "itoa",
@@ -2451,17 +2941,46 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "datafusion-catalog 54.0.0",
+ "datafusion-common 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "parking_lot",
+]
+
+[[package]]
+name = "datafusion-functions-table"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89161dffc22cf2b50f9f4b1bee83b5221d3b4ed7c2e37fd7aa2b22a5297b3a26"
 dependencies = [
  "arrow",
  "async-trait",
- "datafusion-catalog",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-physical-expr",
- "datafusion-physical-plan",
+ "datafusion-catalog 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot",
+]
+
+[[package]]
+name = "datafusion-functions-window"
+version = "54.0.0"
+dependencies = [
+ "arrow",
+ "datafusion-common 54.0.0",
+ "datafusion-doc 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-functions-window-common 54.0.0",
+ "datafusion-macros 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "log",
 ]
 
 [[package]]
@@ -2471,14 +2990,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7339345b226b3874037708bf5023ba1c2de705128f8457a095aae5ae9cb9c78"
 dependencies = [
  "arrow",
- "datafusion-common",
- "datafusion-doc",
- "datafusion-expr",
- "datafusion-functions-window-common",
- "datafusion-macros",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-doc 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-window-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-macros 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
+]
+
+[[package]]
+name = "datafusion-functions-window-common"
+version = "54.0.0"
+dependencies = [
+ "datafusion-common 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
 ]
 
 [[package]]
@@ -2487,8 +3014,17 @@ version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa84836dc2392df6f43d6a29d37fb56a8ebdc8b3f4e10ae8dc15861fd20278fb"
 dependencies = [
- "datafusion-common",
- "datafusion-physical-expr-common",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "datafusion-macros"
+version = "54.0.0"
+dependencies = [
+ "datafusion-doc 54.0.0",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2497,9 +3033,27 @@ version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "587164e03ad68732aa9e7bfe5686e3f25970d4c64fd4bd80790749840892dae5"
 dependencies = [
- "datafusion-doc",
+ "datafusion-doc 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "datafusion-optimizer"
+version = "54.0.0"
+dependencies = [
+ "arrow",
+ "chrono",
+ "datafusion-common 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-expr-common 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "indexmap",
+ "itertools 0.14.0",
+ "log",
+ "recursive",
+ "regex",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2510,10 +3064,10 @@ checksum = "77f20e8cf9e8654d92f4c16b24c487353ee5bf153ffc12d5772cd399ab8cd281"
 dependencies = [
  "arrow",
  "chrono",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-physical-expr",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap",
  "itertools 0.14.0",
  "log",
@@ -2525,15 +3079,35 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
+dependencies = [
+ "arrow",
+ "datafusion-common 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-expr-common 54.0.0",
+ "datafusion-functions-aggregate-common 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "half",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "itertools 0.14.0",
+ "parking_lot",
+ "petgraph",
+ "recursive",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-physical-expr"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f015a4a82f6f7ff7e1d8d4bf3870a936752fa38b17705dfcc14adef95aa8922c"
 dependencies = [
  "arrow",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-functions-aggregate-common",
- "datafusion-physical-expr-common",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-aggregate-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "half",
  "hashbrown 0.17.1",
  "indexmap",
@@ -2547,16 +3121,44 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
+dependencies = [
+ "arrow",
+ "datafusion-common 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-functions 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-physical-expr-adapter"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e6ffff8acdfe54e0ea15ccf38115c4a9184433b0439f42907637928d00a235"
 dependencies = [
  "arrow",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-functions",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-physical-expr-common"
+version = "54.0.0"
+dependencies = [
+ "arrow",
+ "chrono",
+ "datafusion-common 54.0.0",
+ "datafusion-expr-common 54.0.0",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "itertools 0.14.0",
+ "parking_lot",
+ "pin-project",
 ]
 
 [[package]]
@@ -2567,8 +3169,8 @@ checksum = "7967a3e171c6a4bf09474b3f7a14f1a3db13ed1714ba12156f33fcce2bba54e8"
 dependencies = [
  "arrow",
  "chrono",
- "datafusion-common",
- "datafusion-expr-common",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.17.1",
  "indexmap",
  "itertools 0.14.0",
@@ -2579,20 +3181,69 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
+dependencies = [
+ "arrow",
+ "datafusion-common 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-expr-common 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "datafusion-pruning 54.0.0",
+ "datafusion-session 54.0.0",
+ "itertools 0.14.0",
+ "recursive",
+]
+
+[[package]]
+name = "datafusion-physical-optimizer"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ff803e2a96054cb6d83f35f9e60fd4f42eac515e1932bd1b2dbc91d5fcbf36"
 dependencies = [
  "arrow",
- "datafusion-common",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-pruning",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-pruning 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.14.0",
  "recursive",
+]
+
+[[package]]
+name = "datafusion-physical-plan"
+version = "54.0.0"
+dependencies = [
+ "arrow",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-ord",
+ "arrow-schema",
+ "async-trait",
+ "datafusion-common 54.0.0",
+ "datafusion-common-runtime 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-functions 54.0.0",
+ "datafusion-functions-aggregate-common 54.0.0",
+ "datafusion-functions-window-common 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "futures",
+ "half",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "itertools 0.14.0",
+ "log",
+ "num-traits",
+ "parking_lot",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2607,15 +3258,15 @@ dependencies = [
  "arrow-ord",
  "arrow-schema",
  "async-trait",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-functions",
- "datafusion-functions-aggregate-common",
- "datafusion-functions-window-common",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common-runtime 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-aggregate-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-window-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "half",
  "hashbrown 0.17.1",
@@ -2631,25 +3282,23 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd15a1ba5d3af93808241065c6c44dbca8296a189845e8a587c45c07bf0ffae"
 dependencies = [
  "arrow",
  "chrono",
- "datafusion-catalog",
- "datafusion-catalog-listing",
- "datafusion-common",
- "datafusion-datasource",
- "datafusion-datasource-arrow",
- "datafusion-datasource-csv",
- "datafusion-datasource-json",
- "datafusion-datasource-parquet",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-functions-table",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
+ "datafusion-catalog 54.0.0",
+ "datafusion-catalog-listing 54.0.0",
+ "datafusion-common 54.0.0",
+ "datafusion-datasource 54.0.0",
+ "datafusion-datasource-arrow 54.0.0",
+ "datafusion-datasource-csv 54.0.0",
+ "datafusion-datasource-json 54.0.0",
+ "datafusion-datasource-parquet 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-functions-table 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "datafusion-physical-plan 54.0.0",
  "datafusion-proto-common",
  "object_store",
  "prost",
@@ -2658,12 +3307,24 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90042982cf9462eb06a0b81f92efa4188dae871e7ea3ab8dc61aa9c9349b2530"
 dependencies = [
  "arrow",
- "datafusion-common",
+ "datafusion-common 54.0.0",
  "prost",
+]
+
+[[package]]
+name = "datafusion-pruning"
+version = "54.0.0"
+dependencies = [
+ "arrow",
+ "datafusion-common 54.0.0",
+ "datafusion-datasource 54.0.0",
+ "datafusion-expr-common 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "log",
 ]
 
 [[package]]
@@ -2673,13 +3334,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fb9e5774660aa69c3ba93c610f175f75b65cb8c3776edb3626de8f3a4f4ee3"
 dependencies = [
  "arrow",
- "datafusion-common",
- "datafusion-datasource",
- "datafusion-expr-common",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
+]
+
+[[package]]
+name = "datafusion-python-util"
+version = "54.0.0"
+dependencies = [
+ "arrow",
+ "datafusion 54.0.0",
+ "datafusion-ffi",
+ "datafusion-proto",
+ "prost",
+ "pyo3",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-session"
+version = "54.0.0"
+dependencies = [
+ "async-trait",
+ "datafusion-common 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2689,11 +3375,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15ce715fa2a61f4623cc234bcc14a3ef6a91f189128d5b14b468a6a17cdfc417"
 dependencies = [
  "async-trait",
- "datafusion-common",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-plan",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot",
+]
+
+[[package]]
+name = "datafusion-sql"
+version = "54.0.0"
+dependencies = [
+ "arrow",
+ "bigdecimal",
+ "chrono",
+ "datafusion-common 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-functions-nested 54.0.0",
+ "indexmap",
+ "log",
+ "recursive",
+ "regex",
+ "sqlparser",
 ]
 
 [[package]]
@@ -2705,9 +3408,9 @@ dependencies = [
  "arrow",
  "bigdecimal",
  "chrono",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-functions-nested",
+ "datafusion-common 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-nested 54.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap",
  "log",
  "recursive",
@@ -4027,6 +4730,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "liblzma"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4918,6 +5631,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4990,6 +5712,75 @@ checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
 dependencies = [
  "ar_archive_writer",
  "cc",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+dependencies = [
+ "libc",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+dependencies = [
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-log"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64083bd3a16a353d9d62335808e8e13d0552d2a2b83fdb084496192dcfa9fcd"
+dependencies = [
+ "arc-swap",
+ "log",
+ "pyo3",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5707,6 +6498,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2-const-stable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5840,6 +6637,40 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "stabby"
+version = "72.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7b834ec7ced12095fea1e4b07dcb7e8cf2b59b18afa3eac52494d835965a5ec"
+dependencies = [
+ "rustversion",
+ "stabby-abi",
+]
+
+[[package]]
+name = "stabby-abi"
+version = "72.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff1a4f477858a5bdf927c9fab7f579899de9b13e39f8b3b3b300c89fbab632f4"
+dependencies = [
+ "rustc_version",
+ "rustversion",
+ "sha2-const-stable",
+ "stabby-macros",
+]
+
+[[package]]
+name = "stabby-macros"
+version = "72.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b31c4b2434980b67ad83f300a58088ba14d59454dcd79ba3d87419bbd924d31e"
+dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6028,6 +6859,12 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -6364,6 +7201,36 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -7187,6 +8054,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,13 @@
 [workspace]
-members = ["benchmarks", "cli", "console"]
+members = ["benchmarks", "cli", "console", "python", "python/tests/ffi_test_package"]
 
 [workspace.dependencies]
-datafusion = { version = "54.0.0", default-features = false }
-datafusion-proto = { version = "54.0.0" }
+datafusion = { path = "../datafusion/datafusion/core", version = "54.0.0", default-features = false }
+datafusion-ffi = { path = "../datafusion/datafusion/ffi", version = "54.0.0" }
+datafusion-functions-aggregate = { path = "../datafusion/datafusion/functions-aggregate", version = "54.0.0" }
+datafusion-functions-window = { path = "../datafusion/datafusion/functions-window", version = "54.0.0" }
+datafusion-proto = { path = "../datafusion/datafusion/proto", version = "54.0.0" }
+datafusion-python-util = { path = "../datafusion-python/crates/util", version = "54.0.0" }
 
 [package]
 name = "datafusion-distributed"
@@ -23,6 +27,7 @@ datafusion = { workspace = true, features = [
   "datetime_expressions",
 ] }
 datafusion-proto = { workspace = true }
+datafusion-ffi = { workspace = true, optional = true }
 arrow-flight = "58"
 arrow-select = "58"
 arrow-ipc = { version = "58", features = ["zstd"] }
@@ -59,6 +64,7 @@ hyper-util = { version = "0.1.16", optional = true }
 
 [features]
 avro = ["datafusion/avro"]
+ffi = ["dep:datafusion-ffi"]
 integration = ["insta", "parquet", "arrow", "hyper-util"]
 
 system-metrics = ["sysinfo"]

--- a/examples/python_query_planner.py
+++ b/examples/python_query_planner.py
@@ -1,0 +1,27 @@
+"""Run a DataFusion Python query through datafusion-distributed's query planner.
+
+This example assumes one or more datafusion-distributed workers are already
+listening on localhost. For example, start workers from this repository with
+ports matching WORKER_PORTS before running this script.
+"""
+
+from __future__ import annotations
+
+import os
+
+from datafusion import SessionConfig, SessionContext
+import datafusion_distributed as dd
+
+
+def worker_ports() -> list[int]:
+    ports = os.environ.get("WORKER_PORTS", "50051")
+    return [int(port) for port in ports.split(",") if port]
+
+
+config = SessionConfig().with_extension(dd.DistributedConfig())
+ctx = SessionContext(config)
+
+resolver = dd.LocalhostChannelResolver(worker_ports())
+ctx = dd.with_distributed_query_planner(ctx, resolver)
+
+ctx.sql("SELECT 1 AS value").show()

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "datafusion-distributed-python"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+name = "datafusion_distributed_internal"
+crate-type = ["cdylib"]
+
+[dependencies]
+async-trait = "0.1.89"
+datafusion = { workspace = true }
+datafusion-distributed = { path = "..", features = ["ffi"] }
+datafusion-ffi = { workspace = true }
+datafusion-proto = { workspace = true }
+pyo3 = { version = "0.28", features = ["extension-module", "abi3-py310"] }
+tokio = { version = "1.48", features = ["full"] }
+tokio-stream = "0.1.17"
+tonic = { version = "0.14.1", features = ["transport"] }
+url = "2.5.7"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["maturin>=1.8,<2"]
+build-backend = "maturin"
+
+[project]
+name = "datafusion-distributed"
+version = "0.1.0"
+description = "Python bindings for datafusion-distributed"
+requires-python = ">=3.10"
+dependencies = ["datafusion>=54"]
+
+[project.optional-dependencies]
+test = ["pytest>=8"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.maturin]
+module-name = "datafusion_distributed._internal"
+python-source = "python"
+features = ["pyo3/extension-module"]

--- a/python/python/datafusion_distributed/__init__.py
+++ b/python/python/datafusion_distributed/__init__.py
@@ -1,0 +1,1 @@
+from ._internal import *

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,0 +1,101 @@
+mod localhost_channel_resolver;
+mod localhost_worker_cluster;
+mod query_planner;
+
+use datafusion_distributed::DistributedConfig as RustDistributedConfig;
+use datafusion_ffi::config::extension_options::FFI_ExtensionOptions;
+use pyo3::prelude::*;
+use pyo3::types::PyCapsule;
+
+#[pyclass(
+    name = "DistributedConfig",
+    module = "datafusion_distributed._internal",
+    skip_from_py_object
+)]
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PyDistributedConfig {
+    pub(crate) inner: RustDistributedConfig,
+}
+
+#[pymethods]
+impl PyDistributedConfig {
+    #[new]
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn with_file_scan_config_bytes_per_partition(&mut self, value: usize) -> PyResult<()> {
+        self.inner.file_scan_config_bytes_per_partition = value;
+        Ok(())
+    }
+
+    fn with_cardinality_task_count_factor(&mut self, value: f64) -> PyResult<()> {
+        self.inner.cardinality_task_count_factor = value;
+        Ok(())
+    }
+
+    fn with_children_isolator_unions(&mut self, value: bool) -> PyResult<()> {
+        self.inner.children_isolator_unions = value;
+        Ok(())
+    }
+
+    fn with_collect_metrics(&mut self, value: bool) -> PyResult<()> {
+        self.inner.collect_metrics = value;
+        Ok(())
+    }
+
+    fn with_broadcast_joins(&mut self, value: bool) -> PyResult<()> {
+        self.inner.broadcast_joins = value;
+        Ok(())
+    }
+
+    fn with_compression(&mut self, value: String) -> PyResult<()> {
+        self.inner.compression = value;
+        Ok(())
+    }
+
+    fn with_shuffle_batch_size(&mut self, value: usize) -> PyResult<()> {
+        self.inner.shuffle_batch_size = value;
+        Ok(())
+    }
+
+    fn with_max_tasks_per_stage(&mut self, value: usize) -> PyResult<()> {
+        self.inner.max_tasks_per_stage = value;
+        Ok(())
+    }
+
+    fn with_partial_reduce(&mut self, value: bool) -> PyResult<()> {
+        self.inner.partial_reduce = value;
+        Ok(())
+    }
+
+    fn with_worker_connection_buffer_budget_bytes(&mut self, value: usize) -> PyResult<()> {
+        self.inner.worker_connection_buffer_budget_bytes = value;
+        Ok(())
+    }
+
+    fn __datafusion_extension_options__<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyCapsule>> {
+        let mut ffi = FFI_ExtensionOptions::default();
+        ffi.add_config(&self.inner)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        PyCapsule::new(py, ffi, Some(cr"datafusion_extension_options".into()))
+    }
+}
+
+/// Python extension module for datafusion-distributed.
+#[pymodule]
+fn _internal(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    m.add_class::<PyDistributedConfig>()?;
+    m.add_class::<localhost_channel_resolver::PyLocalhostChannelResolver>()?;
+    m.add_class::<localhost_worker_cluster::PyLocalhostWorkerCluster>()?;
+    m.add_class::<query_planner::PyDistributedQueryPlanner>()?;
+    m.add_function(wrap_pyfunction!(
+        query_planner::with_distributed_query_planner,
+        m
+    )?)?;
+    Ok(())
+}

--- a/python/src/localhost_channel_resolver.rs
+++ b/python/src/localhost_channel_resolver.rs
@@ -1,0 +1,80 @@
+use async_trait::async_trait;
+use datafusion::common::DataFusionError;
+use datafusion_distributed::{
+    BoxCloneSyncChannel, ChannelResolver, DefaultChannelResolver, WorkerResolver,
+    WorkerServiceClient,
+};
+use pyo3::prelude::*;
+use std::sync::Arc;
+use url::Url;
+
+#[pyclass(
+    name = "LocalhostChannelResolver",
+    module = "datafusion_distributed._internal",
+    skip_from_py_object
+)]
+#[derive(Clone)]
+pub(crate) struct PyLocalhostChannelResolver {
+    inner: Arc<LocalhostChannelResolver>,
+}
+
+#[pymethods]
+impl PyLocalhostChannelResolver {
+    #[new]
+    fn new(ports: Vec<u16>) -> PyResult<Self> {
+        Self::from_ports(ports)
+    }
+
+    fn urls(&self) -> Vec<String> {
+        self.url_strings()
+    }
+}
+
+impl PyLocalhostChannelResolver {
+    pub(crate) fn from_ports(ports: Vec<u16>) -> PyResult<Self> {
+        let urls = ports
+            .into_iter()
+            .map(|port| {
+                Url::parse(&format!("http://127.0.0.1:{port}"))
+                    .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+            })
+            .collect::<PyResult<Vec<_>>>()?;
+
+        Ok(Self {
+            inner: Arc::new(LocalhostChannelResolver {
+                urls,
+                channel_resolver: DefaultChannelResolver::default(),
+            }),
+        })
+    }
+
+    pub(crate) fn url_strings(&self) -> Vec<String> {
+        self.inner.urls.iter().map(ToString::to_string).collect()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn resolver(&self) -> Arc<LocalhostChannelResolver> {
+        Arc::clone(&self.inner)
+    }
+}
+
+pub(crate) struct LocalhostChannelResolver {
+    urls: Vec<Url>,
+    channel_resolver: DefaultChannelResolver,
+}
+
+impl WorkerResolver for LocalhostChannelResolver {
+    fn get_urls(&self) -> Result<Vec<Url>, DataFusionError> {
+        Ok(self.urls.clone())
+    }
+}
+
+#[async_trait]
+impl ChannelResolver for LocalhostChannelResolver {
+    async fn get_worker_client_for_url(
+        &self,
+        url: &Url,
+    ) -> Result<WorkerServiceClient<BoxCloneSyncChannel>, DataFusionError> {
+        self.channel_resolver.get_worker_client_for_url(url).await
+    }
+}

--- a/python/src/localhost_worker_cluster.rs
+++ b/python/src/localhost_worker_cluster.rs
@@ -1,0 +1,130 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::common::DataFusionError;
+use datafusion::execution::SessionState;
+use datafusion_distributed::{
+    DistributedConfig, DistributedExt, Worker, WorkerQueryContext, WorkerSessionBuilder,
+};
+use datafusion_ffi::proto::physical_extension_codec::FFI_PhysicalExtensionCodec;
+use datafusion_proto::physical_plan::PhysicalExtensionCodec;
+use pyo3::prelude::*;
+use pyo3::types::PyCapsule;
+use std::ptr::NonNull;
+use tokio::runtime::Runtime;
+use tokio::task::JoinSet;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::transport::Server;
+
+use crate::localhost_channel_resolver::PyLocalhostChannelResolver;
+
+#[derive(Clone)]
+struct FfiWorkerSessionBuilder {
+    physical_codec: Arc<dyn PhysicalExtensionCodec>,
+}
+
+#[async_trait]
+impl WorkerSessionBuilder for FfiWorkerSessionBuilder {
+    async fn build_session_state(
+        &self,
+        ctx: WorkerQueryContext,
+    ) -> Result<SessionState, DataFusionError> {
+        Ok(ctx
+            .builder
+            .with_distributed_option_extension(DistributedConfig::default())
+            .with_distributed_user_codec_arc(Arc::clone(&self.physical_codec))
+            .build())
+    }
+}
+
+/// A temporary localhost worker cluster for Python integration tests.
+#[pyclass(
+    name = "LocalhostWorkerCluster",
+    module = "datafusion_distributed._internal",
+    skip_from_py_object
+)]
+pub(crate) struct PyLocalhostWorkerCluster {
+    resolver: PyLocalhostChannelResolver,
+    workers: JoinSet<()>,
+}
+
+#[pymethods]
+impl PyLocalhostWorkerCluster {
+    #[new]
+    #[pyo3(signature = (session_ctx, worker_count=2))]
+    fn new(session_ctx: Bound<'_, PyAny>, worker_count: usize) -> PyResult<Self> {
+        if worker_count == 0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "worker_count must be greater than zero",
+            ));
+        }
+
+        let physical_codec = ffi_physical_codec_from_python(session_ctx)?;
+        let physical_codec: Arc<dyn PhysicalExtensionCodec> = (&physical_codec).into();
+        let (ports, workers) = worker_runtime()
+            .block_on(start_workers(worker_count, physical_codec))
+            .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))?;
+
+        Ok(Self {
+            resolver: PyLocalhostChannelResolver::from_ports(ports)?,
+            workers,
+        })
+    }
+
+    fn resolver(&self) -> PyLocalhostChannelResolver {
+        self.resolver.clone()
+    }
+
+    fn urls(&self) -> Vec<String> {
+        self.resolver.url_strings()
+    }
+}
+
+impl Drop for PyLocalhostWorkerCluster {
+    fn drop(&mut self) {
+        self.workers.abort_all();
+    }
+}
+
+async fn start_workers(
+    worker_count: usize,
+    physical_codec: Arc<dyn PhysicalExtensionCodec>,
+) -> Result<(Vec<u16>, JoinSet<()>), std::io::Error> {
+    let mut ports = Vec::with_capacity(worker_count);
+    let mut workers = JoinSet::new();
+
+    for _ in 0..worker_count {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        ports.push(listener.local_addr()?.port());
+        let worker = Worker::from_session_builder(FfiWorkerSessionBuilder {
+            physical_codec: Arc::clone(&physical_codec),
+        });
+        workers.spawn(async move {
+            Server::builder()
+                .add_service(worker.into_worker_server())
+                .serve_with_incoming(TcpListenerStream::new(listener))
+                .await
+                .expect("localhost test worker failed");
+        });
+    }
+
+    Ok((ports, workers))
+}
+
+fn worker_runtime() -> &'static Runtime {
+    use std::sync::OnceLock;
+
+    static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| Runtime::new().expect("tokio runtime for localhost test workers"))
+}
+
+fn ffi_physical_codec_from_python(obj: Bound<'_, PyAny>) -> PyResult<FFI_PhysicalExtensionCodec> {
+    let capsule = obj
+        .getattr("__datafusion_physical_extension_codec__")?
+        .call0()?;
+    let capsule = capsule.cast::<PyCapsule>()?;
+    let data: NonNull<FFI_PhysicalExtensionCodec> = capsule
+        .pointer_checked(Some(c"datafusion_physical_extension_codec"))?
+        .cast();
+    Ok(unsafe { data.as_ref().clone() })
+}

--- a/python/src/query_planner.rs
+++ b/python/src/query_planner.rs
@@ -1,0 +1,232 @@
+use crate::PyDistributedConfig;
+use crate::localhost_channel_resolver::PyLocalhostChannelResolver;
+use datafusion::common::Result;
+use datafusion::execution::Session;
+use datafusion::execution::context::QueryPlanner;
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
+use datafusion_distributed::{
+    ChannelResolver, DistributedCodec, DistributedConfig, DistributedExt, WorkerResolver,
+    distribute_physical_plan,
+};
+use datafusion_ffi::execution::FFI_TaskContextProvider;
+use datafusion_ffi::proto::logical_extension_codec::FFI_LogicalExtensionCodec;
+use datafusion_ffi::proto::physical_extension_codec::FFI_PhysicalExtensionCodec;
+use datafusion_ffi::query_planner::FFI_QueryPlanner;
+use datafusion_proto::physical_plan::{ComposedPhysicalExtensionCodec, PhysicalExtensionCodec};
+use pyo3::prelude::*;
+use pyo3::types::PyCapsule;
+use std::ptr::NonNull;
+use std::sync::{Arc, OnceLock};
+use tokio::runtime::{Handle, Runtime};
+
+#[pyclass(
+    name = "DistributedQueryPlanner",
+    module = "datafusion_distributed._internal",
+    skip_from_py_object
+)]
+pub(crate) struct PyDistributedQueryPlanner {
+    resolver: PyLocalhostChannelResolver,
+    logical_codec: FFI_LogicalExtensionCodec,
+    physical_codec: FFI_PhysicalExtensionCodec,
+    task_ctx_provider: FFI_TaskContextProvider,
+    _session_ctx: Py<PyAny>,
+    inner: Option<FFI_QueryPlanner>,
+    distributed_config: DistributedConfig,
+}
+
+#[pymethods]
+impl PyDistributedQueryPlanner {
+    #[new]
+    #[pyo3(signature = (resolver, session_ctx, inner=None, config=None))]
+    fn new(
+        resolver: PyRef<'_, PyLocalhostChannelResolver>,
+        session_ctx: Bound<'_, PyAny>,
+        inner: Option<Bound<'_, PyAny>>,
+        config: Option<PyRef<'_, PyDistributedConfig>>,
+    ) -> PyResult<Self> {
+        let logical_codec = ffi_logical_codec_from_python(session_ctx.clone())?;
+        let physical_codec = ffi_physical_codec_from_python(session_ctx.clone())?;
+        let task_ctx_provider = ffi_task_ctx_provider_from_python(session_ctx.clone())?;
+        let session_ctx = session_ctx.unbind();
+        let inner = inner
+            .as_ref()
+            .map(ffi_query_planner_from_python)
+            .transpose()?;
+        Ok(Self {
+            resolver: resolver.clone(),
+            logical_codec,
+            physical_codec,
+            task_ctx_provider,
+            _session_ctx: session_ctx,
+            inner,
+            distributed_config: config
+                .as_ref()
+                .map(|config| config.inner.clone())
+                .unwrap_or_default(),
+        })
+    }
+
+    fn __datafusion_query_planner__<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyCapsule>> {
+        let user_codec: Arc<dyn PhysicalExtensionCodec> = (&self.physical_codec).into();
+        let physical_codec: Arc<dyn PhysicalExtensionCodec + Send> =
+            Arc::new(ComposedPhysicalExtensionCodec::new(vec![
+                Arc::clone(&user_codec),
+                Arc::new(DistributedCodec {}),
+            ]));
+        let physical_codec = FFI_PhysicalExtensionCodec::new(
+            physical_codec,
+            Some(tokio_runtime_handle()),
+            self.task_ctx_provider.clone(),
+        );
+        let planner: Arc<dyn QueryPlanner + Send + Sync> = Arc::new(DistributedFfiQueryPlanner {
+            resolver: self.resolver.clone(),
+            user_codec,
+            _session_ctx: self._session_ctx.clone_ref(py),
+            inner: self.inner.clone(),
+            distributed_config: self.distributed_config.clone(),
+        });
+        let ffi = FFI_QueryPlanner::new_with_ffi_codecs(
+            planner,
+            self.logical_codec.clone(),
+            physical_codec,
+        );
+
+        PyCapsule::new(py, ffi, Some(cr"datafusion_query_planner_v1".into()))
+    }
+}
+
+struct DistributedFfiQueryPlanner {
+    resolver: PyLocalhostChannelResolver,
+    user_codec: Arc<dyn PhysicalExtensionCodec>,
+    _session_ctx: Py<PyAny>,
+    inner: Option<FFI_QueryPlanner>,
+    distributed_config: DistributedConfig,
+}
+
+impl std::fmt::Debug for DistributedFfiQueryPlanner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DistributedFfiQueryPlanner")
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait::async_trait]
+impl QueryPlanner for DistributedFfiQueryPlanner {
+    async fn create_physical_plan(
+        &self,
+        logical_plan: &LogicalPlan,
+        session: &dyn Session,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let physical_plan = match &self.inner {
+            Some(inner) => {
+                inner
+                    .create_physical_plan_with_session_runtime(
+                        logical_plan,
+                        session,
+                        Some(tokio_runtime_handle()),
+                    )
+                    .await?
+            }
+            None => {
+                let planner = DefaultPhysicalPlanner::default();
+                planner.create_physical_plan(logical_plan, session).await?
+            }
+        };
+
+        let mut session_config = session.config().clone();
+        session_config.set_distributed_user_codec_arc(Arc::clone(&self.user_codec));
+        let distributed_config =
+            DistributedConfig::from_config_options_owned(session_config.options())
+                .unwrap_or_else(|_| self.distributed_config.clone());
+        session_config
+            .options_mut()
+            .extensions
+            .insert(distributed_config);
+
+        let resolver = self.resolver.resolver();
+        let channel_resolver: Arc<dyn ChannelResolver + Send + Sync> = resolver.clone();
+        let worker_resolver: Arc<dyn WorkerResolver + Send + Sync> = resolver;
+        session_config.set_distributed_channel_resolver(channel_resolver);
+        session_config.set_distributed_worker_resolver(worker_resolver);
+
+        distribute_physical_plan(physical_plan, session_config.options()).await
+    }
+}
+
+#[pyfunction]
+#[pyo3(signature = (session_ctx, resolver, config=None))]
+pub(crate) fn with_distributed_query_planner(
+    py: Python<'_>,
+    session_ctx: Bound<'_, PyAny>,
+    resolver: PyRef<'_, PyLocalhostChannelResolver>,
+    config: Option<PyRef<'_, PyDistributedConfig>>,
+) -> PyResult<Py<PyAny>> {
+    let inner = session_ctx
+        .getattr("__datafusion_query_planner__")?
+        .call0()?;
+    let planner =
+        PyDistributedQueryPlanner::new(resolver, session_ctx.clone(), Some(inner), config)?;
+    let planner = Py::new(py, planner)?;
+    Ok(session_ctx
+        .call_method1("with_query_planner", (planner,))?
+        .unbind())
+}
+
+fn tokio_runtime_handle() -> Handle {
+    static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+    RUNTIME
+        .get_or_init(|| Runtime::new().expect("tokio runtime for datafusion-distributed Python"))
+        .handle()
+        .clone()
+}
+
+fn ffi_logical_codec_from_python(obj: Bound<'_, PyAny>) -> PyResult<FFI_LogicalExtensionCodec> {
+    let capsule = obj
+        .getattr("__datafusion_logical_extension_codec__")?
+        .call0()?;
+    let capsule = capsule.cast::<PyCapsule>()?;
+    let data: NonNull<FFI_LogicalExtensionCodec> = capsule
+        .pointer_checked(Some(c"datafusion_logical_extension_codec"))?
+        .cast();
+    Ok(unsafe { data.as_ref().clone() })
+}
+
+fn ffi_task_ctx_provider_from_python(obj: Bound<'_, PyAny>) -> PyResult<FFI_TaskContextProvider> {
+    let capsule = obj
+        .getattr("__datafusion_task_context_provider__")?
+        .call0()?;
+    let capsule = capsule.cast::<PyCapsule>()?;
+    let data: NonNull<FFI_TaskContextProvider> = capsule
+        .pointer_checked(Some(c"datafusion_task_context_provider"))?
+        .cast();
+    Ok(unsafe { data.as_ref().clone() })
+}
+
+fn ffi_physical_codec_from_python(obj: Bound<'_, PyAny>) -> PyResult<FFI_PhysicalExtensionCodec> {
+    let capsule = obj
+        .getattr("__datafusion_physical_extension_codec__")?
+        .call0()?;
+    let capsule = capsule.cast::<PyCapsule>()?;
+    let data: NonNull<FFI_PhysicalExtensionCodec> = capsule
+        .pointer_checked(Some(c"datafusion_physical_extension_codec"))?
+        .cast();
+    Ok(unsafe { data.as_ref().clone() })
+}
+
+fn ffi_query_planner_from_python(obj: &Bound<'_, PyAny>) -> PyResult<FFI_QueryPlanner> {
+    let capsule = if obj.hasattr("__datafusion_query_planner__")? {
+        obj.getattr("__datafusion_query_planner__")?.call0()?
+    } else {
+        obj.clone()
+    };
+    let capsule = capsule.cast::<PyCapsule>()?;
+    let data: NonNull<FFI_QueryPlanner> = capsule
+        .pointer_checked(Some(c"datafusion_query_planner_v1"))?
+        .cast();
+    Ok(unsafe { data.as_ref().clone() })
+}

--- a/python/src/query_planner.rs
+++ b/python/src/query_planner.rs
@@ -49,11 +49,11 @@ impl PyDistributedQueryPlanner {
         let logical_codec = ffi_logical_codec_from_python(session_ctx.clone())?;
         let physical_codec = ffi_physical_codec_from_python(session_ctx.clone())?;
         let task_ctx_provider = ffi_task_ctx_provider_from_python(session_ctx.clone())?;
+        let inner = match inner.as_ref() {
+            Some(inner) => Some(ffi_query_planner_from_python(inner)?),
+            None => Some(ffi_query_planner_from_python(&session_ctx)?),
+        };
         let session_ctx = session_ctx.unbind();
-        let inner = inner
-            .as_ref()
-            .map(ffi_query_planner_from_python)
-            .transpose()?;
         Ok(Self {
             resolver: resolver.clone(),
             logical_codec,
@@ -76,7 +76,7 @@ impl PyDistributedQueryPlanner {
         let physical_codec: Arc<dyn PhysicalExtensionCodec + Send> =
             Arc::new(ComposedPhysicalExtensionCodec::new(vec![
                 Arc::clone(&user_codec),
-                Arc::new(DistributedCodec {}),
+                Arc::new(DistributedCodec::new(vec![Arc::clone(&user_codec)])),
             ]));
         let physical_codec = FFI_PhysicalExtensionCodec::new(
             physical_codec,
@@ -166,11 +166,7 @@ pub(crate) fn with_distributed_query_planner(
     resolver: PyRef<'_, PyLocalhostChannelResolver>,
     config: Option<PyRef<'_, PyDistributedConfig>>,
 ) -> PyResult<Py<PyAny>> {
-    let inner = session_ctx
-        .getattr("__datafusion_query_planner__")?
-        .call0()?;
-    let planner =
-        PyDistributedQueryPlanner::new(resolver, session_ctx.clone(), Some(inner), config)?;
+    let planner = PyDistributedQueryPlanner::new(resolver, session_ctx.clone(), None, config)?;
     let planner = Py::new(py, planner)?;
     Ok(session_ctx
         .call_method1("with_query_planner", (planner,))?

--- a/python/tests/ffi_test_package/.gitignore
+++ b/python/tests/ffi_test_package/.gitignore
@@ -1,0 +1,5 @@
+/target
+*.so
+*.dylib
+*.dll
+__pycache__/

--- a/python/tests/ffi_test_package/Cargo.toml
+++ b/python/tests/ffi_test_package/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "datafusion-distributed-ffi-test"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+name = "datafusion_distributed_ffi_test"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+async-trait = "0.1.89"
+datafusion = { workspace = true, default-features = false, features = ["sql"] }
+datafusion-ffi = { workspace = true }
+datafusion-proto = { workspace = true }
+datafusion-functions-aggregate = { workspace = true }
+datafusion-functions-window = { workspace = true }
+datafusion-python-util = { workspace = true }
+pyo3 = { version = "0.28", features = ["extension-module", "abi3", "abi3-py310"] }
+pyo3-log = "0.13.3"
+
+[build-dependencies]
+pyo3-build-config = "0.28"

--- a/python/tests/ffi_test_package/README.md
+++ b/python/tests/ffi_test_package/README.md
@@ -1,0 +1,29 @@
+# Third-party FFI test package
+
+This optional PyO3 package is compiled independently from both `datafusion-python` and `datafusion-distributed`. It supplies foreign scalar, aggregate, and window UDFs, a foreign table provider, a custom physical executor, and logical/physical extension codecs.
+
+The package has its own Cargo workspace so normal datafusion-distributed builds do not compile it. `python/tests/test_foreign_ffi.py` skips when the package is not installed.
+
+After FFI changes, rebuild all three Python extensions from the same source checkout:
+
+```bash
+# Use the datafusion-python development environment, or another environment
+# containing maturin, pytest, and pyarrow.
+export VIRTUAL_ENV=/path/to/venv
+
+(cd ../datafusion-python && maturin develop --uv)
+maturin develop --uv --manifest-path python/Cargo.toml
+maturin develop --uv --manifest-path python/tests/ffi_test_package/Cargo.toml
+
+cd python
+python -m pytest tests/test_foreign_ffi.py -v
+```
+
+Without the final `maturin develop` command, the tests are collected and reported as skipped.
+
+Rust-only validation:
+
+```bash
+cargo check --manifest-path python/tests/ffi_test_package/Cargo.toml
+cargo fmt --manifest-path python/tests/ffi_test_package/Cargo.toml -- --check
+```

--- a/python/tests/ffi_test_package/build.rs
+++ b/python/tests/ffi_test_package/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    pyo3_build_config::add_extension_module_link_args();
+}

--- a/python/tests/ffi_test_package/pyproject.toml
+++ b/python/tests/ffi_test_package/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["maturin>=1.8,<2"]
+build-backend = "maturin"
+
+[project]
+name = "datafusion-distributed-ffi-test"
+version = "0.1.0"
+requires-python = ">=3.10"
+
+[tool.maturin]
+module-name = "datafusion_distributed_ffi_test"
+features = ["pyo3/extension-module"]

--- a/python/tests/ffi_test_package/src/aggregate_udf.rs
+++ b/python/tests/ffi_test_package/src/aggregate_udf.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::DataType;
+use datafusion::common::Result;
+use datafusion::logical_expr::function::AccumulatorArgs;
+use datafusion::logical_expr::{Accumulator, AggregateUDF, AggregateUDFImpl, Signature};
+use datafusion_ffi::udaf::FFI_AggregateUDF;
+use datafusion_functions_aggregate::sum::Sum;
+use pyo3::prelude::*;
+use pyo3::types::PyCapsule;
+
+#[pyclass(from_py_object, module = "datafusion_distributed_ffi_test")]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub(crate) struct ForeignSumUDF {
+    inner: Arc<Sum>,
+}
+
+#[pymethods]
+impl ForeignSumUDF {
+    #[new]
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(Sum::new()),
+        }
+    }
+
+    fn __datafusion_aggregate_udf__<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyCapsule>> {
+        let udf = Arc::new(AggregateUDF::from(self.clone()));
+        PyCapsule::new(
+            py,
+            FFI_AggregateUDF::from(udf),
+            Some(cr"datafusion_aggregate_udf".into()),
+        )
+    }
+}
+
+impl AggregateUDFImpl for ForeignSumUDF {
+    fn name(&self) -> &str {
+        "foreign_sum"
+    }
+
+    fn signature(&self) -> &Signature {
+        self.inner.signature()
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        self.inner.return_type(arg_types)
+    }
+
+    fn accumulator(&self, args: AccumulatorArgs) -> Result<Box<dyn Accumulator>> {
+        self.inner.accumulator(args)
+    }
+
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        self.inner.coerce_types(arg_types)
+    }
+}

--- a/python/tests/ffi_test_package/src/extension_codec.rs
+++ b/python/tests/ffi_test_package/src/extension_codec.rs
@@ -1,0 +1,360 @@
+use std::ptr::NonNull;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::catalog::TableProvider;
+use datafusion::common::{Result, TableReference, not_impl_err, plan_err};
+use datafusion::execution::TaskContext;
+use datafusion::logical_expr::{AggregateUDF, Extension, LogicalPlan, ScalarUDF, WindowUDF};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion_ffi::execution::FFI_TaskContextProvider;
+use datafusion_ffi::proto::logical_extension_codec::FFI_LogicalExtensionCodec;
+use datafusion_ffi::proto::physical_extension_codec::FFI_PhysicalExtensionCodec;
+use datafusion_proto::logical_plan::LogicalExtensionCodec;
+use datafusion_proto::physical_plan::PhysicalExtensionCodec;
+use datafusion_python_util::get_tokio_runtime;
+use pyo3::prelude::*;
+use pyo3::types::PyCapsule;
+
+use crate::aggregate_udf::ForeignSumUDF;
+use crate::scalar_udf::ForeignIsNullUDF;
+use crate::table_provider::{ForeignScanExec, ForeignTable};
+use crate::window_udf::ForeignRankUDF;
+
+const TABLE_TAG: &[u8] = b"df-third-party-table-v1";
+const EXEC_TAG: &[u8] = b"df-third-party-exec-v1";
+const SCALAR_TAG: &[u8] = b"df-third-party-scalar-v1";
+const AGGREGATE_TAG: &[u8] = b"df-third-party-aggregate-v1";
+const WINDOW_TAG: &[u8] = b"df-third-party-window-v1";
+
+#[derive(Default)]
+struct Counters {
+    logical_provider_encode: AtomicUsize,
+    logical_provider_decode: AtomicUsize,
+    physical_plan_encode: AtomicUsize,
+    physical_plan_decode: AtomicUsize,
+    udf_encode: AtomicUsize,
+    udf_decode: AtomicUsize,
+}
+
+struct ForeignLogicalCodec {
+    counters: Arc<Counters>,
+    _session: Py<PyAny>,
+}
+
+impl std::fmt::Debug for ForeignLogicalCodec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ForeignLogicalCodec")
+            .finish_non_exhaustive()
+    }
+}
+
+impl LogicalExtensionCodec for ForeignLogicalCodec {
+    fn try_decode(
+        &self,
+        _buf: &[u8],
+        _inputs: &[LogicalPlan],
+        _ctx: &TaskContext,
+    ) -> Result<Extension> {
+        not_impl_err!("third-party logical extension node is unsupported")
+    }
+
+    fn try_encode(&self, _node: &Extension, _buf: &mut Vec<u8>) -> Result<()> {
+        not_impl_err!("third-party logical extension node is unsupported")
+    }
+
+    fn try_decode_table_provider(
+        &self,
+        buf: &[u8],
+        _table_ref: &TableReference,
+        _schema: SchemaRef,
+        _ctx: &TaskContext,
+    ) -> Result<Arc<dyn TableProvider>> {
+        if buf != TABLE_TAG {
+            return plan_err!("unknown third-party table-provider payload");
+        }
+        self.counters
+            .logical_provider_decode
+            .fetch_add(1, Ordering::SeqCst);
+        Ok(Arc::new(ForeignTable::try_new()?))
+    }
+
+    fn try_encode_table_provider(
+        &self,
+        _table_ref: &TableReference,
+        node: Arc<dyn TableProvider>,
+        buf: &mut Vec<u8>,
+    ) -> Result<()> {
+        if !node.is::<ForeignTable>() {
+            return plan_err!("not a third-party table provider");
+        }
+        self.counters
+            .logical_provider_encode
+            .fetch_add(1, Ordering::SeqCst);
+        buf.extend_from_slice(TABLE_TAG);
+        Ok(())
+    }
+
+    fn try_decode_udf(&self, name: &str, buf: &[u8]) -> Result<Arc<ScalarUDF>> {
+        if name != "foreign_is_null" || buf != SCALAR_TAG {
+            return plan_err!("unknown third-party scalar UDF payload");
+        }
+        self.counters.udf_decode.fetch_add(1, Ordering::SeqCst);
+        Ok(Arc::new(ScalarUDF::from(ForeignIsNullUDF::new())))
+    }
+
+    fn try_encode_udf(&self, node: &ScalarUDF, buf: &mut Vec<u8>) -> Result<()> {
+        if !node.inner().is::<ForeignIsNullUDF>() {
+            return plan_err!("not a third-party scalar UDF");
+        }
+        self.counters.udf_encode.fetch_add(1, Ordering::SeqCst);
+        buf.extend_from_slice(SCALAR_TAG);
+        Ok(())
+    }
+
+    fn try_decode_udaf(&self, name: &str, buf: &[u8]) -> Result<Arc<AggregateUDF>> {
+        if name != "foreign_sum" || buf != AGGREGATE_TAG {
+            return plan_err!("unknown third-party aggregate UDF payload");
+        }
+        self.counters.udf_decode.fetch_add(1, Ordering::SeqCst);
+        Ok(Arc::new(AggregateUDF::from(ForeignSumUDF::new())))
+    }
+
+    fn try_encode_udaf(&self, node: &AggregateUDF, buf: &mut Vec<u8>) -> Result<()> {
+        if !node.inner().is::<ForeignSumUDF>() {
+            return plan_err!("not a third-party aggregate UDF");
+        }
+        self.counters.udf_encode.fetch_add(1, Ordering::SeqCst);
+        buf.extend_from_slice(AGGREGATE_TAG);
+        Ok(())
+    }
+
+    fn try_decode_udwf(&self, name: &str, buf: &[u8]) -> Result<Arc<WindowUDF>> {
+        if name != "foreign_rank" || buf != WINDOW_TAG {
+            return plan_err!("unknown third-party window UDF payload");
+        }
+        self.counters.udf_decode.fetch_add(1, Ordering::SeqCst);
+        Ok(Arc::new(WindowUDF::from(ForeignRankUDF::new())))
+    }
+
+    fn try_encode_udwf(&self, node: &WindowUDF, buf: &mut Vec<u8>) -> Result<()> {
+        if !node.inner().is::<ForeignRankUDF>() {
+            return plan_err!("not a third-party window UDF");
+        }
+        self.counters.udf_encode.fetch_add(1, Ordering::SeqCst);
+        buf.extend_from_slice(WINDOW_TAG);
+        Ok(())
+    }
+}
+
+struct ForeignPhysicalCodec {
+    counters: Arc<Counters>,
+    _session: Py<PyAny>,
+}
+
+impl std::fmt::Debug for ForeignPhysicalCodec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ForeignPhysicalCodec")
+            .finish_non_exhaustive()
+    }
+}
+
+impl PhysicalExtensionCodec for ForeignPhysicalCodec {
+    fn try_decode(
+        &self,
+        buf: &[u8],
+        inputs: &[Arc<dyn ExecutionPlan>],
+        _ctx: &TaskContext,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if let Some(projection) = buf.strip_prefix(EXEC_TAG) {
+            if !inputs.is_empty() {
+                return plan_err!("ForeignScanExec is a leaf plan");
+            }
+            let projection = match projection {
+                [u8::MAX] => None,
+                [len, indices @ ..] if indices.len() == *len as usize => {
+                    Some(indices.iter().map(|index| *index as usize).collect())
+                }
+                _ => return plan_err!("invalid third-party execution-plan payload"),
+            };
+            self.counters
+                .physical_plan_decode
+                .fetch_add(1, Ordering::SeqCst);
+            return Ok(Arc::new(ForeignScanExec::try_new(projection)?));
+        }
+        plan_err!("unknown third-party execution-plan payload")
+    }
+
+    fn try_encode(&self, node: Arc<dyn ExecutionPlan>, buf: &mut Vec<u8>) -> Result<()> {
+        self.counters
+            .physical_plan_encode
+            .fetch_add(1, Ordering::SeqCst);
+        if let Some(node) = node.downcast_ref::<ForeignScanExec>() {
+            buf.extend_from_slice(EXEC_TAG);
+            match node.projection() {
+                None => buf.push(u8::MAX),
+                Some(projection) => {
+                    let length = u8::try_from(projection.len()).map_err(|_| {
+                        datafusion::common::DataFusionError::Plan(
+                            "ForeignScanExec projection is too large".to_string(),
+                        )
+                    })?;
+                    buf.push(length);
+                    for index in projection {
+                        buf.push(u8::try_from(*index).map_err(|_| {
+                            datafusion::common::DataFusionError::Plan(
+                                "ForeignScanExec projection index is too large".to_string(),
+                            )
+                        })?);
+                    }
+                }
+            }
+            return Ok(());
+        }
+
+        plan_err!("not a third-party execution plan")
+    }
+
+    fn try_decode_udf(&self, name: &str, buf: &[u8]) -> Result<Arc<ScalarUDF>> {
+        if name != "foreign_is_null" || buf != SCALAR_TAG {
+            return plan_err!("unknown third-party scalar UDF payload");
+        }
+        self.counters.udf_decode.fetch_add(1, Ordering::SeqCst);
+        Ok(Arc::new(ScalarUDF::from(ForeignIsNullUDF::new())))
+    }
+
+    fn try_encode_udf(&self, node: &ScalarUDF, buf: &mut Vec<u8>) -> Result<()> {
+        if !node.inner().is::<ForeignIsNullUDF>() {
+            return plan_err!("not a third-party scalar UDF");
+        }
+        self.counters.udf_encode.fetch_add(1, Ordering::SeqCst);
+        buf.extend_from_slice(SCALAR_TAG);
+        Ok(())
+    }
+
+    fn try_decode_udaf(&self, name: &str, buf: &[u8]) -> Result<Arc<AggregateUDF>> {
+        if name != "foreign_sum" || buf != AGGREGATE_TAG {
+            return plan_err!("unknown third-party aggregate UDF payload");
+        }
+        self.counters.udf_decode.fetch_add(1, Ordering::SeqCst);
+        Ok(Arc::new(AggregateUDF::from(ForeignSumUDF::new())))
+    }
+
+    fn try_encode_udaf(&self, node: &AggregateUDF, buf: &mut Vec<u8>) -> Result<()> {
+        if !node.inner().is::<ForeignSumUDF>() {
+            return plan_err!("not a third-party aggregate UDF");
+        }
+        self.counters.udf_encode.fetch_add(1, Ordering::SeqCst);
+        buf.extend_from_slice(AGGREGATE_TAG);
+        Ok(())
+    }
+
+    fn try_decode_udwf(&self, name: &str, buf: &[u8]) -> Result<Arc<WindowUDF>> {
+        if name != "foreign_rank" || buf != WINDOW_TAG {
+            return plan_err!("unknown third-party window UDF payload");
+        }
+        self.counters.udf_decode.fetch_add(1, Ordering::SeqCst);
+        Ok(Arc::new(WindowUDF::from(ForeignRankUDF::new())))
+    }
+
+    fn try_encode_udwf(&self, node: &WindowUDF, buf: &mut Vec<u8>) -> Result<()> {
+        if !node.inner().is::<ForeignRankUDF>() {
+            return plan_err!("not a third-party window UDF");
+        }
+        self.counters.udf_encode.fetch_add(1, Ordering::SeqCst);
+        buf.extend_from_slice(WINDOW_TAG);
+        Ok(())
+    }
+}
+
+fn task_ctx_provider_from_python(obj: &Bound<'_, PyAny>) -> PyResult<FFI_TaskContextProvider> {
+    let capsule = obj
+        .getattr("__datafusion_task_context_provider__")?
+        .call0()?;
+    let capsule = capsule.cast::<PyCapsule>()?;
+    let data: NonNull<FFI_TaskContextProvider> = capsule
+        .pointer_checked(Some(c"datafusion_task_context_provider"))?
+        .cast();
+    Ok(unsafe { data.as_ref().clone() })
+}
+
+#[pyclass(module = "datafusion_distributed_ffi_test")]
+pub(crate) struct ForeignExtensionCodec {
+    counters: Arc<Counters>,
+    session: Py<PyAny>,
+    task_ctx_provider: FFI_TaskContextProvider,
+}
+
+#[pymethods]
+impl ForeignExtensionCodec {
+    #[new]
+    fn new(session: Bound<'_, PyAny>) -> PyResult<Self> {
+        let task_ctx_provider = task_ctx_provider_from_python(&session)?;
+        Ok(Self {
+            counters: Arc::new(Counters::default()),
+            session: session.unbind(),
+            task_ctx_provider,
+        })
+    }
+
+    fn logical_provider_encode_calls(&self) -> usize {
+        self.counters.logical_provider_encode.load(Ordering::SeqCst)
+    }
+
+    fn logical_provider_decode_calls(&self) -> usize {
+        self.counters.logical_provider_decode.load(Ordering::SeqCst)
+    }
+
+    fn physical_plan_encode_calls(&self) -> usize {
+        self.counters.physical_plan_encode.load(Ordering::SeqCst)
+    }
+
+    fn physical_plan_decode_calls(&self) -> usize {
+        self.counters.physical_plan_decode.load(Ordering::SeqCst)
+    }
+
+    fn udf_encode_calls(&self) -> usize {
+        self.counters.udf_encode.load(Ordering::SeqCst)
+    }
+
+    fn udf_decode_calls(&self) -> usize {
+        self.counters.udf_decode.load(Ordering::SeqCst)
+    }
+
+    fn __datafusion_logical_extension_codec__<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyCapsule>> {
+        let codec: Arc<dyn LogicalExtensionCodec> = Arc::new(ForeignLogicalCodec {
+            counters: Arc::clone(&self.counters),
+            _session: self.session.clone_ref(py),
+        });
+        let ffi = FFI_LogicalExtensionCodec::new(
+            codec,
+            Some(get_tokio_runtime().handle().clone()),
+            self.task_ctx_provider.clone(),
+        );
+        PyCapsule::new(py, ffi, Some(cr"datafusion_logical_extension_codec".into()))
+    }
+
+    fn __datafusion_physical_extension_codec__<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyCapsule>> {
+        let codec: Arc<dyn PhysicalExtensionCodec + Send> = Arc::new(ForeignPhysicalCodec {
+            counters: Arc::clone(&self.counters),
+            _session: self.session.clone_ref(py),
+        });
+        let ffi = FFI_PhysicalExtensionCodec::new(
+            codec,
+            Some(get_tokio_runtime().handle().clone()),
+            self.task_ctx_provider.clone(),
+        );
+        PyCapsule::new(
+            py,
+            ffi,
+            Some(cr"datafusion_physical_extension_codec".into()),
+        )
+    }
+}

--- a/python/tests/ffi_test_package/src/lib.rs
+++ b/python/tests/ffi_test_package/src/lib.rs
@@ -1,0 +1,23 @@
+mod aggregate_udf;
+mod extension_codec;
+mod scalar_udf;
+mod table_provider;
+mod window_udf;
+
+use aggregate_udf::ForeignSumUDF;
+use extension_codec::ForeignExtensionCodec;
+use pyo3::prelude::*;
+use scalar_udf::ForeignIsNullUDF;
+use table_provider::ForeignTableProvider;
+use window_udf::ForeignRankUDF;
+
+#[pymodule]
+fn datafusion_distributed_ffi_test(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    pyo3_log::init();
+    m.add_class::<ForeignIsNullUDF>()?;
+    m.add_class::<ForeignSumUDF>()?;
+    m.add_class::<ForeignRankUDF>()?;
+    m.add_class::<ForeignTableProvider>()?;
+    m.add_class::<ForeignExtensionCodec>()?;
+    Ok(())
+}

--- a/python/tests/ffi_test_package/src/scalar_udf.rs
+++ b/python/tests/ffi_test_package/src/scalar_udf.rs
@@ -1,0 +1,66 @@
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Array, BooleanArray};
+use datafusion::arrow::datatypes::DataType;
+use datafusion::common::{Result, ScalarValue};
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, TypeSignature,
+    Volatility,
+};
+use datafusion_ffi::udf::FFI_ScalarUDF;
+use pyo3::prelude::*;
+use pyo3::types::PyCapsule;
+
+#[pyclass(from_py_object, module = "datafusion_distributed_ffi_test")]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ForeignIsNullUDF {
+    signature: Signature,
+}
+
+#[pymethods]
+impl ForeignIsNullUDF {
+    #[new]
+    pub(crate) fn new() -> Self {
+        Self {
+            signature: Signature::new(TypeSignature::Any(1), Volatility::Immutable),
+        }
+    }
+
+    fn __datafusion_scalar_udf__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyCapsule>> {
+        let udf = Arc::new(ScalarUDF::from(self.clone()));
+        PyCapsule::new(
+            py,
+            FFI_ScalarUDF::from(udf),
+            Some(cr"datafusion_scalar_udf".into()),
+        )
+    }
+}
+
+impl ScalarUDFImpl for ForeignIsNullUDF {
+    fn name(&self) -> &str {
+        "foreign_is_null"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Boolean)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        Ok(match &args.args[0] {
+            ColumnarValue::Array(array) if array.is_nullable() => {
+                let nulls = array.nulls().unwrap();
+                ColumnarValue::Array(Arc::new(BooleanArray::from_iter(
+                    nulls.iter().map(|valid| Some(!valid)),
+                )))
+            }
+            ColumnarValue::Array(_) => ColumnarValue::Scalar(ScalarValue::Boolean(Some(false))),
+            ColumnarValue::Scalar(value) => {
+                ColumnarValue::Scalar(ScalarValue::Boolean(Some(value == &ScalarValue::Null)))
+            }
+        })
+    }
+}

--- a/python/tests/ffi_test_package/src/table_provider.rs
+++ b/python/tests/ffi_test_package/src/table_provider.rs
@@ -1,0 +1,149 @@
+use std::fmt::Formatter;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::arrow::array::{Int64Array, RecordBatch, StringArray};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::catalog::{Session, TableProvider};
+use datafusion::common::Result;
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::logical_expr::{Expr, TableType};
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use datafusion_ffi::table_provider::FFI_TableProvider;
+use datafusion_python_util::{ffi_logical_codec_from_pycapsule, get_tokio_runtime};
+use pyo3::prelude::*;
+use pyo3::types::PyCapsule;
+
+#[derive(Debug)]
+pub(crate) struct ForeignScanExec {
+    input: Arc<dyn ExecutionPlan>,
+    projection: Option<Vec<usize>>,
+}
+
+impl ForeignScanExec {
+    pub(crate) fn try_new(projection: Option<Vec<usize>>) -> Result<Self> {
+        let (schema, batch) = ForeignTable::data()?;
+        let input = datafusion::datasource::memory::MemorySourceConfig::try_new_exec(
+            &[vec![batch]],
+            schema,
+            projection.clone(),
+        )?;
+        Ok(Self { input, projection })
+    }
+
+    pub(crate) fn projection(&self) -> Option<&[usize]> {
+        self.projection.as_deref()
+    }
+}
+
+impl DisplayAs for ForeignScanExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ForeignScanExec")
+    }
+}
+
+impl ExecutionPlan for ForeignScanExec {
+    fn name(&self) -> &str {
+        "ForeignScanExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        self.input.properties()
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if !children.is_empty() {
+            return datafusion::common::plan_err!("ForeignScanExec is a leaf plan");
+        }
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        self.input.execute(partition, context)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ForeignTable;
+
+impl ForeignTable {
+    pub(crate) fn try_new() -> Result<Self> {
+        Ok(Self)
+    }
+
+    fn data() -> Result<(SchemaRef, RecordBatch)> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("value", DataType::Int64, true),
+            Field::new("category", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int64Array::from(vec![Some(10), None, Some(30), Some(20)])),
+                Arc::new(StringArray::from(vec!["a", "a", "b", "b"])),
+            ],
+        )?;
+        Ok((schema, batch))
+    }
+}
+
+#[async_trait]
+impl TableProvider for ForeignTable {
+    fn schema(&self) -> SchemaRef {
+        ForeignTable::data()
+            .expect("static foreign table data is valid")
+            .0
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        session: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let _ = (session, filters, limit);
+        Ok(Arc::new(ForeignScanExec::try_new(projection.cloned())?))
+    }
+}
+
+#[pyclass(from_py_object, module = "datafusion_distributed_ffi_test")]
+#[derive(Clone, Default)]
+pub(crate) struct ForeignTableProvider;
+
+#[pymethods]
+impl ForeignTableProvider {
+    #[new]
+    fn new() -> Self {
+        Self
+    }
+
+    fn __datafusion_table_provider__<'py>(
+        &self,
+        py: Python<'py>,
+        session: Bound<'_, PyAny>,
+    ) -> PyResult<Bound<'py, PyCapsule>> {
+        let codec = ffi_logical_codec_from_pycapsule(session)?;
+        let provider = ForeignTable::try_new()
+            .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))?;
+        let runtime = get_tokio_runtime().handle().clone();
+        let provider =
+            FFI_TableProvider::new_with_ffi_codec(Arc::new(provider), false, Some(runtime), codec);
+        PyCapsule::new(py, provider, Some(cr"datafusion_table_provider".into()))
+    }
+}

--- a/python/tests/ffi_test_package/src/window_udf.rs
+++ b/python/tests/ffi_test_package/src/window_udf.rs
@@ -1,0 +1,58 @@
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::{DataType, FieldRef};
+use datafusion::common::Result;
+use datafusion::logical_expr::function::{PartitionEvaluatorArgs, WindowUDFFieldArgs};
+use datafusion::logical_expr::{PartitionEvaluator, Signature, WindowUDF, WindowUDFImpl};
+use datafusion_ffi::udwf::FFI_WindowUDF;
+use datafusion_functions_window::rank::rank_udwf;
+use pyo3::prelude::*;
+use pyo3::types::PyCapsule;
+
+#[pyclass(from_py_object, module = "datafusion_distributed_ffi_test")]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub(crate) struct ForeignRankUDF {
+    inner: Arc<WindowUDF>,
+}
+
+#[pymethods]
+impl ForeignRankUDF {
+    #[new]
+    pub(crate) fn new() -> Self {
+        Self { inner: rank_udwf() }
+    }
+
+    fn __datafusion_window_udf__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyCapsule>> {
+        let udf = Arc::new(WindowUDF::from(self.clone()));
+        PyCapsule::new(
+            py,
+            FFI_WindowUDF::from(udf),
+            Some(cr"datafusion_window_udf".into()),
+        )
+    }
+}
+
+impl WindowUDFImpl for ForeignRankUDF {
+    fn name(&self) -> &str {
+        "foreign_rank"
+    }
+
+    fn signature(&self) -> &Signature {
+        self.inner.signature()
+    }
+
+    fn partition_evaluator(
+        &self,
+        args: PartitionEvaluatorArgs,
+    ) -> Result<Box<dyn PartitionEvaluator>> {
+        self.inner.inner().partition_evaluator(args)
+    }
+
+    fn field(&self, args: WindowUDFFieldArgs) -> Result<FieldRef> {
+        self.inner.inner().field(args)
+    }
+
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        self.inner.coerce_types(arg_types)
+    }
+}

--- a/python/tests/test_foreign_ffi.py
+++ b/python/tests/test_foreign_ffi.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+try:
+    import datafusion_distributed_ffi_test as foreign
+except ImportError:
+    foreign = None
+
+pytestmark = pytest.mark.skipif(
+    foreign is None,
+    reason="build python/tests/ffi_test_package to run third-party FFI tests",
+)
+
+from datafusion import SessionConfig, SessionContext, udaf, udf, udwf  # noqa: E402
+
+try:
+    from datafusion_distributed import _internal
+except ImportError:
+    _internal = None
+
+
+def _require_distributed_planner() -> None:
+    if _internal is None:
+        pytest.skip("datafusion-distributed extension module has not been built")
+    if not hasattr(SessionContext(), "__datafusion_query_planner__"):
+        pytest.skip("datafusion-python does not expose query-planner FFI")
+
+
+def _context(config: SessionConfig | None = None):
+    ctx = SessionContext(config) if config is not None else SessionContext()
+    codec = foreign.ForeignExtensionCodec(ctx)
+    ctx = ctx.with_logical_extension_codec(codec)
+    ctx = ctx.with_physical_extension_codec(codec)
+    ctx.register_table("foreign_table", foreign.ForeignTableProvider())
+    ctx.register_udf(udf(foreign.ForeignIsNullUDF()))
+    ctx.register_udaf(udaf(foreign.ForeignSumUDF()))
+    ctx.register_udwf(udwf(foreign.ForeignRankUDF()))
+    return ctx, codec
+
+
+def test_foreign_package_executes_locally() -> None:
+    ctx, _ = _context()
+
+    grouped = ctx.sql(
+        """
+        SELECT category, foreign_sum(value) AS total
+        FROM foreign_table
+        WHERE NOT foreign_is_null(value)
+        GROUP BY category
+        ORDER BY category
+        """
+    ).collect()
+    assert grouped[0].to_pydict() == {
+        "category": ["a", "b"],
+        "total": [10, 50],
+    }
+
+    ranked = ctx.sql(
+        """
+        SELECT value, foreign_rank() OVER (ORDER BY value) AS rank
+        FROM foreign_table
+        WHERE value IS NOT NULL
+        ORDER BY value
+        """
+    ).collect()
+    assert ranked[0].to_pydict() == {
+        "value": [10, 20, 30],
+        "rank": [1, 2, 3],
+    }
+
+    plan = str(ctx.sql("SELECT * FROM foreign_table").execution_plan())
+    assert "ForeignScanExec" in plan
+
+
+def test_foreign_package_crosses_serialized_distributed_planner() -> None:
+    _require_distributed_planner()
+
+    with TemporaryDirectory() as directory:
+        path = Path(directory) / "input.csv"
+        path.write_text("value,category\n10,a\n20,a\n30,b\n40,b\n")
+
+        distributed_config = _internal.DistributedConfig()
+        distributed_config.with_file_scan_config_bytes_per_partition(1)
+        distributed_config.with_max_tasks_per_stage(2)
+        config = SessionConfig().with_extension(distributed_config)
+        ctx, codec = _context(config)
+        ctx.register_csv("input", str(path))
+
+        resolver = _internal.LocalhostChannelResolver([50051, 50052])
+        ctx = _internal.with_distributed_query_planner(
+            ctx, resolver, config=distributed_config
+        )
+
+        plan = str(
+            ctx.sql(
+                """
+                SELECT category, foreign_sum(value) AS total,
+                       foreign_is_null(foreign_sum(value)) AS total_is_null
+                FROM input
+                GROUP BY category
+                """
+            ).execution_plan()
+        )
+
+    assert "DistributedExec" in plan
+    assert codec.physical_plan_encode_calls() > 0
+    assert codec.udf_encode_calls() > 0
+    assert codec.udf_decode_calls() > 0
+
+
+def test_foreign_package_executes_distributed() -> None:
+    _require_distributed_planner()
+
+    distributed_config = _internal.DistributedConfig()
+    distributed_config.with_max_tasks_per_stage(2)
+    config = SessionConfig().with_extension(distributed_config)
+    ctx, _ = _context(config)
+    workers = _internal.LocalhostWorkerCluster(ctx, worker_count=2)
+    ctx = _internal.with_distributed_query_planner(
+        ctx, workers.resolver(), config=distributed_config
+    )
+
+    grouped = ctx.sql(
+        """
+        SELECT category, foreign_sum(value) AS total,
+               foreign_is_null(foreign_sum(value)) AS total_is_null
+        FROM foreign_table
+        GROUP BY category
+        ORDER BY category
+        """
+    ).collect()
+    assert grouped[0].to_pydict() == {
+        "category": ["a", "b"],
+        "total": [10, 50],
+        "total_is_null": [False, False],
+    }
+
+    ranked = ctx.sql(
+        """
+        SELECT value, foreign_rank() OVER (ORDER BY value) AS rank
+        FROM foreign_table
+        WHERE value IS NOT NULL
+        ORDER BY value
+        """
+    ).collect()
+    assert ranked[0].to_pydict() == {
+        "value": [10, 20, 30],
+        "rank": [1, 2, 3],
+    }

--- a/python/tests/test_query_planner.py
+++ b/python/tests/test_query_planner.py
@@ -43,9 +43,9 @@ def test_distributed_query_planner_injects_network_shuffle_and_coalesce() -> Non
         ctx.register_csv("t", str(path))
 
         resolver = _internal.LocalhostChannelResolver([50051, 50052, 50053, 50054])
-        ctx = _internal.with_distributed_query_planner(
-            ctx, resolver, config=distributed_config
-        )
+        ctx = ctx.with_query_planner(_internal.DistributedQueryPlanner(
+            resolver, ctx, config=distributed_config
+        ))
 
         plan = str(
             ctx.sql("SELECT * FROM t")

--- a/python/tests/test_query_planner.py
+++ b/python/tests/test_query_planner.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+from datafusion import SessionConfig, SessionContext, col
+
+try:
+    from datafusion_distributed import _internal
+except ImportError:
+    _internal = None
+
+
+def _physical_plan_text(ctx: SessionContext, sql: str) -> str:
+    return str(ctx.sql(sql).execution_plan())
+
+
+def _require_query_planner_ffi() -> None:
+    if _internal is None:
+        pytest.skip("datafusion-distributed extension module has not been built")
+
+    if not hasattr(SessionContext(), "__datafusion_query_planner__") or not hasattr(
+        SessionContext(), "with_query_planner"
+    ):
+        pytest.skip("datafusion-python does not expose the query-planner FFI API")
+
+
+def test_distributed_query_planner_injects_network_shuffle_and_coalesce() -> None:
+    _require_query_planner_ffi()
+
+    with TemporaryDirectory() as directory:
+        path = Path(directory) / "input.csv"
+        rows = "\n".join(f"{index % 3},{index}" for index in range(100))
+        path.write_text(f"k,v\n{rows}\n")
+
+        distributed_config = _internal.DistributedConfig()
+        distributed_config.with_file_scan_config_bytes_per_partition(1)
+        distributed_config.with_max_tasks_per_stage(4)
+
+        config = SessionConfig().with_extension(distributed_config)
+        ctx = SessionContext(config)
+        ctx.register_csv("t", str(path))
+
+        resolver = _internal.LocalhostChannelResolver([50051, 50052, 50053, 50054])
+        ctx = _internal.with_distributed_query_planner(
+            ctx, resolver, config=distributed_config
+        )
+
+        plan = str(
+            ctx.sql("SELECT * FROM t")
+            .repartition_by_hash(col("k"), num=4)
+            .aggregate([col("k")], [])
+            .execution_plan()
+        )
+
+        assert "DistributedExec" in plan
+        assert "NetworkShuffleExec" in plan
+        assert "NetworkCoalesceExec" in plan
+
+
+def test_default_query_planner_does_not_produce_distributed_physical_plan() -> None:
+    ctx = SessionContext()
+
+    plan = _physical_plan_text(ctx, "SELECT 1 AS value")
+
+    assert "DistributedExec" not in plan

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1,0 +1,247 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "datafusion"
+version = "54.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "pyarrow" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/90/886f7e9cf827f07ebd60bd293e54e0a028a50dd49bbaef0ee42aae1981ea/datafusion-54.0.0.tar.gz", hash = "sha256:cfe7e8dfc026efc05824f49b53ad6a72caf5c2d6820759b6212a09e245a427ed", size = 276448, upload-time = "2026-06-29T11:19:34.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/58/4c5b981e3d9ade32a906c15a4941eef50c9b862781cdc14bf4dff48d026a/datafusion-54.0.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:946f55e48b8d523d7b4ac106bdf588b4493c2c66f81877d6952aafeaf7c3ec73", size = 39810553, upload-time = "2026-06-29T11:19:02.1Z" },
+    { url = "https://files.pythonhosted.org/packages/66/e5/5e4dbd42ce9a2affb3be90d9ab17cebde1a6f28b0d9fb4b83d612d5c8e42/datafusion-54.0.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:2a3bf43185c7e43e25242e5fb17b6a11b86bf976434c0bc493fdedbd9a080969", size = 37145255, upload-time = "2026-06-29T11:19:05.491Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/5e/dbb9e6e3e5006d34f295d7ac73f1302c8f2df140666402a06e6c55028edb/datafusion-54.0.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9432bf162381e9282cbc74915b8b773895de18be836f7e3f6d0de4d981f24630", size = 38853856, upload-time = "2026-06-29T11:19:08.732Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/81/e69008e3479f4d0134875bc4ae39503bedcd55ca2597e71392c963c651b4/datafusion-54.0.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3bcd4d213fa74710e75e6e182cc468c2bdbc5ffc74a08c8155d414fbbfa1b3f6", size = 41050149, upload-time = "2026-06-29T11:19:12.108Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d4/8ba6e3fe3291c9ccc94b5ca3ec3c1fbcbfbe5ece5ffb965e4550844e2c56/datafusion-54.0.0-cp310-abi3-win_amd64.whl", hash = "sha256:b934e097e1bdca7d5768a81ac1bc4a1812cb459269f8b1a5d892a5d930f18376", size = 43444869, upload-time = "2026-06-29T11:19:15.963Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/41/5608323226f21a0fa180823c531dbc0ed270e9b694f299b7647505cb6a06/datafusion-54.0.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:c4e79048da82ad89b768bd0be7df39254cd2a0afe2b719d1f129e8a7229af683", size = 39796248, upload-time = "2026-06-29T11:19:19.208Z" },
+    { url = "https://files.pythonhosted.org/packages/18/81/392ee323104ab14ca689384723b69e137064a828233c165574f97a74c0e9/datafusion-54.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fe57038003b18e28b90752c1e32b44af74ec4f552a1904aee725e1129a00c447", size = 37153577, upload-time = "2026-06-29T11:19:22.397Z" },
+    { url = "https://files.pythonhosted.org/packages/40/c4/ebd5ef5349ecbea7f5f9da76c213581c13e7bbe1b5735c9925b279eeb4eb/datafusion-54.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:574f642832a106456cfc4f32aa82484c504fc32f4be2b510202bcb579de8e6d1", size = 38849839, upload-time = "2026-06-29T11:19:25.783Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/b9/2383d30d317bb913cab97dbf2e6e1d5f37f594860d5c5bc176e025cf7d4a/datafusion-54.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:796fd5683927443c5bc61999d00b9007ef9b5ce107725ea8d241df718860985d", size = 41074623, upload-time = "2026-06-29T11:19:29.119Z" },
+    { url = "https://files.pythonhosted.org/packages/35/5c/553fd1107dede0a56727fda7216a7198d41394f2d19697f4fb104cc695ea/datafusion-54.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:64973c63874ec31670dd97b32b18af7b07fad679cb20d58ed154038e3a5c204e", size = 43438801, upload-time = "2026-06-29T11:19:32.799Z" },
+]
+
+[[package]]
+name = "datafusion-distributed"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "datafusion" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "datafusion", specifier = ">=54" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
+]
+provides-extras = ["test"]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "25.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/f3/95428098d1fa7d04432fb750eed06b41304c2f6a5d3319985e64db2d9d41/pyarrow-25.0.0.tar.gz", hash = "sha256:d2d697008b5ec06d75952ef260c2e9a8a0f6ccfce24266c04c9c8ade927cb3b4", size = 1199181, upload-time = "2026-07-10T08:29:50.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/2a/eaa70e6d6ed430c2e90c0599e2831a41a50251879e44788ccdbc73115af1/pyarrow-25.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:ce0ca222802087b9a8cb031a6468442cb6b67c290a45a601cac64753d34954d3", size = 35945551, upload-time = "2026-07-10T08:25:23.153Z" },
+    { url = "https://files.pythonhosted.org/packages/df/e0/917086af6b246143012cdc8a7c886b018b53204f3d69fc5f9be5857a8b80/pyarrow-25.0.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:7d6da02ffc7a3a9bda3b7ded4cc2a27ff73969ab37153f3afd46bbbc1ba4f0f7", size = 37636698, upload-time = "2026-07-10T08:25:28.031Z" },
+    { url = "https://files.pythonhosted.org/packages/68/6a/c87829f92503f84993721791c942f3d9aa81044de51a8cfb1da5810e5345/pyarrow-25.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:dbf9fa5d4bde73b1cc16377dcaaa010f971e6fa7f5083f5d44f34b50bc1d74af", size = 46858364, upload-time = "2026-07-10T08:25:34.527Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/ba/2030d454c2747e26cce23e4a0338067ee0830a155b7894da04caa96783a5/pyarrow-25.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:b72d943ff4e10fec8d48aedb23322d8f6ea8bc2d698b81db37e73730f69e4862", size = 50056398, upload-time = "2026-07-10T08:25:40.785Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ce/ba7a5ce7bf0cfc372ec48203a34ece42f73aa2f3231706f61c55e105ecd0/pyarrow-25.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5fb2d837960f1df7f679ff9f1a55065e306347d379e0768cebf14781254d6194", size = 49958146, upload-time = "2026-07-10T08:25:46.98Z" },
+    { url = "https://files.pythonhosted.org/packages/75/eb/c34a29fb7a70dca2f903c7d85a928928ef55af20cd56e99de6b4c0d897bc/pyarrow-25.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:add690feafa0953c443cdba9e9e87f5eaa198f1ea2e43a3b146ea83f202262d0", size = 53096264, upload-time = "2026-07-10T08:25:53.925Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f9/35b1f83a0727d84951588e4034aca2feb76dfb45b0725918c0037b0a48f7/pyarrow-25.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:d293e9959b29a24c82d936d04ab2b7fd8b8d334030de2e56a99aba94f008ad7a", size = 27840572, upload-time = "2026-07-10T08:25:58.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/98/ae2b5acf9876dbeffa6f320776242c52caab062df55c8ac5501ed2679e74/pyarrow-25.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:2e3b6544e26e393fe2cd530f523e36c1c8d3c345bbbb60cca3fd866be8322517", size = 35939080, upload-time = "2026-07-10T08:26:04.53Z" },
+    { url = "https://files.pythonhosted.org/packages/80/09/3de2a968edbd496c86cb8b932cdbee2d4b08c4a28e9884a15e5c705a646b/pyarrow-25.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:b724d127783b4c19f088fcdfc844cbc318809246a30307bcabd5ed02045e890e", size = 37633420, upload-time = "2026-07-10T08:26:10.354Z" },
+    { url = "https://files.pythonhosted.org/packages/19/86/8399243a4ce080426ec37db18d5e29148b7ec960a8a8c7f9059a7bf6ef0a/pyarrow-25.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:244f98a595f70fa4fd35faa7508c4ae67e14a173397a4b3b49d2b3c360fb0062", size = 46861050, upload-time = "2026-07-10T08:26:16.397Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/72d704b02bc5fc6d06954d76a0208c1e79cad3ab370f6d6a91ffe5078870/pyarrow-25.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:0222f0071d13313962a88d21bf28b80d355ac39d81bfa6ff3fe00eeaf748e4be", size = 50056458, upload-time = "2026-07-10T08:26:23.271Z" },
+    { url = "https://files.pythonhosted.org/packages/06/5d/3c31a60b6403d63cad2e0f829096f5fc5763a129ead4207a5d4690b96448/pyarrow-25.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b58726f118c079f9d4ed7e904975d4f15fd69d0741ba511a4e2dcaa4ef16354f", size = 49957793, upload-time = "2026-07-10T08:26:30.232Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f7/8f8a019061f9863a831915329264372a87ed25eaf9109ce56eb0e84012c5/pyarrow-25.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:38a2c887cb3883e241b70201688db34133b6dfadd04f03c8f9213df53770c18e", size = 53100544, upload-time = "2026-07-10T08:26:36.414Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e2/738071e95c5ddad7b3dfc12f569ffa992db89d7d7b4a95258fd184191249/pyarrow-25.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:161649d60a7a46c613a19fd795763ea8a88c36ba997dd99d9bc66e6794ee36e8", size = 27848311, upload-time = "2026-07-10T08:26:41.429Z" },
+    { url = "https://files.pythonhosted.org/packages/73/44/fdd3a4377807b7dcabe2d4b5aa99dbbc98e2e5df3f1ca4e7f0aec492d987/pyarrow-25.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:149730a3d1f0fb59d663a0b8aa210adfd9c17c27cd94a0d143e60daea8320d4e", size = 35850884, upload-time = "2026-07-10T08:26:47.357Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/71/9f053177a7709b8c90abb00a2375b916286f9f0d6cfb21a5cadd4ef811e8/pyarrow-25.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:0721332c30fdd453fdd1fc203b2ac1f4c9db5aea28fa38d41f2574c4b068b9ec", size = 37616197, upload-time = "2026-07-10T08:26:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/95/1a/22bfb6597dcdc861fa83c39c06e1457cb56f698940eff42fbb25de30e8e5/pyarrow-25.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:fa1482b3da10cac2d4db6e26b81da543e237616af2ef6d466018b31ca586496f", size = 46841966, upload-time = "2026-07-10T08:27:07.685Z" },
+    { url = "https://files.pythonhosted.org/packages/55/0e/cd705c042bc4fe7022478db577fcab4abdcfabb9bc37ab7a75556b3fcb2b/pyarrow-25.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:5d1dbf24e151042f2fa3c129563f65d66674128868496fb008c4272b16bdf778", size = 50088993, upload-time = "2026-07-10T08:27:14.268Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ee/d822e1ee31fe31ec5d057210e0605c950b975dcd8d9a332976cc859a9df8/pyarrow-25.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:20887a762dd61dcc530f93a140840ab1f6aa7836b33270e42d627ab3cf11e537", size = 49941005, upload-time = "2026-07-10T08:27:21.274Z" },
+    { url = "https://files.pythonhosted.org/packages/33/1b/207a90cc64619a095eb75a263ae069735f2810056d43c667befd573ec083/pyarrow-25.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:58d1ab556b0cea1c93fdb799b24ad58adb2f2a2788dbce782a94f64ae1a5cc9b", size = 53112355, upload-time = "2026-07-10T08:27:27.911Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/fe/81d1e5f8beed15c01e98649d5c6e2167b67fd395884a2488f18bf1cf0dba/pyarrow-25.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:3f356afe61186395c861d5cd63dc21ff7d5fa335012a4668d979257df7fea0f5", size = 27945954, upload-time = "2026-07-10T08:27:32.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c8/098ce17d778fd9d29e40bb8c5f19a40cc90c3f0b46c9057b0d7993f42f54/pyarrow-25.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:8831a3ba52fa7cdb78d368d968b1dcd06171e6dff5461e16d90de91d371e47bc", size = 35844549, upload-time = "2026-07-10T08:27:37.956Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/66/24c28877219abf6263d909b1592c97ff82c59f13a59acbed11fc87c0654f/pyarrow-25.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:5f4bacb60f91dd2fca6c52f1b9a0012cd090e0294f1f781dc1881a247a352f8e", size = 37610397, upload-time = "2026-07-10T08:27:43.803Z" },
+    { url = "https://files.pythonhosted.org/packages/53/55/6d1d5f5aff317ec5de9421594679ed51ed828fe7e2ce209327f819d801e4/pyarrow-25.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:59516c822d5fd8e544aaa0dfe72f36fed5d4c24ea8390aab1bcd31d7e959c6be", size = 46841701, upload-time = "2026-07-10T08:27:49.741Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/5d/f790fb6965ab54c9da0dda7856abc75fd0d7648d865f8d603c111d203a64/pyarrow-25.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f9dbd83e91c239a1f5ee7ce13f108b5f6c0efbe40a4375260d8f08b43ad05e9", size = 50090118, upload-time = "2026-07-10T08:27:56.051Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/8c/faf025357ebf31bc96777f234277aa31e2aeca6dd4ecaa391f29085473c2/pyarrow-25.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:18dcc8cc50b5e72eae6fcbfc6c8776c21a007176b27a3cdec5c2f5bcf126708d", size = 49945559, upload-time = "2026-07-10T08:28:01.927Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a1/bd051871708ea99a5e0fc711926c26c6f2c6d0130c7aaac8093e34998af6/pyarrow-25.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4ec1895a87aa834c3b99b7a1e758747eb8bb57f922b32c0e0fa04afb8d6998b1", size = 53114238, upload-time = "2026-07-10T08:28:08.594Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/31/737f0c3cffcd6af647849477d1dd68045deac2e3963c3f9f211bedc48540/pyarrow-25.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:77c8d1ae46a44b4006e8db1cc977bbcc6ce4873c92f74137d68e45503b97fb18", size = 27861162, upload-time = "2026-07-10T08:28:12.975Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/581ccbcdb3d897eb2893328d68db3d52eca373bf2a7e964d0a6276b8e85b/pyarrow-25.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:72132b9a8a0a1840197794d4dea26080069b6b0981c116bc078762dc9691b21b", size = 35878945, upload-time = "2026-07-10T08:28:18.222Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d1/ccb01db7329ea0411ef4fbd9b62a04d3268b36777d4e758d5e39b91ddeab/pyarrow-25.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e009ef945e498dca2f050ea10d2e9764cb44017254826fc4574fdb8d2530173b", size = 37630854, upload-time = "2026-07-10T08:28:23.452Z" },
+    { url = "https://files.pythonhosted.org/packages/af/9f/2d81ba89d1e4198d0cb25fe7529de936830fdaec0db926bb52a1ef7080d4/pyarrow-25.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:f57a39dbcb416345401c2e77a4373669b45fd111a1768e6cf267a7a0607ff0ec", size = 46905617, upload-time = "2026-07-10T08:28:29.376Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/0ed312ec800fb536f93783215126cee4b8977dcfeccba6f0f44df0cc87d7/pyarrow-25.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:447df764beb07c544f0178a5f6b70ef44b9ecf382b3cdfad4c2d7867353c3887", size = 50119765, upload-time = "2026-07-10T08:28:35.826Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/88/cab5063ba0c4d46a9f6b4b7eb1c9029dc0302d65cd5ab3510c949a386568/pyarrow-25.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ac5dfeee59f9ceb4d45ba76e83b026c38c24334135bb329d8274baa49cec3c62", size = 50027563, upload-time = "2026-07-10T08:28:43.848Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/fb/4d24f1b7fe2e042dc4ef315ef75e4e702d8e46fe10c37e63caff00502b03/pyarrow-25.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f0f100dacf2c0f400601664a79d1a907ced4740514bb2b00917341038e2ce76f", size = 53162437, upload-time = "2026-07-10T08:28:52.819Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/65/da20806de93ca6ee91e72cb6a9b08b3ac890b46efc8d94a7326c651c4c81/pyarrow-25.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:2e093efbecb5317372f819228fa4b4e6157eee48d3f0a7b0303705ebf81a7104", size = 28613262, upload-time = "2026-07-10T08:29:47.544Z" },
+    { url = "https://files.pythonhosted.org/packages/86/9f/c632afb1d3ef4a7814cee236718235f3a47eac46e97eb87df40f550b6b48/pyarrow-25.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:26be35b80780d2d21f4bae3d568b1666337c3a89722cc1794c956a77017cb24e", size = 36120702, upload-time = "2026-07-10T08:28:59.577Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0a/093d53a0e72ad06e45d6443e00651bbc2d21af4211295086cbf4d873d3b9/pyarrow-25.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:6f4812bfbf11ca7d8faf59eb8fff8bf4dd25ce3a38b62baa010cc17a0926d1b2", size = 37750674, upload-time = "2026-07-10T08:29:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/18/b37fc31a69cff4bdfb8842683def5612f551b93fff6f44375e4a4a6a5535/pyarrow-25.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b8af8ceedf0c9c160fd2b63440f2d205b9404db85866c1217bfea601de7cfb50", size = 46912304, upload-time = "2026-07-10T08:29:14.656Z" },
+    { url = "https://files.pythonhosted.org/packages/32/35/5cae19ba72493e5598022468b56f6a5571f399f485bf412f157356476caa/pyarrow-25.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c70a5fd9a82bd1a702fd482bdc62d38dcb672fb2b449b1d7c0d7d1f4be7b7bfe", size = 50073652, upload-time = "2026-07-10T08:29:22.467Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a5/ddd508424bdfd5e6945765e9e2ffc687e2f6115972badc8ecf423076c407/pyarrow-25.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0490a7f8b38ffe11cc26526b50c65d111cb54ddac3717cec781806793f1244dc", size = 50058654, upload-time = "2026-07-10T08:29:29.689Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a4/324d0db203ff5eebe8694ec2d6ec5a23f9aaa5d02e5b8c692914c518c33c/pyarrow-25.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e83916bbcf380866b4e14255850b33323ff678dc9758411d0409cdd2523880b0", size = 53140153, upload-time = "2026-07-10T08:29:36.041Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/8d/d236e9c82fe315f9128885c8be3ec719f41965a1eb6b6f4b42470904cd41/pyarrow-25.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:13240f0d3dc5932ccd0bfa90cd76d835680b9d94a7661c635df4b703d40ce849", size = 28743657, upload-time = "2026-07-10T08:29:42.742Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/src/distributed_planner/distributed_config.rs
+++ b/src/distributed_planner/distributed_config.rs
@@ -116,6 +116,30 @@ impl DistributedConfig {
         };
         Ok(distributed_cfg)
     }
+
+    /// Gets an owned [DistributedConfig] from the [ConfigOptions]'s extensions.
+    ///
+    /// This prefers a native [DistributedConfig] extension. When compiled with the `ffi` feature,
+    /// it also falls back to extracting a config from `FFI_ExtensionOptions`, which is how a
+    /// config created behind DataFusion FFI can appear to Rust. Private trait-object fields do not
+    /// cross the FFI boundary and are reconstructed at their defaults by the config extension.
+    pub fn from_config_options_owned(cfg: &ConfigOptions) -> Result<Self, DataFusionError> {
+        if let Some(distributed_cfg) = cfg.extensions.get::<DistributedConfig>() {
+            return Ok(distributed_cfg.clone());
+        }
+
+        #[cfg(feature = "ffi")]
+        if let Some(ffi) = cfg
+            .extensions
+            .get::<datafusion_ffi::config::extension_options::FFI_ExtensionOptions>()
+        {
+            return ffi
+                .to_extension::<DistributedConfig>()
+                .map_err(|e| DataFusionError::Execution(format!("{e}")));
+        }
+
+        plan_err!("DistributedConfig is not in ConfigOptions.extensions")
+    }
 }
 
 impl ConfigExtension for DistributedConfig {

--- a/src/distributed_planner/distributed_query_planner.rs
+++ b/src/distributed_planner/distributed_query_planner.rs
@@ -9,7 +9,8 @@ use crate::distributed_planner::push_fetch_into_network_coalesce::push_fetch_int
 use crate::{DistributedConfig, DistributedExec, NetworkBoundaryExt, TaskEstimator};
 use async_trait::async_trait;
 use datafusion::common::tree_node::{Transformed, TreeNode};
-use datafusion::execution::SessionState;
+use datafusion::config::ConfigOptions;
+use datafusion::execution::Session;
 use datafusion::execution::context::QueryPlanner;
 use datafusion::logical_expr::LogicalPlan;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
@@ -50,7 +51,7 @@ impl QueryPlanner for DistributedQueryPlanner {
     async fn create_physical_plan(
         &self,
         logical_plan: &LogicalPlan,
-        session_state: &SessionState,
+        session_state: &dyn Session,
     ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
         let original_plan = match &self.prev {
             None => {
@@ -66,62 +67,70 @@ impl QueryPlanner for DistributedQueryPlanner {
             }
         };
 
-        if original_plan.is::<DistributedExec>() {
-            return Ok(original_plan);
-        }
-
-        let cfg = session_state.config_options().as_ref();
-        let d_cfg = DistributedConfig::from_config_options(cfg)?;
-
-        // The plan already contains network boundaries set by the user. Just ensure they have nice
-        // unique identifiers for each stage, and move forward with it.
-        if original_plan.exists(|plan| Ok(plan.is_network_boundary()))? {
-            // Ensure the leafs are appropriately scaled up.
-            let scaled = original_plan.transform_down_with_task_count(1, |plan, task_count| {
-                if !plan.children().is_empty() {
-                    return Ok(Transformed::no(plan));
-                }
-                let task_estimator = &d_cfg.__private_task_estimator;
-                match task_estimator.scale_up_leaf_node(&plan, task_count, cfg)? {
-                    None => Ok(Transformed::no(plan)),
-                    Some(scaled) => Ok(Transformed::yes(scaled)),
-                }
-            })?;
-            // Ensure the stages in the plan have nice unique identifiers.
-            let plan = prepare_network_boundaries(scaled.data)?;
-            if !plan.exists(|plan| Ok(plan.is_network_boundary()))? {
-                return Ok(plan);
-            }
-            let plan = push_fetch_into_network_coalesce(plan)?;
-            return Ok(Arc::new(
-                DistributedExec::new(plan).with_metrics_collection(d_cfg.collect_metrics),
-            ));
-        }
-
-        let mut plan = Arc::clone(&original_plan);
-
-        if plan.output_partitioning().partition_count() > 1 {
-            plan = Arc::new(CoalescePartitionsExec::new(plan));
-        }
-
-        let cfg = session_state.config_options();
-
-        plan = insert_broadcast_execs(plan, cfg)?;
-
-        plan = inject_network_boundaries(plan, CardinalityBasedNetworkBoundaryBuilder, cfg).await?;
-
-        plan = prepare_network_boundaries(plan)?;
-        if !plan.exists(|plan| Ok(plan.is_network_boundary()))? {
-            return Ok(original_plan);
-        }
-
-        let plan = partial_reduce_below_network_shuffles(plan, cfg)?;
-        let plan = push_fetch_into_network_coalesce(plan)?;
-
-        Ok(Arc::new(
-            DistributedExec::new(plan).with_metrics_collection(d_cfg.collect_metrics),
-        ))
+        distribute_physical_plan(original_plan, session_state.config_options()).await
     }
+}
+
+/// Runs the distributed planning pipeline on an already-created physical plan.
+///
+/// This is the same pipeline used by [`DistributedQueryPlanner`], factored out for FFI callers
+/// that already obtained a physical plan from a planner in another library.
+pub async fn distribute_physical_plan(
+    original_plan: Arc<dyn ExecutionPlan>,
+    cfg: &ConfigOptions,
+) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+    if original_plan.is::<DistributedExec>() {
+        return Ok(original_plan);
+    }
+
+    let d_cfg = DistributedConfig::from_config_options_owned(cfg)?;
+
+    // The plan already contains network boundaries set by the user. Just ensure they have nice
+    // unique identifiers for each stage, and move forward with it.
+    if original_plan.exists(|plan| Ok(plan.is_network_boundary()))? {
+        // Ensure the leafs are appropriately scaled up.
+        let scaled = original_plan.transform_down_with_task_count(1, |plan, task_count| {
+            if !plan.children().is_empty() {
+                return Ok(Transformed::no(plan));
+            }
+            let task_estimator = &d_cfg.__private_task_estimator;
+            match task_estimator.scale_up_leaf_node(&plan, task_count, cfg)? {
+                None => Ok(Transformed::no(plan)),
+                Some(scaled) => Ok(Transformed::yes(scaled)),
+            }
+        })?;
+        // Ensure the stages in the plan have nice unique identifiers.
+        let plan = prepare_network_boundaries(scaled.data)?;
+        if !plan.exists(|plan| Ok(plan.is_network_boundary()))? {
+            return Ok(plan);
+        }
+        let plan = push_fetch_into_network_coalesce(plan)?;
+        return Ok(Arc::new(
+            DistributedExec::new(plan).with_metrics_collection(d_cfg.collect_metrics),
+        ));
+    }
+
+    let mut plan = Arc::clone(&original_plan);
+
+    if plan.output_partitioning().partition_count() > 1 {
+        plan = Arc::new(CoalescePartitionsExec::new(plan));
+    }
+
+    plan = insert_broadcast_execs(plan, cfg)?;
+
+    plan = inject_network_boundaries(plan, CardinalityBasedNetworkBoundaryBuilder, cfg).await?;
+
+    plan = prepare_network_boundaries(plan)?;
+    if !plan.exists(|plan| Ok(plan.is_network_boundary()))? {
+        return Ok(original_plan);
+    }
+
+    let plan = partial_reduce_below_network_shuffles(plan, cfg)?;
+    let plan = push_fetch_into_network_coalesce(plan)?;
+
+    Ok(Arc::new(
+        DistributedExec::new(plan).with_metrics_collection(d_cfg.collect_metrics),
+    ))
 }
 
 #[cfg(test)]

--- a/src/distributed_planner/inject_network_boundaries.rs
+++ b/src/distributed_planner/inject_network_boundaries.rs
@@ -140,7 +140,7 @@ pub(crate) async fn inject_network_boundaries(
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let ctx = InjectNetworkBoundaryContext {
         cfg,
-        d_cfg: DistributedConfig::from_config_options(cfg)?,
+        d_cfg: &DistributedConfig::from_config_options_owned(cfg)?,
         nb_builder: &nb_builder,
         task_counts: &Mutex::new(HashMap::new()),
         query_id: Uuid::new_v4(),

--- a/src/distributed_planner/insert_broadcast.rs
+++ b/src/distributed_planner/insert_broadcast.rs
@@ -118,7 +118,7 @@ pub(super) fn insert_broadcast_execs(
     plan: Arc<dyn ExecutionPlan>,
     cfg: &ConfigOptions,
 ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-    let d_cfg = DistributedConfig::from_config_options(cfg)?;
+    let d_cfg = DistributedConfig::from_config_options_owned(cfg)?;
     if !d_cfg.broadcast_joins {
         return Ok(plan);
     }

--- a/src/distributed_planner/mod.rs
+++ b/src/distributed_planner/mod.rs
@@ -10,6 +10,7 @@ mod session_state_builder_ext;
 mod task_estimator;
 
 pub use distributed_config::DistributedConfig;
+pub use distributed_query_planner::distribute_physical_plan;
 pub use network_boundary::{NetworkBoundary, NetworkBoundaryExt};
 pub(crate) use network_boundary::{ProducerHead, insert_producer_head};
 pub use session_state_builder_ext::SessionStateBuilderExt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub use distributed_ext::DistributedExt;
 pub use distributed_planner::{
     DistributedConfig, NetworkBoundary, NetworkBoundaryExt, SessionStateBuilderExt,
     TaskCountAnnotation, TaskEstimation, TaskEstimator, TaskRoutingContext,
+    distribute_physical_plan,
 };
 pub use execution_plans::{
     BroadcastExec, DistributedLeafExec, NetworkBroadcastExec, NetworkCoalesceExec,

--- a/src/protobuf/distributed_codec.rs
+++ b/src/protobuf/distributed_codec.rs
@@ -2,23 +2,27 @@ use super::get_distributed_user_codecs;
 use crate::NetworkShuffleExec;
 use crate::common::{deserialize_uuid, serialize_uuid};
 use crate::execution_plans::{
-    BroadcastExec, ChildWeight, ChildrenIsolatorUnionExec, NetworkBroadcastExec,
-    NetworkCoalesceExec,
+    BroadcastExec, ChildWeight, ChildrenIsolatorUnionExec, DistributedLeafExec,
+    NetworkBroadcastExec, NetworkCoalesceExec,
 };
 use crate::stage::{LocalStage, RemoteStage, Stage};
 use crate::worker::WorkerConnectionPool;
-use crate::{DistributedTaskContext, NetworkBoundary};
+use crate::{DistributedExec, DistributedTaskContext, NetworkBoundary};
 use bytes::Bytes;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::common::Result;
 use datafusion::error::DataFusionError;
 use datafusion::execution::TaskContext;
+use datafusion::logical_expr::{AggregateUDF, ScalarUDF, WindowUDF};
 use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::union::UnionExec;
 use datafusion::physical_plan::{ExecutionPlan, Partitioning, PlanProperties};
 use datafusion::prelude::SessionConfig;
+use datafusion_proto::bytes::{
+    physical_plan_from_bytes_with_extension_codec, physical_plan_to_bytes_with_extension_codec,
+};
 use datafusion_proto::physical_plan::from_proto::parse_protobuf_partitioning;
 use datafusion_proto::physical_plan::to_proto::serialize_partitioning;
 use datafusion_proto::physical_plan::{
@@ -34,13 +38,27 @@ use url::Url;
 
 /// DataFusion [PhysicalExtensionCodec] implementation that allows serializing and
 /// deserializing the custom ExecutionPlans in this project
-#[derive(Debug)]
-pub struct DistributedCodec;
+#[derive(Debug, Default, Clone)]
+pub struct DistributedCodec {
+    user_codecs: Vec<Arc<dyn PhysicalExtensionCodec>>,
+}
 
 impl DistributedCodec {
+    pub fn new(user_codecs: Vec<Arc<dyn PhysicalExtensionCodec>>) -> Self {
+        Self { user_codecs }
+    }
+
     pub fn new_combined_with_user(cfg: &SessionConfig) -> ComposedPhysicalExtensionCodec {
-        let mut codecs: Vec<Arc<dyn PhysicalExtensionCodec>> = vec![Arc::new(DistributedCodec {})];
-        codecs.extend(get_distributed_user_codecs(cfg));
+        let user_codecs = get_distributed_user_codecs(cfg);
+        let mut codecs: Vec<Arc<dyn PhysicalExtensionCodec>> =
+            vec![Arc::new(DistributedCodec::new(user_codecs.clone()))];
+        codecs.extend(user_codecs);
+        ComposedPhysicalExtensionCodec::new(codecs)
+    }
+
+    fn combined(&self) -> ComposedPhysicalExtensionCodec {
+        let mut codecs: Vec<Arc<dyn PhysicalExtensionCodec>> = vec![Arc::new(self.clone())];
+        codecs.extend(self.user_codecs.iter().cloned());
         ComposedPhysicalExtensionCodec::new(codecs)
     }
 }
@@ -95,6 +113,33 @@ impl PhysicalExtensionCodec for DistributedCodec {
         }
 
         match distributed_exec_node {
+            DistributedExecNode::Distributed(DistributedRootExecProto { collect_metrics }) => {
+                if inputs.len() != 1 {
+                    return Err(proto_error(format!(
+                        "DistributedExec expects exactly one child, got {}",
+                        inputs.len()
+                    )));
+                }
+                Ok(Arc::new(
+                    DistributedExec::new(Arc::clone(&inputs[0]))
+                        .with_metrics_collection(collect_metrics),
+                ))
+            }
+            DistributedExecNode::DistributedLeaf(DistributedLeafExecProto {
+                original,
+                variants,
+            }) => {
+                let codec = self.combined();
+                let original =
+                    physical_plan_from_bytes_with_extension_codec(&original, ctx, &codec)?;
+                let variants = variants
+                    .iter()
+                    .map(|variant| {
+                        physical_plan_from_bytes_with_extension_codec(variant, ctx, &codec)
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                Ok(Arc::new(DistributedLeafExec::try_new(original, variants)?))
+            }
             DistributedExecNode::NetworkHashShuffle(NetworkShuffleExecProto {
                 schema,
                 partitioning,
@@ -105,7 +150,7 @@ impl PhysicalExtensionCodec for DistributedCodec {
                     .map(|s| s.try_into())
                     .ok_or(proto_error("NetworkShuffleExec is missing schema"))??;
 
-                let decode_ctx = PhysicalPlanDecodeContext::new(ctx, &DistributedCodec {});
+                let decode_ctx = PhysicalPlanDecodeContext::new(ctx, self);
                 let partitioning = parse_protobuf_partitioning(
                     partitioning.as_ref(),
                     &decode_ctx,
@@ -130,7 +175,7 @@ impl PhysicalExtensionCodec for DistributedCodec {
                     .map(|s| s.try_into())
                     .ok_or(proto_error("NetworkCoalesceExec is missing schema"))??;
 
-                let decode_ctx = PhysicalPlanDecodeContext::new(ctx, &DistributedCodec {});
+                let decode_ctx = PhysicalPlanDecodeContext::new(ctx, self);
                 let partitioning = parse_protobuf_partitioning(
                     partitioning.as_ref(),
                     &decode_ctx,
@@ -155,7 +200,7 @@ impl PhysicalExtensionCodec for DistributedCodec {
                     .map(|s| s.try_into())
                     .ok_or(proto_error("NetworkBroadcastExec is missing schema"))??;
 
-                let decode_ctx = PhysicalPlanDecodeContext::new(ctx, &DistributedCodec {});
+                let decode_ctx = PhysicalPlanDecodeContext::new(ctx, self);
                 let partitioning = parse_protobuf_partitioning(
                     partitioning.as_ref(),
                     &decode_ctx,
@@ -260,12 +305,46 @@ impl PhysicalExtensionCodec for DistributedCodec {
             })
         }
 
-        if let Some(node) = node.downcast_ref::<NetworkShuffleExec>() {
+        if let Some(node) = node.downcast_ref::<DistributedExec>() {
+            let wrapper = DistributedExecProto {
+                node: Some(DistributedExecNode::Distributed(DistributedRootExecProto {
+                    collect_metrics: node.metrics_store.is_some(),
+                })),
+            };
+
+            wrapper.encode(buf).map_err(|e| proto_error(format!("{e}")))
+        } else if let Some(node) = node.downcast_ref::<DistributedLeafExec>() {
+            let codec = self.combined();
+            let wrapper = DistributedExecProto {
+                node: Some(DistributedExecNode::DistributedLeaf(
+                    DistributedLeafExecProto {
+                        original: physical_plan_to_bytes_with_extension_codec(
+                            Arc::clone(node.original()),
+                            &codec,
+                        )?
+                        .to_vec(),
+                        variants: node
+                            .variants()
+                            .iter()
+                            .map(|variant| {
+                                physical_plan_to_bytes_with_extension_codec(
+                                    Arc::clone(variant),
+                                    &codec,
+                                )
+                                .map(|bytes| bytes.to_vec())
+                            })
+                            .collect::<Result<Vec<_>>>()?,
+                    },
+                )),
+            };
+
+            wrapper.encode(buf).map_err(|e| proto_error(format!("{e}")))
+        } else if let Some(node) = node.downcast_ref::<NetworkShuffleExec>() {
             let inner = NetworkShuffleExecProto {
                 schema: Some(node.schema().try_into()?),
                 partitioning: Some(serialize_partitioning(
                     node.properties().output_partitioning(),
-                    &DistributedCodec {},
+                    self,
                     &DefaultPhysicalProtoConverter {},
                 )?),
                 input_stage: Some(encode_stage_proto(node.input_stage())?),
@@ -281,7 +360,7 @@ impl PhysicalExtensionCodec for DistributedCodec {
                 schema: Some(node.schema().try_into()?),
                 partitioning: Some(serialize_partitioning(
                     node.properties().output_partitioning(),
-                    &DistributedCodec {},
+                    self,
                     &DefaultPhysicalProtoConverter {},
                 )?),
                 input_stage: Some(encode_stage_proto(node.input_stage())?),
@@ -297,7 +376,7 @@ impl PhysicalExtensionCodec for DistributedCodec {
                 schema: Some(node.schema().try_into()?),
                 partitioning: Some(serialize_partitioning(
                     node.properties().output_partitioning(),
-                    &DistributedCodec {},
+                    self,
                     &DefaultPhysicalProtoConverter {},
                 )?),
                 input_stage: Some(encode_stage_proto(node.input_stage())?),
@@ -354,6 +433,27 @@ impl PhysicalExtensionCodec for DistributedCodec {
             Err(proto_error(format!("Unexpected plan {}", node.name())))
         }
     }
+
+    fn try_encode_udf(&self, node: &ScalarUDF, _buf: &mut Vec<u8>) -> Result<()> {
+        Err(proto_error(format!(
+            "Unexpected scalar UDF {}",
+            node.name()
+        )))
+    }
+
+    fn try_encode_udaf(&self, node: &AggregateUDF, _buf: &mut Vec<u8>) -> Result<()> {
+        Err(proto_error(format!(
+            "Unexpected aggregate UDF {}",
+            node.name()
+        )))
+    }
+
+    fn try_encode_udwf(&self, node: &WindowUDF, _buf: &mut Vec<u8>) -> Result<()> {
+        Err(proto_error(format!(
+            "Unexpected window UDF {}",
+            node.name()
+        )))
+    }
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -380,7 +480,7 @@ pub struct ExecutionTaskProto {
 
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DistributedExecProto {
-    #[prost(oneof = "DistributedExecNode", tags = "1, 2, 3, 4, 5, 6")]
+    #[prost(oneof = "DistributedExecNode", tags = "1, 2, 4, 5, 6, 7, 8")]
     pub node: Option<DistributedExecNode>,
 }
 
@@ -397,6 +497,24 @@ pub enum DistributedExecNode {
     NetworkBroadcast(NetworkBroadcastExecProto),
     #[prost(message, tag = "6")]
     Broadcast(BroadcastExecProto),
+    #[prost(message, tag = "7")]
+    Distributed(DistributedRootExecProto),
+    #[prost(message, tag = "8")]
+    DistributedLeaf(DistributedLeafExecProto),
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DistributedRootExecProto {
+    #[prost(bool, tag = "1")]
+    pub collect_metrics: bool,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DistributedLeafExecProto {
+    #[prost(bytes, tag = "1")]
+    pub original: Vec<u8>,
+    #[prost(bytes, repeated, tag = "2")]
+    pub variants: Vec<Vec<u8>>,
 }
 
 /// Protobuf representation of the [NetworkShuffleExec] physical node. It serves as
@@ -573,7 +691,7 @@ mod tests {
 
     #[test]
     fn test_roundtrip_single_flight() -> datafusion::common::Result<()> {
-        let codec = DistributedCodec;
+        let codec = DistributedCodec::default();
         let ctx = create_context();
 
         let schema = schema_i32("a");
@@ -592,7 +710,7 @@ mod tests {
 
     #[test]
     fn test_roundtrip_union() -> datafusion::common::Result<()> {
-        let codec = DistributedCodec;
+        let codec = DistributedCodec::default();
         let ctx = create_context();
 
         let schema = schema_i32("c");
@@ -622,7 +740,7 @@ mod tests {
 
     #[test]
     fn test_roundtrip_sort_flight() -> datafusion::common::Result<()> {
-        let codec = DistributedCodec;
+        let codec = DistributedCodec::default();
         let ctx = create_context();
 
         let schema = schema_i32("d");
@@ -655,7 +773,7 @@ mod tests {
 
     #[test]
     fn test_roundtrip_single_flight_coalesce() -> datafusion::common::Result<()> {
-        let codec = DistributedCodec;
+        let codec = DistributedCodec::default();
         let ctx = create_context();
 
         let schema = schema_i32("e");
@@ -676,7 +794,7 @@ mod tests {
 
     #[test]
     fn test_roundtrip_single_flight_with_plan() -> datafusion::common::Result<()> {
-        let codec = DistributedCodec;
+        let codec = DistributedCodec::default();
         let ctx = create_context();
 
         let schema = schema_i32("a");
@@ -698,7 +816,7 @@ mod tests {
 
     #[test]
     fn test_roundtrip_single_flight_coalesce_with_plan() -> datafusion::common::Result<()> {
-        let codec = DistributedCodec;
+        let codec = DistributedCodec::default();
         let ctx = create_context();
 
         let schema = schema_i32("e");
@@ -719,7 +837,7 @@ mod tests {
 
     #[test]
     fn test_roundtrip_flight_coalesce() -> datafusion::common::Result<()> {
-        let codec = DistributedCodec;
+        let codec = DistributedCodec::default();
         let ctx = create_context();
 
         let schema = schema_i32("f");
@@ -743,7 +861,7 @@ mod tests {
 
     #[test]
     fn test_roundtrip_union_coalesce() -> datafusion::common::Result<()> {
-        let codec = DistributedCodec;
+        let codec = DistributedCodec::default();
         let ctx = create_context();
 
         let schema = schema_i32("g");
@@ -773,7 +891,7 @@ mod tests {
 
     #[test]
     fn test_roundtrip_children_isolator_union() -> datafusion::common::Result<()> {
-        let codec = DistributedCodec;
+        let codec = DistributedCodec::default();
         let ctx = create_context();
 
         let schema = schema_i32("h");


### PR DESCRIPTION
**DO NOT MERGE**

This PR is opened as a demonstration of how FFI Query Planner could be exposed based on 54.0.0 instead of trying to keep 4 repositories all working against `datafusion main`.

- DataFusion https://github.com/apache/datafusion/pull/23581
- DataFusion Python https://github.com/apache/datafusion-python/pull/1636
- DataFusion Ballista https://github.com/apache/datafusion-ballista/pull/2040
- DataFusion Distributed (this)
