### PR TITLE
Make desired task-count handlers async

### DIFF
--- a/docs/source/user-guide/04-distribute-custom-plan.md
+++ b/docs/source/user-guide/04-distribute-custom-plan.md
@@ -107,13 +107,15 @@ many tasks the stage containing your leaf should run on.
 For a sharded scan, one task per shard is a natural choice:
 
 ```rust
+use datafusion::common::Result;
+
 fn sharded_scan_desired_task_count(
     event: DesiredTaskCountEvent,
-) -> Option<DesiredTaskCountEventResponse> {
+) -> Option<Result<DesiredTaskCountEventResponse>> {
     // Only handle our own node; returning None lets other handlers try.
     let scan = event.plan.downcast_ref::<ShardedScanExec>()?;
     // One task per shard — the planner caps this at the number of workers.
-    Some(DesiredTaskCountEventResponse::desired(scan.shards.len()))
+    Some(Ok(DesiredTaskCountEventResponse::desired(scan.shards.len())))
 }
 ```
 
@@ -126,6 +128,7 @@ What the return value means:
   cannot be distributed."
 - `None` — defer to the other registered handlers (and finally the built-in
   file-scan handler).
+- `Some(Err(...))` — stop planning and return the error to the caller.
 
 To send each task to a specific worker instead of the default round-robin, see
 [Routing tasks to workers](../advanced/06-worker-routing.md).

--- a/examples/custom_execution_plan.rs
+++ b/examples/custom_execution_plan.rs
@@ -300,16 +300,16 @@ impl ConfigExtension for NumbersConfig {
 
 fn numbers_desired_task_count_handler(
     ev: DesiredTaskCountEvent,
-) -> Option<DesiredTaskCountEventResponse> {
+) -> Option<Result<DesiredTaskCountEventResponse>> {
     let cfg = ev.session_config;
     let plan = ev.plan.downcast_ref::<NumbersExec>()?;
     let cfg: &NumbersConfig = cfg.options().extensions.get()?;
     let task_count = (plan.ranges_per_task[0].end - plan.ranges_per_task[0].start) as f64
         / cfg.numbers_per_task as f64;
 
-    Some(DesiredTaskCountEventResponse::desired(
-        task_count.ceil() as usize
-    ))
+    Some(Ok(DesiredTaskCountEventResponse::desired(
+        task_count.ceil() as usize,
+    )))
 }
 
 fn numbers_scale_up_leaf_node_handler(

--- a/examples/custom_worker_url_routing.rs
+++ b/examples/custom_worker_url_routing.rs
@@ -159,9 +159,9 @@ fn hash_key(file_group: &FileGroup) -> usize {
 
 fn cached_file_scan_desired_task_count_handler(
     ev: DesiredTaskCountEvent,
-) -> Option<DesiredTaskCountEventResponse> {
+) -> Option<Result<DesiredTaskCountEventResponse>> {
     ev.plan.downcast_ref::<CacheExec>()?;
-    Some(DesiredTaskCountEventResponse::desired(usize::MAX))
+    Some(Ok(DesiredTaskCountEventResponse::desired(usize::MAX)))
 }
 
 fn cached_file_scan_scale_up_leaf_node_handler(

--- a/examples/work_unit_feed.rs
+++ b/examples/work_unit_feed.rs
@@ -245,14 +245,14 @@ impl PhysicalExtensionCodec for RemoteScanExecCodec {
 
 fn remote_scan_desired_task_count_handler(
     ev: DesiredTaskCountEvent,
-) -> Option<DesiredTaskCountEventResponse> {
+) -> Option<Result<DesiredTaskCountEventResponse>> {
     let task_count = ev
         .plan
         .downcast_ref::<RemoteScanExec>()?
         .feed
         .inner()?
         .task_count;
-    Some(DesiredTaskCountEventResponse::desired(task_count))
+    Some(Ok(DesiredTaskCountEventResponse::desired(task_count)))
 }
 
 fn remote_scan_scale_up_leaf_node_handler(

--- a/src/distributed_ext.rs
+++ b/src/distributed_ext.rs
@@ -584,11 +584,12 @@ pub trait DistributedExt: Sized {
     /// ```rust
     /// # use datafusion::execution::SessionStateBuilder;
     /// # use datafusion::physical_plan::empty::EmptyExec;
+    /// # use datafusion::common::Result;
     /// # use datafusion_distributed::{DistributedExt, DesiredTaskCountEvent, DesiredTaskCountEventResponse};
     ///
-    /// fn handle_custom_desired_task_count(event: DesiredTaskCountEvent) -> Option<DesiredTaskCountEventResponse> {
+    /// fn handle_custom_desired_task_count(event: DesiredTaskCountEvent) -> Option<Result<DesiredTaskCountEventResponse>> {
     ///     let _exec = event.plan.downcast_ref::<EmptyExec>()?;
-    ///     Some(DesiredTaskCountEventResponse::desired(3))
+    ///     Some(Ok(DesiredTaskCountEventResponse::desired(3)))
     /// }
     ///
     /// SessionStateBuilder::new()

--- a/src/distributed_planner/inject_network_boundaries.rs
+++ b/src/distributed_planner/inject_network_boundaries.rs
@@ -237,7 +237,7 @@ async fn _inject_network_boundaries(
             plan: &plan,
             session_config: nb_ctx.cfg,
         };
-        return if let Some(estimate) = DesiredTaskCountHandlers::handle(ev).await {
+        return if let Some(estimate) = DesiredTaskCountHandlers::handle(ev).await.transpose()? {
             Ok(nb_ctx.plan_with_task_count(plan, estimate.task_count.limit(nb_ctx.max_tasks()?)))
         } else {
             // We could not determine how many tasks this leaf node should run on, so
@@ -263,10 +263,11 @@ async fn _inject_network_boundaries(
     };
     let mut task_count = DesiredTaskCountHandlers::handle(ev)
         .await
+        .transpose()?
         .map_or(Desired(1), |v| v.task_count);
-    if nb_ctx.d_cfg.children_isolator_unions && plan.is::<UnionExec>() {
-        // Unions have the chance to decide how many tasks they should run on. If there's a union
-        // with a bunch of children, the user might want to increase parallelism and increase the
+    if plan.is::<ChildrenIsolatorUnionExec>() {
+        // Isolating unions have the chance to decide how many tasks they should run on. If there
+        // is a union with a bunch of children, the user might want to increase parallelism and the
         // task count for the stage running that.
         let mut count = 0;
         for processed_child in processed_children.iter() {
@@ -1191,20 +1192,19 @@ mod tests {
 
     fn repartition_max_one_desired_task_count_handler(
         ev: DesiredTaskCountEvent,
-    ) -> Option<DesiredTaskCountEventResponse> {
-        ev.plan
-            .is::<RepartitionExec>()
-            .then(|| DesiredTaskCountEventResponse::maximum(1))
+    ) -> Option<Result<DesiredTaskCountEventResponse>> {
+        ev.plan.downcast_ref::<RepartitionExec>()?;
+        Some(Ok(DesiredTaskCountEventResponse::maximum(1)))
     }
 
     fn broadcast_build_coalesce_max_desired_task_count_handler(
         ev: DesiredTaskCountEvent,
-    ) -> Option<DesiredTaskCountEventResponse> {
+    ) -> Option<Result<DesiredTaskCountEventResponse>> {
         ev.plan
             .downcast_ref::<CoalescePartitionsExec>()?
             .input()
-            .is::<BroadcastExec>()
-            .then(|| DesiredTaskCountEventResponse::maximum(1))
+            .downcast_ref::<BroadcastExec>()?;
+        Some(Ok(DesiredTaskCountEventResponse::maximum(1)))
     }
 
     async fn annotate_test_plan(test_plan_builder: TestPlanBuilder, query: &str) -> String {

--- a/src/distributed_planner/inject_network_boundaries.rs
+++ b/src/distributed_planner/inject_network_boundaries.rs
@@ -237,7 +237,7 @@ async fn _inject_network_boundaries(
             plan: &plan,
             session_config: nb_ctx.cfg,
         };
-        return if let Some(estimate) = DesiredTaskCountHandlers::handle(ev) {
+        return if let Some(estimate) = DesiredTaskCountHandlers::handle(ev).await {
             Ok(nb_ctx.plan_with_task_count(plan, estimate.task_count.limit(nb_ctx.max_tasks()?)))
         } else {
             // We could not determine how many tasks this leaf node should run on, so
@@ -261,10 +261,12 @@ async fn _inject_network_boundaries(
         plan: &plan,
         session_config: nb_ctx.cfg,
     };
-    let mut task_count = DesiredTaskCountHandlers::handle(ev).map_or(Desired(1), |v| v.task_count);
-    if plan.is::<ChildrenIsolatorUnionExec>() {
-        // Isolating unions have the chance to decide how many tasks they should run on. If there
-        // is a union with a bunch of children, the user might want to increase parallelism and the
+    let mut task_count = DesiredTaskCountHandlers::handle(ev)
+        .await
+        .map_or(Desired(1), |v| v.task_count);
+    if nb_ctx.d_cfg.children_isolator_unions && plan.is::<UnionExec>() {
+        // Unions have the chance to decide how many tasks they should run on. If there's a union
+        // with a bunch of children, the user might want to increase parallelism and increase the
         // task count for the stage running that.
         let mut count = 0;
         for processed_child in processed_children.iter() {

--- a/src/events/common.rs
+++ b/src/events/common.rs
@@ -26,11 +26,7 @@ impl<H: ?Sized> Clone for EventHandlerChain<H> {
 
 impl<H: ?Sized> EventHandlerChain<H> {
     pub(super) fn iter(&self) -> impl Iterator<Item = &H> {
-        self.custom
-            .iter()
-            .rev()
-            .chain(&self.builtin)
-            .map(AsRef::as_ref)
+        self.custom.iter().chain(&self.builtin).map(AsRef::as_ref)
     }
 
     pub(super) fn find_map<T>(&self, mut f: impl FnMut(&H) -> Option<T>) -> Option<T> {

--- a/src/events/common.rs
+++ b/src/events/common.rs
@@ -25,6 +25,14 @@ impl<H: ?Sized> Clone for EventHandlerChain<H> {
 }
 
 impl<H: ?Sized> EventHandlerChain<H> {
+    pub(super) fn iter(&self) -> impl Iterator<Item = &H> {
+        self.custom
+            .iter()
+            .rev()
+            .chain(&self.builtin)
+            .map(AsRef::as_ref)
+    }
+
     pub(super) fn find_map<T>(&self, mut f: impl FnMut(&H) -> Option<T>) -> Option<T> {
         // Give priority to custom handlers registered by users.
         if let Some(res) = self.custom.iter().find_map(|handler| f(handler.as_ref())) {

--- a/src/events/defaults/file_scan_config.rs
+++ b/src/events/defaults/file_scan_config.rs
@@ -115,6 +115,7 @@ mod tests {
             plan: &plan,
             session_config: &cfg,
         })
+        .await
         .expect("a handler should respond");
         assert_eq!(response.task_count.as_usize(), 10);
         Ok(())
@@ -131,6 +132,7 @@ mod tests {
             plan: &plan,
             session_config: &cfg,
         })
+        .await
         .expect("a handler should respond");
         assert_eq!(response.task_count.as_usize(), 30);
         Ok(())

--- a/src/events/defaults/file_scan_config.rs
+++ b/src/events/defaults/file_scan_config.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 pub(crate) fn file_scan_config_desired_task_count(
     ev: DesiredTaskCountEvent,
-) -> Option<DesiredTaskCountEventResponse> {
+) -> Option<Result<DesiredTaskCountEventResponse>> {
     let cfg = ev.session_config;
     let dse: &DataSourceExec = ev.plan.downcast_ref()?;
     let file_scan: &FileScanConfig = dse.data_source().downcast_ref()?;
@@ -30,7 +30,7 @@ pub(crate) fn file_scan_config_desired_task_count(
         .div_ceil(d_cfg.file_scan_config_bytes_per_partition)
         .div_ceil(cfg.target_partitions());
 
-    Some(DesiredTaskCountEventResponse::desired(task_count))
+    Some(Ok(DesiredTaskCountEventResponse::desired(task_count)))
 }
 
 pub(crate) fn file_scan_config_scale_up_leaf_node(
@@ -116,7 +116,7 @@ mod tests {
             session_config: &cfg,
         })
         .await
-        .expect("a handler should respond");
+        .expect("a handler should respond")?;
         assert_eq!(response.task_count.as_usize(), 10);
         Ok(())
     }
@@ -133,7 +133,7 @@ mod tests {
             session_config: &cfg,
         })
         .await
-        .expect("a handler should respond");
+        .expect("a handler should respond")?;
         assert_eq!(response.task_count.as_usize(), 30);
         Ok(())
     }
@@ -151,7 +151,7 @@ mod tests {
             plan: &plan,
             session_config: &cfg,
         })
-        .expect("a file scan should be recognized");
+        .expect("a file scan should be recognized")?;
         assert_eq!(response.task_count.as_usize(), 3);
         Ok(())
     }
@@ -199,19 +199,21 @@ mod tests {
         Ok(plan)
     }
 
-    fn desired_ten(_: DesiredTaskCountEvent) -> Option<DesiredTaskCountEventResponse> {
-        Some(DesiredTaskCountEventResponse::desired(10))
+    fn desired_ten(_: DesiredTaskCountEvent) -> Option<Result<DesiredTaskCountEventResponse>> {
+        Some(Ok(DesiredTaskCountEventResponse::desired(10)))
     }
 
-    fn desired_twenty(_: DesiredTaskCountEvent) -> Option<DesiredTaskCountEventResponse> {
-        Some(DesiredTaskCountEventResponse::desired(20))
+    fn desired_twenty(_: DesiredTaskCountEvent) -> Option<Result<DesiredTaskCountEventResponse>> {
+        Some(Ok(DesiredTaskCountEventResponse::desired(20)))
     }
 
-    fn no_desired_task_count(_: DesiredTaskCountEvent) -> Option<DesiredTaskCountEventResponse> {
+    fn no_desired_task_count(
+        _: DesiredTaskCountEvent,
+    ) -> Option<Result<DesiredTaskCountEventResponse>> {
         None
     }
 
-    fn desired_thirty(_: DesiredTaskCountEvent) -> Option<DesiredTaskCountEventResponse> {
-        Some(DesiredTaskCountEventResponse::desired(30))
+    fn desired_thirty(_: DesiredTaskCountEvent) -> Option<Result<DesiredTaskCountEventResponse>> {
+        Some(Ok(DesiredTaskCountEventResponse::desired(30)))
     }
 }

--- a/src/events/desired_task_count.rs
+++ b/src/events/desired_task_count.rs
@@ -1,6 +1,7 @@
 use super::TaskCountAnnotation::{Desired, Maximum};
 use super::common::EventHandlerChain;
 use async_trait::async_trait;
+use datafusion::common::Result;
 use datafusion::execution::config::SessionConfig;
 use datafusion::physical_plan::ExecutionPlan;
 use std::sync::Arc;
@@ -77,7 +78,8 @@ impl DesiredTaskCountEventResponse {
 #[async_trait]
 pub trait DesiredTaskCountHandler: Send + Sync + 'static {
     /// Function applied to each node that returns a [DesiredTaskCountEventResponse] hinting how
-    /// many tasks should be used in the [Stage] containing that node.
+    /// many tasks should be used in the [Stage] containing that node, or an error if the hint
+    /// cannot be determined.
     ///
     /// Handlers are asynchronous and may await metadata or external services. Handler functions
     /// return a [`DesiredTaskCountFuture`] so their futures can borrow from the event.
@@ -91,7 +93,10 @@ pub trait DesiredTaskCountHandler: Send + Sync + 'static {
     ///   that the leaf node cannot be distributed across tasks.
     /// - If the node is a normal node in the plan, then the maximum task count from its children
     ///   is inherited.
-    async fn handle(&self, ev: DesiredTaskCountEvent<'_>) -> Option<DesiredTaskCountEventResponse>;
+    async fn handle(
+        &self,
+        ev: DesiredTaskCountEvent<'_>,
+    ) -> Option<Result<DesiredTaskCountEventResponse>>;
 }
 
 impl From<TaskCountAnnotation> for usize {
@@ -129,26 +134,35 @@ impl TaskCountAnnotation {
 impl<F> DesiredTaskCountHandler for F
 where
     F: Send + Sync + 'static,
-    F: for<'a> Fn(DesiredTaskCountEvent<'a>) -> Option<DesiredTaskCountEventResponse>,
+    F: for<'a> Fn(DesiredTaskCountEvent<'a>) -> Option<Result<DesiredTaskCountEventResponse>>,
 {
-    async fn handle(&self, ev: DesiredTaskCountEvent<'_>) -> Option<DesiredTaskCountEventResponse> {
+    async fn handle(
+        &self,
+        ev: DesiredTaskCountEvent<'_>,
+    ) -> Option<Result<DesiredTaskCountEventResponse>> {
         self(ev)
     }
 }
 
 #[async_trait]
 impl DesiredTaskCountHandler for usize {
-    async fn handle(&self, ev: DesiredTaskCountEvent<'_>) -> Option<DesiredTaskCountEventResponse> {
+    async fn handle(
+        &self,
+        ev: DesiredTaskCountEvent<'_>,
+    ) -> Option<Result<DesiredTaskCountEventResponse>> {
         ev.plan
             .children()
             .is_empty()
-            .then(|| DesiredTaskCountEventResponse::desired(*self))
+            .then(|| Ok(DesiredTaskCountEventResponse::desired(*self)))
     }
 }
 
 #[async_trait]
 impl DesiredTaskCountHandler for Arc<dyn DesiredTaskCountHandler> {
-    async fn handle(&self, ev: DesiredTaskCountEvent<'_>) -> Option<DesiredTaskCountEventResponse> {
+    async fn handle(
+        &self,
+        ev: DesiredTaskCountEvent<'_>,
+    ) -> Option<Result<DesiredTaskCountEventResponse>> {
         self.as_ref().handle(ev).await
     }
 }
@@ -158,7 +172,7 @@ pub(crate) type DesiredTaskCountHandlers = EventHandlerChain<dyn DesiredTaskCoun
 impl DesiredTaskCountHandlers {
     pub(crate) async fn handle(
         ev: DesiredTaskCountEvent<'_>,
-    ) -> Option<DesiredTaskCountEventResponse> {
+    ) -> Option<Result<DesiredTaskCountEventResponse>> {
         let handlers = ev
             .session_config
             .get_extension::<DesiredTaskCountHandlers>()?;

--- a/src/events/desired_task_count.rs
+++ b/src/events/desired_task_count.rs
@@ -1,5 +1,6 @@
 use super::TaskCountAnnotation::{Desired, Maximum};
 use super::common::EventHandlerChain;
+use async_trait::async_trait;
 use datafusion::execution::config::SessionConfig;
 use datafusion::physical_plan::ExecutionPlan;
 use std::sync::Arc;
@@ -73,9 +74,13 @@ impl DesiredTaskCountEventResponse {
     }
 }
 
+#[async_trait]
 pub trait DesiredTaskCountHandler: Send + Sync + 'static {
     /// Function applied to each node that returns a [DesiredTaskCountEventResponse] hinting how
     /// many tasks should be used in the [Stage] containing that node.
+    ///
+    /// Handlers are asynchronous and may await metadata or external services. Handler functions
+    /// return a [`DesiredTaskCountFuture`] so their futures can borrow from the event.
     ///
     /// All the [TaskEstimator] registered in the session will be applied to the node
     /// until one returns an estimation.
@@ -86,7 +91,7 @@ pub trait DesiredTaskCountHandler: Send + Sync + 'static {
     ///   that the leaf node cannot be distributed across tasks.
     /// - If the node is a normal node in the plan, then the maximum task count from its children
     ///   is inherited.
-    fn handle(&self, ev: DesiredTaskCountEvent) -> Option<DesiredTaskCountEventResponse>;
+    async fn handle(&self, ev: DesiredTaskCountEvent<'_>) -> Option<DesiredTaskCountEventResponse>;
 }
 
 impl From<TaskCountAnnotation> for usize {
@@ -120,18 +125,20 @@ impl TaskCountAnnotation {
     }
 }
 
+#[async_trait]
 impl<F> DesiredTaskCountHandler for F
 where
     F: Send + Sync + 'static,
     F: for<'a> Fn(DesiredTaskCountEvent<'a>) -> Option<DesiredTaskCountEventResponse>,
 {
-    fn handle(&self, ev: DesiredTaskCountEvent) -> Option<DesiredTaskCountEventResponse> {
+    async fn handle(&self, ev: DesiredTaskCountEvent<'_>) -> Option<DesiredTaskCountEventResponse> {
         self(ev)
     }
 }
 
+#[async_trait]
 impl DesiredTaskCountHandler for usize {
-    fn handle(&self, ev: DesiredTaskCountEvent) -> Option<DesiredTaskCountEventResponse> {
+    async fn handle(&self, ev: DesiredTaskCountEvent<'_>) -> Option<DesiredTaskCountEventResponse> {
         ev.plan
             .children()
             .is_empty()
@@ -139,18 +146,27 @@ impl DesiredTaskCountHandler for usize {
     }
 }
 
+#[async_trait]
 impl DesiredTaskCountHandler for Arc<dyn DesiredTaskCountHandler> {
-    fn handle(&self, ev: DesiredTaskCountEvent) -> Option<DesiredTaskCountEventResponse> {
-        self.as_ref().handle(ev)
+    async fn handle(&self, ev: DesiredTaskCountEvent<'_>) -> Option<DesiredTaskCountEventResponse> {
+        self.as_ref().handle(ev).await
     }
 }
 
 pub(crate) type DesiredTaskCountHandlers = EventHandlerChain<dyn DesiredTaskCountHandler>;
 
 impl DesiredTaskCountHandlers {
-    pub(crate) fn handle(ev: DesiredTaskCountEvent) -> Option<DesiredTaskCountEventResponse> {
-        ev.session_config
-            .get_extension::<DesiredTaskCountHandlers>()?
-            .find_map(|handler| handler.handle(ev))
+    pub(crate) async fn handle(
+        ev: DesiredTaskCountEvent<'_>,
+    ) -> Option<DesiredTaskCountEventResponse> {
+        let handlers = ev
+            .session_config
+            .get_extension::<DesiredTaskCountHandlers>()?;
+        for handler in handlers.iter() {
+            if let Some(response) = handler.handle(ev).await {
+                return Some(response);
+            }
+        }
+        None
     }
 }

--- a/src/test_utils/plans.rs
+++ b/src/test_utils/plans.rs
@@ -14,15 +14,16 @@ use crate::{
     test_utils::in_memory_channel_resolver::InMemoryWorkerResolver,
 };
 use crate::{NetworkBoundaryExt, TaskKey};
-use datafusion::{
-    common::{HashMap, HashSet},
-    physical_plan::ExecutionPlan,
-};
 #[cfg(test)]
 use datafusion::{
+    common::Result,
     execution::{SessionState, context::SessionContext, session_state::SessionStateBuilder},
     physical_plan::displayable,
     prelude::SessionConfig,
+};
+use datafusion::{
+    common::{HashMap, HashSet},
+    physical_plan::ExecutionPlan,
 };
 use std::sync::Arc;
 
@@ -365,7 +366,7 @@ impl Default for TestPlanBuilder {
 #[cfg(test)]
 pub(crate) fn build_side_one_desired_task_count_handler(
     ev: DesiredTaskCountEvent,
-) -> Option<DesiredTaskCountEventResponse> {
+) -> Option<Result<DesiredTaskCountEventResponse>> {
     let plan = ev.plan;
     if !plan.children().is_empty() {
         return None;
@@ -374,7 +375,7 @@ pub(crate) fn build_side_one_desired_task_count_handler(
     let has_min_temp = schema.fields().iter().any(|f| f.name() == "MinTemp");
     let has_max_temp = schema.fields().iter().any(|f| f.name() == "MaxTemp");
     if has_min_temp && !has_max_temp {
-        Some(DesiredTaskCountEventResponse::maximum(1))
+        Some(Ok(DesiredTaskCountEventResponse::maximum(1)))
     } else {
         None
     }

--- a/src/test_utils/routing.rs
+++ b/src/test_utils/routing.rs
@@ -4,9 +4,8 @@ use arrow::{
 };
 use datafusion::{
     catalog::{Session, TableFunctionImpl, TableProvider},
-    common::{ScalarValue, Statistics, internal_err, plan_err},
+    common::{Result, ScalarValue, Statistics, internal_err, plan_err},
     datasource::TableType,
-    error::Result,
     execution::TaskContext,
     physical_expr::EquivalenceProperties,
     physical_plan::{
@@ -247,10 +246,10 @@ fn url_emitter_schema() -> SchemaRef {
 
 pub fn url_emitter_desired_task_count(
     ev: DesiredTaskCountEvent,
-) -> Option<DesiredTaskCountEventResponse> {
+) -> Option<Result<DesiredTaskCountEventResponse>> {
     ev.plan
         .downcast_ref::<URLEmitterExec>()
-        .map(|exec| DesiredTaskCountEventResponse::desired(exec.task_count))
+        .map(|exec| Ok(DesiredTaskCountEventResponse::desired(exec.task_count)))
 }
 
 pub fn url_emitter_scale_up_leaf_node(

--- a/src/test_utils/test_work_unit_feed.rs
+++ b/src/test_utils/test_work_unit_feed.rs
@@ -321,10 +321,12 @@ impl TableProvider for TestWorkUnitFeedTableProvider {
 
 pub fn row_generator_desired_task_count_handler(
     ev: DesiredTaskCountEvent,
-) -> Option<DesiredTaskCountEventResponse> {
+) -> Option<Result<DesiredTaskCountEventResponse>> {
     let exec = ev.plan.downcast_ref::<RowGeneratorExec>()?;
     let provider = exec.feed.clone().try_into_inner().ok()?;
-    Some(DesiredTaskCountEventResponse::desired(provider.task_count))
+    Some(Ok(DesiredTaskCountEventResponse::desired(
+        provider.task_count,
+    )))
 }
 
 pub fn row_generator_scale_up_leaf_node_handler(

--- a/src/test_utils/work_unit_file_scan.rs
+++ b/src/test_utils/work_unit_file_scan.rs
@@ -355,7 +355,7 @@ impl PhysicalOptimizerRule for WorkUnitFileScanRule {
 /// `file_scan_config_bytes_per_partition * target_partitions` bytes.
 pub fn work_unit_file_scan_desired_task_count(
     ev: DesiredTaskCountEvent,
-) -> Option<DesiredTaskCountEventResponse> {
+) -> Option<Result<DesiredTaskCountEventResponse>> {
     let cfg = ev.session_config;
     let dse = ev.plan.downcast_ref::<DataSourceExec>()?;
     let wfs = dse.data_source().downcast_ref::<WorkUnitFileScanConfig>()?;
@@ -373,7 +373,7 @@ pub fn work_unit_file_scan_desired_task_count(
         .div_ceil(d_cfg.file_scan_config_bytes_per_partition)
         .div_ceil(cfg.target_partitions());
 
-    Some(DesiredTaskCountEventResponse::desired(task_count))
+    Some(Ok(DesiredTaskCountEventResponse::desired(task_count)))
 }
 
 /// Rebuilds a work-unit file scan after the stage task count is finalized.


### PR DESCRIPTION
## Stack

1. https://github.com/datafusion-contrib/datafusion-distributed/pull/564
2. https://github.com/datafusion-contrib/datafusion-distributed/pull/567
3. https://github.com/datafusion-contrib/datafusion-distributed/pull/568
4. https://github.com/datafusion-contrib/datafusion-distributed/pull/569 <- you are here
5. https://github.com/datafusion-contrib/datafusion-distributed/pull/570

---

Makes only desired task-count handlers asynchronous, so implementations can await metadata before returning a hint. The event still borrows `SessionConfig`, avoiding configuration copies.

```rust
#[async_trait]
impl DesiredTaskCountHandler for MyHandler {
    async fn handle(&self, event: DesiredTaskCountEvent<'_>)
        -> Option<Result<DesiredTaskCountEventResponse>>
    {
        Some(Ok(DesiredTaskCountEventResponse::desired(8)))
    }
}
```


