### PR TITLE
Support distributed EXPLAIN ANALYZE

### DIFF
--- a/src/distributed_planner/distributed_query_planner.rs
+++ b/src/distributed_planner/distributed_query_planner.rs
@@ -8,15 +8,18 @@ use crate::distributed_planner::partial_reduce_below_network_shuffles::partial_r
 use crate::distributed_planner::prepare_network_boundaries::prepare_network_boundaries;
 use crate::distributed_planner::push_fetch_into_network_coalesce::push_fetch_into_network_coalesce;
 use crate::events::{ScaleUpLeafNodeEvent, ScaleUpLeafNodeHandlers};
+use crate::explain_analyze::DistributedAnalyzeExec;
 use crate::{DistributedConfig, DistributedExec, NetworkBoundaryExt};
 use async_trait::async_trait;
 use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::execution::SessionState;
 use datafusion::execution::context::QueryPlanner;
 use datafusion::logical_expr::LogicalPlan;
+use datafusion::physical_plan::analyze::AnalyzeExec;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
+use futures::future::BoxFuture;
 use std::sync::Arc;
 
 /// Transforms a single-node physical plan into a distributed plan by injecting network
@@ -71,8 +74,32 @@ impl QueryPlanner for DistributedQueryPlanner {
             }
         };
 
+        create_distributed_plan(original_plan, session_state).await
+    }
+}
+
+/// Applies distributed planning to an already-created physical plan.
+///
+/// Inputs to [`AnalyzeExec`] are planned recursively. When one becomes distributed, the native
+/// node is replaced by [`DistributedAnalyzeExec`]. The future is boxed because recursive `async
+/// fn`s would otherwise have an infinitely-sized return type.
+fn create_distributed_plan(
+    original_plan: Arc<dyn ExecutionPlan>,
+    session_state: &SessionState,
+) -> BoxFuture<'_, datafusion::common::Result<Arc<dyn ExecutionPlan>>> {
+    Box::pin(async move {
         if original_plan.is::<DistributedExec>() {
             return Ok(original_plan);
+        }
+
+        if let Some(analyze) = original_plan.downcast_ref::<AnalyzeExec>() {
+            // Recursively distribute the query being analyzed. Replace `AnalyzeExec` only when its
+            // input became distributed; otherwise retain DataFusion's native implementation.
+            let input = create_distributed_plan(Arc::clone(analyze.input()), session_state).await?;
+            return match input.is::<DistributedExec>() {
+                true => Ok(Arc::new(DistributedAnalyzeExec::new(analyze, input))),
+                false => Arc::new(analyze.clone()).with_new_children(vec![input]),
+            };
         }
 
         let session_cfg = session_state.config();
@@ -141,7 +168,7 @@ impl QueryPlanner for DistributedQueryPlanner {
         Ok(Arc::new(
             DistributedExec::new(plan).with_metrics_collection(d_cfg.collect_metrics),
         ))
-    }
+    })
 }
 
 #[cfg(test)]

--- a/src/explain_analyze.rs
+++ b/src/explain_analyze.rs
@@ -93,15 +93,13 @@ impl ExecutionPlan for DistributedAnalyzeExec {
                 total_rows += batch.num_rows();
             }
 
-            let plan = explain_analyze(
-                input,
-                match verbose {
-                    true => DistributedMetricsFormat::PerTask,
-                    false => DistributedMetricsFormat::Aggregated,
-                },
-            )
-            .await?;
-            create_output_batch(verbose, total_rows, start.elapsed(), plan, schema)
+            let plan =
+                explain_analyze(Arc::clone(&input), DistributedMetricsFormat::Aggregated).await?;
+            let full_plan = match verbose {
+                true => Some(explain_analyze(input, DistributedMetricsFormat::PerTask).await?),
+                false => None,
+            };
+            create_output_batch(total_rows, start.elapsed(), plan, full_plan, schema)
         };
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(
@@ -112,10 +110,10 @@ impl ExecutionPlan for DistributedAnalyzeExec {
 }
 
 fn create_output_batch(
-    verbose: bool,
     total_rows: usize,
     duration: std::time::Duration,
     plan: String,
+    full_plan: Option<String>,
     schema: SchemaRef,
 ) -> Result<RecordBatch> {
     let mut type_builder = StringBuilder::with_capacity(1, 1024);
@@ -124,9 +122,9 @@ fn create_output_batch(
     type_builder.append_value("Plan with Metrics");
     plan_builder.append_value(&plan);
 
-    if verbose {
+    if let Some(full_plan) = full_plan {
         type_builder.append_value("Plan with Full Metrics");
-        plan_builder.append_value(&plan);
+        plan_builder.append_value(full_plan);
 
         type_builder.append_value("Output Rows");
         plan_builder.append_value(total_rows.to_string());

--- a/src/explain_analyze.rs
+++ b/src/explain_analyze.rs
@@ -1,0 +1,146 @@
+use crate::DistributedMetricsFormat;
+use crate::common::require_one_child;
+use crate::stage::explain_analyze;
+use datafusion::arrow::array::StringBuilder;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::instant::Instant;
+use datafusion::common::{DataFusionError, Result, assert_eq_or_internal_err};
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_plan::analyze::AnalyzeExec;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, Distribution, ExecutionPlan, PlanProperties,
+};
+use futures::{StreamExt, stream};
+use std::fmt::Formatter;
+use std::sync::Arc;
+
+/// Distributed counterpart of DataFusion's [`AnalyzeExec`].
+///
+/// It drains a [`crate::DistributedExec`], waits for metrics from every worker, and returns the
+/// distributed plan with those metrics as the `EXPLAIN ANALYZE` result.
+#[derive(Debug)]
+pub(crate) struct DistributedAnalyzeExec {
+    input: Arc<dyn ExecutionPlan>,
+    verbose: bool,
+    properties: Arc<PlanProperties>,
+}
+
+impl DistributedAnalyzeExec {
+    pub(crate) fn new(analyze_exec: &AnalyzeExec, input: Arc<dyn ExecutionPlan>) -> Self {
+        Self {
+            input,
+            verbose: analyze_exec.verbose(),
+            properties: Arc::clone(analyze_exec.properties()),
+        }
+    }
+}
+
+impl DisplayAs for DistributedAnalyzeExec {
+    fn fmt_as(&self, _: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "DistributedAnalyzeExec verbose={}", self.verbose)
+    }
+}
+
+impl ExecutionPlan for DistributedAnalyzeExec {
+    fn name(&self) -> &str {
+        "DistributedAnalyzeExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        vec![Distribution::UnspecifiedDistribution]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(Self {
+            input: require_one_child(&children)?,
+            verbose: self.verbose,
+            properties: Arc::clone(&self.properties),
+        }))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        assert_eq_or_internal_err!(
+            partition,
+            0,
+            "DistributedAnalyzeExec invalid partition. Expected 0, got {partition}"
+        );
+
+        let mut input_stream = self.input.execute(0, context)?;
+        let input = Arc::clone(&self.input);
+        let schema = self.schema();
+        let verbose = self.verbose;
+        let output = async move {
+            let start = Instant::now();
+            let mut total_rows = 0;
+            while let Some(batch) = input_stream.next().await.transpose()? {
+                total_rows += batch.num_rows();
+            }
+
+            let plan = explain_analyze(
+                input,
+                match verbose {
+                    true => DistributedMetricsFormat::PerTask,
+                    false => DistributedMetricsFormat::Aggregated,
+                },
+            )
+            .await?;
+            create_output_batch(verbose, total_rows, start.elapsed(), plan, schema)
+        };
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            self.schema(),
+            stream::once(output),
+        )))
+    }
+}
+
+fn create_output_batch(
+    verbose: bool,
+    total_rows: usize,
+    duration: std::time::Duration,
+    plan: String,
+    schema: SchemaRef,
+) -> Result<RecordBatch> {
+    let mut type_builder = StringBuilder::with_capacity(1, 1024);
+    let mut plan_builder = StringBuilder::with_capacity(1, 1024);
+
+    type_builder.append_value("Plan with Metrics");
+    plan_builder.append_value(&plan);
+
+    if verbose {
+        type_builder.append_value("Plan with Full Metrics");
+        plan_builder.append_value(&plan);
+
+        type_builder.append_value("Output Rows");
+        plan_builder.append_value(total_rows.to_string());
+
+        type_builder.append_value("Duration");
+        plan_builder.append_value(format!("{duration:?}"));
+    }
+
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(type_builder.finish()),
+            Arc::new(plan_builder.finish()),
+        ],
+    )
+    .map_err(DataFusionError::from)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod coordinator;
 mod distributed_ext;
 mod distributed_planner;
 mod execution_plans;
+mod explain_analyze;
 mod metrics;
 mod passthrough_headers;
 mod protocol;

--- a/tests/explain_analyze.rs
+++ b/tests/explain_analyze.rs
@@ -1,0 +1,95 @@
+#[cfg(all(feature = "integration", test))]
+mod tests {
+    use datafusion::arrow::array::{Array, StringArray};
+    use datafusion::arrow::util::pretty::pretty_format_batches;
+    use datafusion::common::{Result, assert_contains};
+    use datafusion::physical_plan::execute_stream;
+    use datafusion_distributed::test_utils::localhost::start_localhost_context;
+    use datafusion_distributed::test_utils::parquet::register_parquet_tables;
+    use datafusion_distributed::{DefaultSessionBuilder, DistributedExt};
+    use futures::TryStreamExt;
+    use test_case::test_case;
+
+    #[test_case(false ; "static_task_count")]
+    #[test_case(true ; "dynamic_task_count")]
+    #[tokio::test]
+    async fn explain_analyze_displays_distributed_metrics(
+        dynamic_task_count: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (mut ctx, _guard, _) = start_localhost_context(3, DefaultSessionBuilder).await;
+        ctx.set_distributed_dynamic_task_count(dynamic_task_count)?;
+        register_parquet_tables(&ctx).await?;
+
+        let plan = ctx
+            .sql(
+                r#"EXPLAIN ANALYZE
+                   SELECT count(*), "RainToday"
+                   FROM weather
+                   GROUP BY "RainToday"
+                   ORDER BY count(*)"#,
+            )
+            .await?
+            .create_physical_plan()
+            .await?;
+        assert_eq!(plan.name(), "DistributedAnalyzeExec");
+        assert_eq!(plan.children()[0].name(), "DistributedExec");
+
+        let batches = execute_stream(plan, ctx.task_ctx())?
+            .try_collect::<Vec<_>>()
+            .await?;
+        let formatted = pretty_format_batches(&batches)?.to_string();
+        println!("{formatted}");
+
+        assert_contains!(&formatted, "Plan with Metrics");
+        assert_contains!(&formatted, "DistributedExec");
+        assert_contains!(&formatted, "NetworkShuffleExec");
+        assert_contains!(&formatted, "metrics=[output_rows=");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn explain_analyze_verbose_displays_additional_metrics()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (ctx, _guard, _) = start_localhost_context(3, DefaultSessionBuilder).await;
+        register_parquet_tables(&ctx).await?;
+
+        let plan = ctx
+            .sql(
+                r#"EXPLAIN ANALYZE VERBOSE
+                   SELECT count(*), "RainToday"
+                   FROM weather
+                   GROUP BY "RainToday"
+                   ORDER BY count(*)"#,
+            )
+            .await?
+            .create_physical_plan()
+            .await?;
+        assert_eq!(plan.name(), "DistributedAnalyzeExec");
+        assert_eq!(plan.children()[0].name(), "DistributedExec");
+
+        let batches = execute_stream(plan, ctx.task_ctx())?
+            .try_collect::<Vec<_>>()
+            .await?;
+        let formatted = pretty_format_batches(&batches)?.to_string();
+        println!("{formatted}");
+
+        assert_contains!(&formatted, "Plan with Full Metrics");
+        assert_contains!(&formatted, "Output Rows");
+        assert_contains!(&formatted, "Duration");
+        assert_contains!(&formatted, "metrics=[output_rows=");
+
+        let plan_types = batches[0].column(0).as_any().downcast_ref::<StringArray>();
+        let plans = batches[0].column(1).as_any().downcast_ref::<StringArray>();
+        let (plan_types, plans) = match (plan_types, plans) {
+            (Some(plan_types), Some(plans)) => (plan_types, plans),
+            _ => panic!("EXPLAIN ANALYZE columns should be strings"),
+        };
+        let output_rows = (0..plan_types.len())
+            .find(|index| plan_types.value(*index) == "Output Rows")
+            .expect("verbose output should contain an Output Rows entry");
+        assert_eq!(plans.value(output_rows), "2");
+
+        Ok(())
+    }
+}

--- a/tests/explain_analyze.rs
+++ b/tests/explain_analyze.rs
@@ -2,7 +2,7 @@
 mod tests {
     use datafusion::arrow::array::{Array, StringArray};
     use datafusion::arrow::util::pretty::pretty_format_batches;
-    use datafusion::common::{Result, assert_contains};
+    use datafusion::common::{Result, assert_contains, assert_not_contains};
     use datafusion::physical_plan::execute_stream;
     use datafusion_distributed::test_utils::localhost::start_localhost_context;
     use datafusion_distributed::test_utils::parquet::register_parquet_tables;
@@ -44,6 +44,7 @@ mod tests {
         assert_contains!(&formatted, "DistributedExec");
         assert_contains!(&formatted, "NetworkShuffleExec");
         assert_contains!(&formatted, "metrics=[output_rows=");
+        assert_not_contains!(&formatted, "metrics=[output_rows={");
 
         Ok(())
     }
@@ -85,10 +86,15 @@ mod tests {
             (Some(plan_types), Some(plans)) => (plan_types, plans),
             _ => panic!("EXPLAIN ANALYZE columns should be strings"),
         };
-        let output_rows = (0..plan_types.len())
-            .find(|index| plan_types.value(*index) == "Output Rows")
-            .expect("verbose output should contain an Output Rows entry");
-        assert_eq!(plans.value(output_rows), "2");
+        let plan_for = |plan_type| {
+            let index = (0..plan_types.len())
+                .find(|index| plan_types.value(*index) == plan_type)
+                .unwrap_or_else(|| panic!("verbose output should contain a {plan_type} entry"));
+            plans.value(index)
+        };
+        assert_not_contains!(plan_for("Plan with Metrics"), "metrics=[output_rows={");
+        assert_contains!(plan_for("Plan with Full Metrics"), "metrics=[output_rows={");
+        assert_eq!(plan_for("Output Rows"), "2");
 
         Ok(())
     }


### PR DESCRIPTION
Closes #476

Adds native support for EXPLAIN ANALYZE in a distributed context. Here's an example output:


```sql
EXPLAIN ANALYZE VERBOSE
SELECT count(*), "RainToday"
FROM weather
GROUP BY "RainToday"
ORDER BY count(*)   
```

```
+------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type              | plan                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Plan with Metrics      | ┌───── DistributedExec ── plan_send_latency_avg={0:13.74ms}, plan_send_latency_max={0:14.04ms}, plan_bytes_sent={0:19.2 KB}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
|                        | │ SortPreservingMergeExec: [count(*)@0 ASC NULLS LAST], metrics=[output_rows=2, elapsed_compute=186.00µs, output_bytes=48.0 B, output_batches=1]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
|                        | │   [Stage 2] => NetworkCoalesceExec: output_partitions=6, input_tasks=2, metrics=[elapsed_compute=285.62µs, output_bytes=48.0 B, msg_count=8, network_latency_count=8, max_mem_used=1.62 K, network_latency_sum=9.19ms, bytes_transferred=2.2 KB, network_latency_first=1.80ms, network_latency_max=1.80ms, network_latency_min=319.00µs, network_latency_p50=1.24ms, network_latency_p95=1.48ms]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
|                        | └──────────────────────────────────────────────────                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
|                        |   ┌───── Stage 2 ── tasks=2, partitions=3 plan_added_at={0:16.67ms, 1:15.03ms}, plan_executed_at={0:16.73ms, 1:15.12ms}, plan_finished_at={0:34.92ms, 1:34.88ms}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
|                        |   │ SortExec: expr=[count(*)@0 ASC NULLS LAST], preserve_partitioning=[true], metrics=[output_rows=2, elapsed_compute=15.67µs, output_bytes=0.0 B, output_batches=0, spill_count=0, spilled_bytes=0.0 B, spilled_rows=0]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
|                        |   │   ProjectionExec: expr=[count(Int64(1))@1 as count(*), RainToday@0 as RainToday], metrics=[output_rows=2, elapsed_compute=7.71µs, output_bytes=192.0 B, output_batches=2, expr_0_eval_time=545ns, expr_1_eval_time=170ns]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
|                        |   │     AggregateExec: mode=FinalPartitioned, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))], metrics=[output_rows=2, elapsed_compute=300.04µs, output_bytes=192.0 B, output_batches=2, spill_count=0, spilled_bytes=0.0 B, spilled_rows=0, peak_mem_used=2.69 K, aggregate_arguments_time=8.55µs, aggregation_time=78.09µs, emitting_time=6.34µs, time_calculating_group_ids=18.30µs]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
|                        |   │       [Stage 1] => NetworkShuffleExec: output_partitions=3, input_tasks=3, metrics=[elapsed_compute=622.84µs, output_bytes=144.0 B, local_connections_used=6, msg_count=16, network_latency_count=16, max_mem_used=4.00 K, network_latency_sum=35.83ms, bytes_transferred=4.6 KB, network_latency_first=3.49ms, network_latency_max=3.49ms, network_latency_min=425.00µs, network_latency_p50=3.24ms, network_latency_p95=3.37ms]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
|                        |   └──────────────────────────────────────────────────                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
|                        |     ┌───── Stage 1 ── tasks=3, partitions=6 plan_added_at={0:13.52ms, 1:16.25ms, 2:14.44ms}, plan_executed_at={0:20.36ms, 1:17.86ms, 2:17.18ms}, plan_finished_at={0:34.06ms, 1:34.90ms, 2:34.86ms}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
|                        |     │ RepartitionExec: partitioning=Hash([RainToday@0], 6), input_partitions=3, metrics=[output_rows=6, elapsed_compute=28.00µs, output_bytes=768.0 KB, output_batches=4, spill_count=0, spilled_bytes=0.0 B, spilled_rows=0, fetch_time=69.44ms, repartition_time=287.46µs, send_time=125.67µs]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
|                        |     │   AggregateExec: mode=Partial, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))], metrics=[output_rows=6, elapsed_compute=523.67µs, output_bytes=288.0 B, output_batches=3, spill_count=0, spilled_bytes=0.0 B, spilled_rows=0, skipped_aggregation_rows=0, peak_mem_used=8.93 K, aggregate_arguments_time=36.63µs, aggregation_time=48.17µs, emitting_time=12.63µs, time_calculating_group_ids=183.17µs, reduction_factor=1.64% (6/366)]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
|                        |     │     DistributedLeafExec:, metrics=[output_rows=366, elapsed_compute=16.81µs, output_bytes=7.9 KB, output_batches=3, files_ranges_pruned_statistics=11 total → 11 matched, row_groups_pruned_statistics=3 total → 3 matched, row_groups_pruned_bloom_filter=3 total → 3 matched, page_index_pages_pruned=0 total → 0 matched, page_index_rows_pruned=0 total → 0 matched, limit_pruned_row_groups=0 total → 0 matched, batches_split=0, bytes_scanned=3.12 K, file_open_errors=0, file_scan_errors=0, files_opened=11, files_processed=11, num_predicate_creation_errors=0, predicate_evaluation_errors=0, pushdown_rows_matched=0, pushdown_rows_pruned=0, predicate_cache_inner_records=0, predicate_cache_records=0, bloom_filter_eval_time=723ns, metadata_load_time=61.58ms, page_index_eval_time=22ns, row_pushdown_eval_time=22ns, statistics_eval_time=22ns, time_elapsed_opening=63.30ms, time_elapsed_processing=7.49ms, time_elapsed_scanning_total=5.65ms, time_elapsed_scanning_until_data=5.15ms, output_rows_skew=75% (15.00 K/20.00 K), scan_efficiency_ratio=0.62% (3.12 K/504.0 K)]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
|                        |     │       t0: DataSourceExec: file_groups={3 groups: [[Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000000.parquet:0..15264], [Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000000.parquet:45792..46084, Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000001.parquet:0..14972], [Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000002.parquet:39..15303]]}, projection=[RainToday], file_type=parquet                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
|                        |     │       t1: DataSourceExec: file_groups={3 groups: [[Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000000.parquet:15264..30528], [Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000001.parquet:14972..30236], [Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000002.parquet:15303..30567]]}, projection=[RainToday], file_type=parquet                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
|                        |     │       t2: DataSourceExec: file_groups={3 groups: [[Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000000.parquet:30528..45792], [Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000001.parquet:30236..45461, Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000002.parquet:0..39], [Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000002.parquet:30567..45824]]}, projection=[RainToday], file_type=parquet                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
|                        |     └──────────────────────────────────────────────────                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
|                        |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| Plan with Full Metrics | ┌───── DistributedExec ── plan_send_latency_avg={0:13.74ms}, plan_send_latency_max={0:14.04ms}, plan_bytes_sent={0:19.2 KB}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
|                        | │ SortPreservingMergeExec: [count(*)@0 ASC NULLS LAST], metrics=[output_rows={0:2}, elapsed_compute={0:186.00µs}, output_bytes={0:48.0 B}, output_batches={0:1}]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
|                        | │   [Stage 2] => NetworkCoalesceExec: output_partitions=6, input_tasks=2, metrics=[elapsed_compute={0:285.62µs}, output_bytes={0:48.0 B}, msg_count={0:8}, network_latency_count={0:8}, max_mem_used={0:1.62 K}, network_latency_sum={0:9.19ms}, bytes_transferred={0:2.2 KB}, network_latency_first={0:1.80ms}, network_latency_max={0:1.80ms}, network_latency_min={0:319.00µs}, network_latency_p50={0:1.24ms}, network_latency_p95={0:1.48ms}]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
|                        | └──────────────────────────────────────────────────                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
|                        |   ┌───── Stage 2 ── tasks=2, partitions=3 plan_added_at={0:16.67ms, 1:15.03ms}, plan_executed_at={0:16.73ms, 1:15.12ms}, plan_finished_at={0:34.92ms, 1:34.88ms}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
|                        |   │ SortExec: expr=[count(*)@0 ASC NULLS LAST], preserve_partitioning=[true], metrics=[output_rows={0:2, 1:0}, elapsed_compute={0:15.67µs, 1:3ns}, output_bytes={0:0.0 B, 1:0.0 B}, output_batches={0:0, 1:0}, spill_count={0:0, 1:0}, spilled_bytes={0:0.0 B, 1:0.0 B}, spilled_rows={0:0, 1:0}]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
|                        |   │   ProjectionExec: expr=[count(Int64(1))@1 as count(*), RainToday@0 as RainToday], metrics=[output_rows={0:2, 1:0}, elapsed_compute={0:7.71µs, 1:3ns}, output_bytes={0:192.0 B, 1:0.0 B}, output_batches={0:2, 1:0}, expr_0_eval_time={0:542ns, 1:3ns}, expr_1_eval_time={0:167ns, 1:3ns}]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
|                        |   │     AggregateExec: mode=FinalPartitioned, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))], metrics=[output_rows={0:2, 1:0}, elapsed_compute={0:197.54µs, 1:102.50µs}, output_bytes={0:192.0 B, 1:0.0 B}, output_batches={0:2, 1:0}, spill_count={0:0, 1:0}, spilled_bytes={0:0.0 B, 1:0.0 B}, spilled_rows={0:0, 1:0}, peak_mem_used={0:1.78 K, 1:912}, aggregate_arguments_time={0:8.54µs, 1:3ns}, aggregation_time={0:78.08µs, 1:3ns}, emitting_time={0:6.33µs, 1:3ns}, time_calculating_group_ids={0:18.29µs, 1:3ns}]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
|                        |   │       [Stage 1] => NetworkShuffleExec: output_partitions=3, input_tasks=3, metrics=[elapsed_compute={0:435.83µs, 1:187.00µs}, output_bytes={0:144.0 B, 1:0.0 B}, local_connections_used={0:3, 1:3}, msg_count={0:10, 1:6}, network_latency_count={0:10, 1:6}, max_mem_used={0:2.65 K, 1:1.35 K}, network_latency_sum={0:22.68ms, 1:13.15ms}, bytes_transferred={0:3.2 KB, 1:1350.0 B}, network_latency_first={0:3.49ms, 1:1.09ms}, network_latency_max={0:3.49ms, 1:3.33ms}, network_latency_min={0:425.00µs, 1:1.04ms}, network_latency_p50={0:3.24ms, 1:1.10ms}, network_latency_p95={0:3.37ms, 1:3.30ms}]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
|                        |   └──────────────────────────────────────────────────                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
|                        |     ┌───── Stage 1 ── tasks=3, partitions=6 plan_added_at={0:13.52ms, 1:16.25ms, 2:14.44ms}, plan_executed_at={0:20.36ms, 1:17.86ms, 2:17.18ms}, plan_finished_at={0:34.06ms, 1:34.90ms, 2:34.86ms}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
|                        |     │ RepartitionExec: partitioning=Hash([RainToday@0], 6), input_partitions=3, metrics=[output_rows={0:4, 1:0, 2:2}, elapsed_compute={0:10.21µs, 1:5.75µs, 2:12.04µs}, output_bytes={0:384.0 KB, 1:0.0 B, 2:384.0 KB}, output_batches={0:2, 1:0, 2:2}, spill_count={0:0, 1:0, 2:0}, spilled_bytes={0:0.0 B, 1:0.0 B, 2:0.0 B}, spilled_rows={0:0, 1:0, 2:0}, fetch_time={0:28.58ms, 1:17.71ms, 2:23.15ms}, repartition_time={0:25.79µs, 1:3ns, 2:261.67µs}, send_time={0:13.85µs, 1:18ns, 2:111.81µs}]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
|                        |     │   AggregateExec: mode=Partial, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))], metrics=[output_rows={0:4, 1:0, 2:2}, elapsed_compute={0:152.88µs, 1:30.67µs, 2:340.12µs}, output_bytes={0:192.0 B, 1:0.0 B, 2:96.0 B}, output_batches={0:2, 1:0, 2:1}, spill_count={0:0, 1:0, 2:0}, spilled_bytes={0:0.0 B, 1:0.0 B, 2:0.0 B}, spilled_rows={0:0, 1:0, 2:0}, skipped_aggregation_rows={0:0, 1:0, 2:0}, peak_mem_used={0:5.04 K, 1:912, 2:2.98 K}, aggregate_arguments_time={0:8.04µs, 1:3ns, 2:28.59µs}, aggregation_time={0:6.54µs, 1:3ns, 2:41.63µs}, emitting_time={0:6.92µs, 1:3ns, 2:5.71µs}, time_calculating_group_ids={0:52.92µs, 1:3ns, 2:130.25µs}, reduction_factor={0:1.64% (4/244), 1:N/A (0/0), 2:1.64% (2/122)}]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
|                        |     │     DistributedLeafExec:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
|                        |     │       t0: DataSourceExec: file_groups={3 groups: [[Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000000.parquet:0..15264], [Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000000.parquet:45792..46084, Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000001.parquet:0..14972], [Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000002.parquet:39..15303]]}, projection=[RainToday], file_type=parquet, metrics=[output_rows={0:244}, elapsed_compute={0:7.34µs}, output_bytes={0:5.3 KB}, output_batches={0:2}, files_ranges_pruned_statistics={0:4 total → 4 matched}, row_groups_pruned_statistics={0:2 total → 2 matched}, row_groups_pruned_bloom_filter={0:2 total → 2 matched}, page_index_pages_pruned={0:0 total → 0 matched}, page_index_rows_pruned={0:0 total → 0 matched}, limit_pruned_row_groups={0:0 total → 0 matched}, batches_split={0:0}, bytes_scanned={0:2.09 K}, file_open_errors={0:0}, file_scan_errors={0:0}, files_opened={0:4}, files_processed={0:4}, num_predicate_creation_errors={0:0}, predicate_evaluation_errors={0:0}, pushdown_rows_matched={0:0}, pushdown_rows_pruned={0:0}, predicate_cache_inner_records={0:0}, predicate_cache_records={0:0}, bloom_filter_eval_time={0:297ns}, metadata_load_time={0:24.28ms}, page_index_eval_time={0:8ns}, row_pushdown_eval_time={0:8ns}, statistics_eval_time={0:8ns}, time_elapsed_opening={0:24.90ms}, time_elapsed_processing={0:2.84ms}, time_elapsed_scanning_total={0:3.53ms}, time_elapsed_scanning_until_data={0:3.38ms}, output_rows_skew={0:50% (5.00 K/10.00 K)}, scan_efficiency_ratio={0:1.14% (2.09 K/183.5 K)}]       |
|                        |     │       t1: DataSourceExec: file_groups={3 groups: [[Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000000.parquet:15264..30528], [Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000001.parquet:14972..30236], [Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000002.parquet:15303..30567]]}, projection=[RainToday], file_type=parquet, metrics=[output_rows={1:0}, elapsed_compute={1:6ns}, output_bytes={1:0.0 B}, output_batches={1:0}, files_ranges_pruned_statistics={1:3 total → 3 matched}, row_groups_pruned_statistics={1:0 total → 0 matched}, row_groups_pruned_bloom_filter={1:0 total → 0 matched}, page_index_pages_pruned={1:0 total → 0 matched}, page_index_rows_pruned={1:0 total → 0 matched}, limit_pruned_row_groups={1:0 total → 0 matched}, batches_split={1:0}, bytes_scanned={1:0}, file_open_errors={1:0}, file_scan_errors={1:0}, files_opened={1:3}, files_processed={1:3}, num_predicate_creation_errors={1:0}, predicate_evaluation_errors={1:0}, pushdown_rows_matched={1:0}, pushdown_rows_pruned={1:0}, predicate_cache_inner_records={1:0}, predicate_cache_records={1:0}, bloom_filter_eval_time={1:129ns}, metadata_load_time={1:17.35ms}, page_index_eval_time={1:6ns}, row_pushdown_eval_time={1:6ns}, statistics_eval_time={1:6ns}, time_elapsed_opening={1:17.61ms}, time_elapsed_processing={1:1.47ms}, time_elapsed_scanning_total={1:22.33µs}, time_elapsed_scanning_until_data={1:22.21µs}, output_rows_skew={1:N/A (0/0)}, scan_efficiency_ratio={1:0% (0/137.4 K)}]                                                                                                                                     |
|                        |     │       t2: DataSourceExec: file_groups={3 groups: [[Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000000.parquet:30528..45792], [Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000001.parquet:30236..45461, Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000002.parquet:0..39], [Users/gabriel.musatmestre/github/datafusion-distributed/testdata/weather/result-000002.parquet:30567..45824]]}, projection=[RainToday], file_type=parquet, metrics=[output_rows={2:122}, elapsed_compute={2:9.46µs}, output_bytes={2:2.6 KB}, output_batches={2:1}, files_ranges_pruned_statistics={2:4 total → 4 matched}, row_groups_pruned_statistics={2:1 total → 1 matched}, row_groups_pruned_bloom_filter={2:1 total → 1 matched}, page_index_pages_pruned={2:0 total → 0 matched}, page_index_rows_pruned={2:0 total → 0 matched}, limit_pruned_row_groups={2:0 total → 0 matched}, batches_split={2:0}, bytes_scanned={2:1.03 K}, file_open_errors={2:0}, file_scan_errors={2:0}, files_opened={2:4}, files_processed={2:4}, num_predicate_creation_errors={2:0}, predicate_evaluation_errors={2:0}, pushdown_rows_matched={2:0}, pushdown_rows_pruned={2:0}, predicate_cache_inner_records={2:0}, predicate_cache_records={2:0}, bloom_filter_eval_time={2:297ns}, metadata_load_time={2:19.94ms}, page_index_eval_time={2:8ns}, row_pushdown_eval_time={2:8ns}, statistics_eval_time={2:8ns}, time_elapsed_opening={2:20.80ms}, time_elapsed_processing={2:3.18ms}, time_elapsed_scanning_total={2:2.09ms}, time_elapsed_scanning_until_data={2:1.75ms}, output_rows_skew={2:100% (10.00 K/10.00 K)}, scan_efficiency_ratio={2:0.56% (1.03 K/183.2 K)}] |
|                        |     └──────────────────────────────────────────────────                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
|                        |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| Output Rows            | 2                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
| Duration               | 42.275875ms                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```
