### PR TITLE
Enable broadcast joins by default

### DIFF
--- a/src/distributed_planner/distributed_config.rs
+++ b/src/distributed_planner/distributed_config.rs
@@ -32,10 +32,7 @@ extensions_options! {
         pub collect_metrics: bool, default = true
         /// Enable broadcast joins for CollectLeft hash joins. When enabled, the build side of
         /// a CollectLeft join is broadcast to all consumer tasks.
-        /// TODO: This option exists temporarily until we become smarter about when to actually
-        /// use broadcasting like checking build side size.
-        /// For now, broadcasting all CollectLeft joins is not always beneficial.
-        pub broadcast_joins: bool, default = false
+        pub broadcast_joins: bool, default = true
         /// The compression used for sending data over the network between workers.
         /// It can be set to either `zstd`, `lz4` or `none`.
         pub compression: String, default = "lz4".to_string()


### PR DESCRIPTION
This has proven to be production ready for while now, so let's enable it by default