### PR TITLE
feat: Add plan compression  and CLI decode support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2134,6 +2134,7 @@ dependencies = [
  "arrow-ipc",
  "arrow-select",
  "async-trait",
+ "base64 0.23.1",
  "bincode",
  "bytes",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2289,6 +2289,7 @@ version = "0.1.0"
 dependencies = [
  "arrow",
  "async-trait",
+ "base64 0.23.0",
  "color-eyre",
  "crossterm",
  "datafusion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,7 +287,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "comfy-table",
  "half",
@@ -335,7 +335,7 @@ dependencies = [
  "arrow-cast",
  "arrow-ipc",
  "arrow-schema",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "prost",
@@ -1063,6 +1063,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "base64-simd"
@@ -2193,6 +2199,7 @@ dependencies = [
  "arrow-ipc",
  "arrow-select",
  "async-trait",
+ "base64 0.23.0",
  "bincode",
  "bytes",
  "chrono",
@@ -2368,7 +2375,7 @@ checksum = "14872c47bfc3d21e53ec82f57074e6987a15941c1e2f43cde4ac6ae2746634e3"
 dependencies = [
  "arrow",
  "arrow-buffer",
- "base64",
+ "base64 0.22.1",
  "blake2",
  "blake3",
  "chrono",
@@ -3599,7 +3606,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -4436,7 +4443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "form_urlencoded",
@@ -4617,7 +4624,7 @@ dependencies = [
  "arrow-ipc",
  "arrow-schema",
  "arrow-select",
- "base64",
+ "base64 0.22.1",
  "brotli",
  "bytes",
  "chrono",
@@ -5347,7 +5354,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -6072,7 +6079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.11.1",
  "fancy-regex",
  "filedescriptor",
@@ -6376,7 +6383,7 @@ checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2 0.4.14",
  "http 1.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ insta = { version = "1.46.0", features = ["filters"], optional = true }
 parquet = { version = "58", optional = true }
 arrow = { version = "58", optional = true, features = ["test_utils"] }
 hyper-util = { version = "0.1.16", optional = true }
+base64 = "0.23.0"
 
 [features]
 default = ["grpc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ insta = { version = "1.46.0", features = ["filters"], optional = true }
 parquet = { version = "59", optional = true }
 arrow = { version = "59", optional = true, features = ["test_utils"] }
 hyper-util = { version = "0.1.16", optional = true }
+base64 = { version = "0.23.0", optional = true }
 
 [features]
 default = ["grpc", "parquet", "sql"]
@@ -76,7 +77,8 @@ grpc = [
     "arrow-select",
     "arrow-ipc",
     "tonic",
-    "tower"
+    "tower",
+    "dep:base64",
 ]
 
 integration = ["insta", "dep:parquet", "arrow", "hyper-util", "grpc", "parquet", "sql"]

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -15,6 +15,7 @@ tonic = "0.14.2"
 datafusion-distributed = { path = "..", features = ["integration", "system-metrics"] }
 url = "2.5.7"
 tokio-stream = "0.1.18"
+base64 = "0.23.0"
 
 [dev-dependencies]
 arrow = "58"

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -5,6 +5,8 @@ mod ui;
 mod worker;
 
 use app::App;
+use base64::engine::general_purpose::STANDARD;
+use base64::engine::Engine;
 use crossterm::event::{self, Event};
 use ratatui::DefaultTerminal;
 use std::time::{Duration, Instant};
@@ -24,6 +26,10 @@ struct Args {
     /// Polling interval in milliseconds
     #[structopt(long = "poll-interval", default_value = "100")]
     poll_interval: u64,
+
+    /// Decode and print a base64-encoded plan string produced by explain_analyze.
+    #[structopt(long = "encoded-plan")]
+    encoded_plan: Option<String>,
 }
 
 #[tokio::main]
@@ -31,6 +37,14 @@ async fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
 
     let args = Args::from_args();
+
+    if let Some(encoded) = args.encoded_plan {
+        let decoded = Engine::decode(&STANDARD, &encoded)
+            .map(|b| String::from_utf8_lossy(&b).into_owned())
+            .unwrap_or(encoded);
+        println!("{decoded}");
+        return Ok(());
+    }
 
     let seed_url = Url::parse(&format!("http://localhost:{}", args.port)).expect("valid URL");
 

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -6,6 +6,7 @@ mod worker;
 
 use app::App;
 use crossterm::event::{self, Event};
+use datafusion_distributed::DistributedExec;
 use ratatui::DefaultTerminal;
 use std::time::{Duration, Instant};
 use structopt::StructOpt;
@@ -19,11 +20,16 @@ use url::Url;
 struct Args {
     /// Port of a worker to connect to for auto-discovery.
     /// The console calls GetClusterWorkers on this worker to discover the full cluster.
-    port: u16,
+    /// Required when not using --encoded-plan.
+    port: Option<u16>,
 
     /// Polling interval in milliseconds
     #[structopt(long = "poll-interval", default_value = "100")]
     poll_interval: u64,
+
+    /// Decode and print a base64-encoded plan string produced by explain_analyze.
+    #[structopt(long = "encoded-plan")]
+    encoded_plan: Option<String>,
 }
 
 #[tokio::main]
@@ -32,7 +38,17 @@ async fn main() -> color_eyre::Result<()> {
 
     let args = Args::from_args();
 
-    let seed_url = Url::parse(&format!("http://localhost:{}", args.port)).expect("valid URL");
+    if let Some(encoded) = args.encoded_plan {
+        let decoded = DistributedExec::decode_plan_snapshot(&encoded)
+            .map_err(|e| color_eyre::eyre::eyre!("failed to decode plan: {e}"))?;
+        println!("{decoded}");
+        return Ok(());
+    }
+
+    let port = args.port.ok_or_else(|| {
+        color_eyre::eyre::eyre!("<port> is required when not using --encoded-plan")
+    })?;
+    let seed_url = Url::parse(&format!("http://localhost:{port}")).expect("valid URL");
 
     let poll_interval = Duration::from_millis(args.poll_interval);
     let mut app = App::new(seed_url);

--- a/docs/source/user-guide/05-metrics.md
+++ b/docs/source/user-guide/05-metrics.md
@@ -82,3 +82,30 @@ runtime metrics, including network-level metrics on the boundaries:
 
 > If `plan` is not a distributed plan (its root is not a `DistributedExec`),
 > `rewrite_distributed_plan_with_metrics` returns it unchanged, so it is always safe to call.
+
+## Using EXPLAIN ANALYZE
+
+When you run `EXPLAIN ANALYZE` through a `SessionContext` backed by this library the `plan` column in
+the result batch contains a **base64-encoded plan snapshot** rather than rendered text.  The snapshot
+bundles each node's display name and its runtime metrics into a compact protobuf that can be shipped
+from a worker to a client without losing any information.
+
+Decode it in Rust with `DistributedExec::decode_plan_snapshot`:
+
+```rust
+use datafusion_distributed::DistributedExec;
+
+let batches = ctx.sql("EXPLAIN ANALYZE SELECT ...").await?.collect().await?;
+// The plan column value is a base64 string.
+let encoded: &str = /* extract from batch */;
+let text = DistributedExec::decode_plan_snapshot(encoded)?;
+println!("{text}");
+```
+
+Or use the bundled console tool for one-off inspection:
+
+```bash
+datafusion-distributed-console --encoded-plan <base64-string>
+```
+
+The console exits with a non-zero status if the payload is invalid or truncated.

--- a/src/coordinator/distributed.rs
+++ b/src/coordinator/distributed.rs
@@ -1,3 +1,5 @@
+use base64::engine::general_purpose::STANDARD;
+use base64::engine::Engine;
 use crate::common::require_one_child;
 use crate::coordinator::metrics_store::MetricsStore;
 use crate::coordinator::prepare_dynamic_plan::prepare_dynamic_plan;
@@ -133,6 +135,12 @@ impl DistributedExec {
             .map_err(|e| internal_datafusion_err!("Failed to lock head stage: {}", e))?
             .clone()
             .ok_or_else(|| internal_datafusion_err!("No head stage found. Was execute() called?"))
+    }
+    /// Decodes a base64-encoded plan string produced by [`explain_analyze`](crate::explain_analyze).
+    pub fn extract_encoded_plan(&self, encoded_plan: &str) -> String {
+        Engine::decode(&STANDARD, encoded_plan)
+        .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+        .unwrap_or_else(|_| encoded_plan.to_string())
     }
 }
 

--- a/src/coordinator/distributed.rs
+++ b/src/coordinator/distributed.rs
@@ -4,6 +4,8 @@ use crate::coordinator::prepare_dynamic_plan::prepare_dynamic_plan;
 use crate::coordinator::prepare_static_plan::prepare_static_plan;
 use crate::coordinator::query_coordinator::QueryCoordinator;
 use crate::distributed_planner::NetworkBoundaryExt;
+#[cfg(feature = "grpc")]
+use crate::protocol::grpc::plan_snapshot;
 use crate::{DistributedConfig, TaskKey};
 use datafusion::common::internal_datafusion_err;
 use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
@@ -134,6 +136,12 @@ impl DistributedExec {
             .map_err(|e| internal_datafusion_err!("Failed to lock head stage: {}", e))?
             .clone()
             .ok_or_else(|| internal_datafusion_err!("No head stage found. Was execute() called?"))
+    }
+    /// Decodes a base64-encoded plan snapshot produced by `EXPLAIN ANALYZE` into a
+    /// human-readable string listing each plan node and its aggregated metrics.
+    #[cfg(feature = "grpc")]
+    pub fn decode_plan_snapshot(encoded: &str) -> Result<String> {
+        plan_snapshot::decode(encoded)
     }
 }
 

--- a/src/protocol/grpc/mod.rs
+++ b/src/protocol/grpc/mod.rs
@@ -4,6 +4,7 @@ mod generated;
 mod metrics_proto;
 mod observability;
 mod on_drop_stream;
+pub(crate) mod plan_snapshot;
 mod spawn_select_all;
 mod worker_client;
 mod worker_service;

--- a/src/protocol/grpc/plan_snapshot.rs
+++ b/src/protocol/grpc/plan_snapshot.rs
@@ -1,0 +1,143 @@
+use super::generated::worker as pb;
+use super::metrics_proto::{df_metrics_set_to_proto, metrics_set_proto_to_df};
+use crate::coordinator::DistributedExec;
+use crate::distributed_planner::NetworkBoundaryExt;
+use crate::stage::format_metrics_by_task;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::displayable;
+use datafusion::physical_plan::metrics::MetricsSet;
+use prost::Message;
+
+#[derive(Clone, PartialEq, prost::Message)]
+struct PlanNodeSnapshot {
+    #[prost(string, tag = "1")]
+    display_name: String,
+    #[prost(message, optional, tag = "2")]
+    metrics: Option<pb::MetricsSet>,
+}
+
+#[derive(Clone, PartialEq, prost::Message)]
+struct PlanSnapshot {
+    #[prost(message, repeated, tag = "1")]
+    nodes: Vec<PlanNodeSnapshot>,
+}
+
+/// Encodes the post-execution plan as a base64 protobuf `PlanSnapshot`.
+///
+/// Walks the full plan tree (including worker stages reachable through network
+/// boundaries) and captures each node's display name and metrics.
+pub fn encode(plan: &dyn ExecutionPlan) -> Result<String> {
+    let mut raw: Vec<(String, Option<MetricsSet>)> = Vec::new();
+
+    let start: &dyn ExecutionPlan = if plan.is::<DistributedExec>() {
+        raw.push(("DistributedExec".to_string(), plan.metrics()));
+        match plan.children().into_iter().next() {
+            Some(child) => child.as_ref(),
+            None => return Ok(STANDARD.encode(PlanSnapshot { nodes: vec![] }.encode_to_vec())),
+        }
+    } else {
+        plan
+    };
+
+    collect_nodes(start, &mut raw);
+
+    let nodes = raw
+        .into_iter()
+        .map(|(name, metrics)| {
+            let proto_metrics = metrics.as_ref().map(df_metrics_set_to_proto).transpose()?;
+            Ok(PlanNodeSnapshot {
+                display_name: name,
+                metrics: proto_metrics,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(STANDARD.encode(PlanSnapshot { nodes }.encode_to_vec()))
+}
+
+/// Decodes a base64 `PlanSnapshot` produced by [`encode`] into a human-readable string.
+pub fn decode(b64: &str) -> Result<String> {
+    let bytes = STANDARD
+        .decode(b64)
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+    let snapshot = PlanSnapshot::decode(bytes.as_slice())
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+    let mut out = String::new();
+    for node in &snapshot.nodes {
+        let metrics_str = node
+            .metrics
+            .as_ref()
+            .map(metrics_set_proto_to_df)
+            .transpose()?
+            .map(|m| {
+                let formatted = format_metrics_by_task(&m);
+                if formatted.is_empty() {
+                    String::new()
+                } else {
+                    format!(", metrics=[{formatted}]")
+                }
+            })
+            .unwrap_or_default();
+        out.push_str(&format!("{}{}\n", node.display_name, metrics_str));
+    }
+    Ok(out)
+}
+
+fn collect_nodes(plan: &dyn ExecutionPlan, nodes: &mut Vec<(String, Option<MetricsSet>)>) {
+    let name = displayable(plan).one_line().to_string();
+    nodes.push((name.trim_end().to_string(), plan.metrics()));
+
+    if let Some(nb) = plan.as_network_boundary() {
+        if let Some(stage_plan) = nb.input_stage().local_plan() {
+            collect_nodes(stage_plan.as_ref(), nodes);
+        }
+        return;
+    }
+
+    for child in plan.children() {
+        collect_nodes(child.as_ref(), nodes);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coordinator::DistributedExec;
+    use datafusion::arrow::datatypes::Schema;
+    use datafusion::physical_plan::empty::EmptyExec;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_encode_decode_roundtrip() {
+        let plan = EmptyExec::new(Arc::new(Schema::empty()));
+        let encoded = encode(&plan).unwrap();
+        let decoded = decode(&encoded).unwrap();
+        assert!(decoded.contains("EmptyExec"));
+    }
+
+    #[test]
+    fn test_distributed_exec_root_appears_first_in_preorder() {
+        let schema = Arc::new(Schema::empty());
+        let plan = DistributedExec::new(Arc::new(EmptyExec::new(schema)));
+
+        let encoded = encode(&plan).unwrap();
+        let decoded = decode(&encoded).unwrap();
+        let lines: Vec<&str> = decoded.lines().collect();
+
+        assert_eq!(lines.len(), 2, "expected DistributedExec + one child");
+        assert!(
+            lines[0].contains("DistributedExec"),
+            "root must be DistributedExec, got: {}",
+            lines[0]
+        );
+        assert!(
+            lines[1].contains("EmptyExec"),
+            "child must be EmptyExec, got: {}",
+            lines[1]
+        );
+    }
+}

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -1,4 +1,7 @@
+use base64::engine::general_purpose::STANDARD;
+use base64::engine::Engine;
 use crate::coordinator::{DistributedExec, MetricsStore};
+
 use crate::execution_plans::{DistributedLeafExec, NetworkCoalesceExec};
 use crate::metrics::DISTRIBUTED_DATAFUSION_TASK_ID_LABEL;
 use datafusion::common::{HashMap, Statistics, config_err};
@@ -252,7 +255,12 @@ pub async fn explain_analyze(
             .to_string()),
         Some(_) => {
             let executed = rewrite_distributed_plan_with_metrics(executed.clone(), format).await?;
-            Ok(display_plan_ascii(executed.as_ref(), true))
+            let display_string = display_plan_ascii(executed.as_ref(), true);
+            if display_string.len() >= 10_000 {
+                Ok(Engine::encode(&STANDARD, display_string.as_bytes()))
+            } else {
+                Ok(display_string)
+            }
         }
     }
 }

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -1,6 +1,8 @@
 use crate::coordinator::{DistributedExec, MetricsStore};
 use crate::execution_plans::{DistributedLeafExec, NetworkCoalesceExec};
 use crate::metrics::DISTRIBUTED_DATAFUSION_TASK_ID_LABEL;
+#[cfg(feature = "grpc")]
+use crate::protocol::grpc::plan_snapshot;
 use datafusion::common::{HashMap, Statistics, config_err};
 use datafusion::common::{exec_err, plan_err};
 use datafusion::error::Result;
@@ -256,7 +258,10 @@ pub async fn explain_analyze(
             .to_string()),
         Some(_) => {
             let executed = rewrite_distributed_plan_with_metrics(executed.clone(), format).await?;
-            Ok(display_plan_ascii(executed.as_ref(), true))
+            #[cfg(feature = "grpc")]
+            return plan_snapshot::encode(executed.as_ref());
+            #[cfg(not(feature = "grpc"))]
+            return Ok(display_plan_ascii(executed.as_ref(), true));
         }
     }
 }
@@ -545,7 +550,7 @@ fn sorted_for_display_by_task_id(metrics: MetricsSet) -> MetricsSet {
 ///
 /// See
 /// https://github.com/apache/datafusion/blob/b463a9f9e3c9603eb2db7113125fea3a1b7f5455/datafusion/physical-plan/src/display.rs#L421.
-fn format_metrics_by_task(metrics: &MetricsSet) -> String {
+pub(crate) fn format_metrics_by_task(metrics: &MetricsSet) -> String {
     let aggregated = aggregate_by_task_id(metrics);
     let sorted = sorted_for_display_by_task_id(aggregated).timestamps_removed();
 

--- a/tests/explain_analyze.rs
+++ b/tests/explain_analyze.rs
@@ -2,11 +2,11 @@
 mod tests {
     use datafusion::arrow::array::{Array, StringArray};
     use datafusion::arrow::util::pretty::pretty_format_batches;
-    use datafusion::common::{Result, assert_contains, assert_not_contains};
+    use datafusion::common::{Result, assert_contains};
     use datafusion::physical_plan::execute_stream;
     use datafusion_distributed::test_utils::localhost::start_localhost_context;
     use datafusion_distributed::test_utils::parquet::register_parquet_tables;
-    use datafusion_distributed::{DefaultSessionBuilder, DistributedExt};
+    use datafusion_distributed::{DefaultSessionBuilder, DistributedExec, DistributedExt};
     use futures::TryStreamExt;
     use test_case::test_case;
 
@@ -41,10 +41,17 @@ mod tests {
         println!("{formatted}");
 
         assert_contains!(&formatted, "Plan with Metrics");
+
+        let encoded = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap()
+            .value(0);
+        let formatted = DistributedExec::decode_plan_snapshot(encoded)?;
         assert_contains!(&formatted, "DistributedExec");
         assert_contains!(&formatted, "NetworkShuffleExec");
-        assert_contains!(&formatted, "metrics=[output_rows=");
-        assert_not_contains!(&formatted, "metrics=[output_rows={");
+        assert_contains!(&formatted, "output_rows"); // e.g. output_rows{partition=0}=2
 
         Ok(())
     }
@@ -78,7 +85,6 @@ mod tests {
         assert_contains!(&formatted, "Plan with Full Metrics");
         assert_contains!(&formatted, "Output Rows");
         assert_contains!(&formatted, "Duration");
-        assert_contains!(&formatted, "metrics=[output_rows=");
 
         let plan_types = batches[0].column(0).as_any().downcast_ref::<StringArray>();
         let plans = batches[0].column(1).as_any().downcast_ref::<StringArray>();
@@ -92,8 +98,14 @@ mod tests {
                 .unwrap_or_else(|| panic!("verbose output should contain a {plan_type} entry"));
             plans.value(index)
         };
-        assert_not_contains!(plan_for("Plan with Metrics"), "metrics=[output_rows={");
-        assert_contains!(plan_for("Plan with Full Metrics"), "metrics=[output_rows={");
+        let formatted = DistributedExec::decode_plan_snapshot(plan_for("Plan with Metrics"))?;
+        assert_contains!(&formatted, "output_rows=");
+        assert!(
+            !formatted.contains("output_rows={"),
+            "Plan with Metrics should aggregate across tasks (no task map), got: {formatted}"
+        );
+        let formatted = DistributedExec::decode_plan_snapshot(plan_for("Plan with Full Metrics"))?;
+        assert_contains!(&formatted, "output_rows={");
         assert_eq!(plan_for("Output Rows"), "2");
 
         Ok(())


### PR DESCRIPTION
Closes #523

## Why?
- see #523

## What Changed
- Added protobuf-backed `PlanSnapshot` / `PlanNodeSnapshot` encode and decode support.
- Captures each plan node’s display name and runtime metrics using the existing metrics protobuf conversion path.
- Makes distributed `EXPLAIN ANALYZE` return a base64-encoded snapshot when the `grpc` feature is enabled.
- Exposes `DistributedExec::decode_plan_snapshot`.
- Adds `datafusion-distributed-console --encoded-plan` for one-off decoding.
- Documents the encoded-plan workflow in the metrics guide.

# Test
- updated `tests/explain_analyze.rs` to expect the new output format