### PR TITLE
Auto implement event handlers for Arcs

### DIFF
--- a/src/events/route_tasks.rs
+++ b/src/events/route_tasks.rs
@@ -61,6 +61,12 @@ where
     }
 }
 
+impl RouteTasksHandler for Arc<dyn RouteTasksHandler> {
+    fn handle(&self, ev: RouteTasksEvent) -> Option<Result<RouteTasksEventResponse>> {
+        self.as_ref().handle(ev)
+    }
+}
+
 pub(crate) type RouteTasksHandlers = EventHandlerChain<dyn RouteTasksHandler>;
 
 impl RouteTasksHandlers {

--- a/src/events/scale_up_leaf_node.rs
+++ b/src/events/scale_up_leaf_node.rs
@@ -60,6 +60,12 @@ where
     }
 }
 
+impl ScaleUpLeafNodeHandler for Arc<dyn ScaleUpLeafNodeHandler> {
+    fn handle(&self, ev: ScaleUpLeafNodeEvent) -> Option<Result<ScaleUpLeafNodeEventResponse>> {
+        self.as_ref().handle(ev)
+    }
+}
+
 pub(crate) type ScaleUpLeafNodeHandlers = EventHandlerChain<dyn ScaleUpLeafNodeHandler>;
 
 impl ScaleUpLeafNodeHandlers {

--- a/src/events/worker_plan_rewrite.rs
+++ b/src/events/worker_plan_rewrite.rs
@@ -51,6 +51,15 @@ where
     }
 }
 
+impl WorkerPlanRewriteHandler for Arc<dyn WorkerPlanRewriteHandler> {
+    fn rewrite_worker_plan(
+        &self,
+        ev: WorkerPlanRewriteEvent,
+    ) -> Result<WorkerPlanRewriteEventResponse> {
+        self.as_ref().rewrite_worker_plan(ev)
+    }
+}
+
 pub(crate) type WorkerPlanRewriteHandlers = EventHandlerChain<dyn WorkerPlanRewriteHandler>;
 
 impl WorkerPlanRewriteHandlers {


### PR DESCRIPTION
That way, people can pass not only owned event handlers but also dynamic shared ones.