### PR TITLE
worker: add reject_unregistered_execute_tasks on worker service

### DIFF
--- a/src/protocol/grpc/mod.rs
+++ b/src/protocol/grpc/mod.rs
@@ -8,6 +8,7 @@ mod spawn_select_all;
 mod worker_client;
 mod worker_service;
 
+pub(crate) use errors::datafusion_error_to_tonic_status;
 // TODO: this should not be exposed.
 pub(crate) use channel_resolver::DEFAULT_CHANNEL_RESOLVER_PER_RUNTIME;
 

--- a/src/protocol/grpc/worker_service.rs
+++ b/src/protocol/grpc/worker_service.rs
@@ -6,6 +6,7 @@ use super::spawn_select_all::spawn_select_all;
 use crate::common::{deserialize_uuid, now_ns};
 use crate::protocol::ProducerHeadSpec;
 use crate::protocol::grpc::{ObservabilityServiceImpl, ObservabilityServiceServer};
+use crate::worker::UnregisteredTaskDuringDrain;
 use crate::{
     CoordinatorToWorkerMsg, DistributedConfig, ExecuteTaskRequest, LoadInfo, SetPlanRequest,
     TaskKey, TaskMetrics, WorkUnitBatch, WorkUnitFeedDeclaration, WorkUnitMsg, Worker,
@@ -128,7 +129,7 @@ impl pb::worker_service_server::WorkerService for Worker {
         let (arrow_streams, task_ctx) = self
             .execute_task(request)
             .await
-            .map_err(datafusion_error_to_tonic_status)?;
+            .map_err(execute_task_error_to_tonic_status)?;
 
         let d_cfg = DistributedConfig::from_config_options(task_ctx.session_config().options())
             .map_err(datafusion_error_to_tonic_status)?;
@@ -178,6 +179,18 @@ impl pb::worker_service_server::WorkerService for Worker {
             version: self.version().to_string(),
         }))
     }
+}
+
+fn execute_task_error_to_tonic_status(error: DataFusionError) -> Status {
+    if let DataFusionError::External(source) = &error
+        && source
+            .downcast_ref::<UnregisteredTaskDuringDrain>()
+            .is_some()
+    {
+        return Status::unavailable(error.to_string());
+    }
+
+    datafusion_error_to_tonic_status(error)
 }
 
 fn decode_coordinator_to_worker_msg(
@@ -415,4 +428,39 @@ fn garbage_collect_arrays(
         arrays,
         &RecordBatchOptions::new().with_row_count(Some(row_count)),
     )?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ProducerHeadSpec;
+    use tonic::Code;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn unregistered_task_during_drain_maps_to_unavailable() {
+        let worker = Worker::default();
+        worker.reject_unregistered_execute_tasks();
+
+        let result = worker
+            .execute_task(ExecuteTaskRequest {
+                task_key: TaskKey {
+                    query_id: Uuid::nil(),
+                    stage_id: 0,
+                    task_number: 0,
+                },
+                target_partition_start: 0,
+                target_partition_end: 1,
+                producer_head_spec: ProducerHeadSpec::None,
+            })
+            .await;
+        let Err(error) = result else {
+            panic!("unregistered task should be rejected during drain");
+        };
+
+        assert_eq!(
+            execute_task_error_to_tonic_status(error).code(),
+            Code::Unavailable
+        );
+    }
 }

--- a/src/protocol/grpc/worker_service.rs
+++ b/src/protocol/grpc/worker_service.rs
@@ -1,4 +1,4 @@
-use super::errors::{datafusion_error_to_tonic_status, map_status_to_datafusion_error};
+use super::errors::map_status_to_datafusion_error;
 use super::generated::worker as pb;
 use super::metrics_proto::df_metrics_set_to_proto;
 use super::spawn_select_all::spawn_select_all;
@@ -6,7 +6,7 @@ use super::spawn_select_all::spawn_select_all;
 use crate::common::{deserialize_uuid, now_ns};
 use crate::protocol::ProducerHeadSpec;
 use crate::protocol::grpc::{ObservabilityServiceImpl, ObservabilityServiceServer};
-use crate::worker::UnregisteredTaskDuringDrain;
+use crate::worker::execute_task_error_to_tonic_status;
 use crate::{
     CoordinatorToWorkerMsg, DistributedConfig, ExecuteTaskRequest, LoadInfo, SetPlanRequest,
     TaskKey, TaskMetrics, WorkUnitBatch, WorkUnitFeedDeclaration, WorkUnitMsg, Worker,
@@ -179,18 +179,6 @@ impl pb::worker_service_server::WorkerService for Worker {
             version: self.version().to_string(),
         }))
     }
-}
-
-fn execute_task_error_to_tonic_status(error: DataFusionError) -> Status {
-    if let DataFusionError::External(source) = &error
-        && source
-            .downcast_ref::<UnregisteredTaskDuringDrain>()
-            .is_some()
-    {
-        return Status::unavailable(error.to_string());
-    }
-
-    datafusion_error_to_tonic_status(error)
 }
 
 fn decode_coordinator_to_worker_msg(
@@ -428,39 +416,4 @@ fn garbage_collect_arrays(
         arrays,
         &RecordBatchOptions::new().with_row_count(Some(row_count)),
     )?)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::ProducerHeadSpec;
-    use tonic::Code;
-    use uuid::Uuid;
-
-    #[tokio::test]
-    async fn unregistered_task_during_drain_maps_to_unavailable() {
-        let worker = Worker::default();
-        worker.reject_unregistered_execute_tasks();
-
-        let result = worker
-            .execute_task(ExecuteTaskRequest {
-                task_key: TaskKey {
-                    query_id: Uuid::nil(),
-                    stage_id: 0,
-                    task_number: 0,
-                },
-                target_partition_start: 0,
-                target_partition_end: 1,
-                producer_head_spec: ProducerHeadSpec::None,
-            })
-            .await;
-        let Err(error) = result else {
-            panic!("unregistered task should be rejected during drain");
-        };
-
-        assert_eq!(
-            execute_task_error_to_tonic_status(error).code(),
-            Code::Unavailable
-        );
-    }
 }

--- a/src/worker/errors.rs
+++ b/src/worker/errors.rs
@@ -1,0 +1,66 @@
+use crate::TaskKey;
+#[cfg(feature = "grpc")]
+use datafusion::error::DataFusionError;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug)]
+pub(super) struct UnregisteredTaskDuringDrainError {
+    task_key: TaskKey,
+}
+
+impl UnregisteredTaskDuringDrainError {
+    pub(super) fn new(task_key: TaskKey) -> Self {
+        Self { task_key }
+    }
+
+    #[cfg(feature = "grpc")]
+    fn to_tonic_status(&self) -> tonic::Status {
+        tonic::Status::unavailable(self.to_string())
+    }
+}
+
+impl Display for UnregisteredTaskDuringDrainError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "worker is draining and task key {:?} is not registered",
+            self.task_key
+        )
+    }
+}
+
+impl Error for UnregisteredTaskDuringDrainError {}
+
+#[cfg(feature = "grpc")]
+pub(crate) fn execute_task_error_to_tonic_status(error: DataFusionError) -> tonic::Status {
+    if let DataFusionError::External(source) = &error
+        && let Some(error) = source.downcast_ref::<UnregisteredTaskDuringDrainError>()
+    {
+        return error.to_tonic_status();
+    }
+
+    crate::protocol::grpc::datafusion_error_to_tonic_status(error)
+}
+
+#[cfg(all(test, feature = "grpc"))]
+mod tests {
+    use super::*;
+    use tonic::Code;
+    use uuid::Uuid;
+
+    #[test]
+    fn unregistered_task_during_drain_maps_to_unavailable() {
+        let error =
+            DataFusionError::External(Box::new(UnregisteredTaskDuringDrainError::new(TaskKey {
+                query_id: Uuid::nil(),
+                stage_id: 0,
+                task_number: 0,
+            })));
+
+        assert_eq!(
+            execute_task_error_to_tonic_status(error).code(),
+            Code::Unavailable
+        );
+    }
+}

--- a/src/worker/impl_execute_task.rs
+++ b/src/worker/impl_execute_task.rs
@@ -1,14 +1,40 @@
 use crate::ExecuteTaskRequest;
-use crate::worker::worker_service::{TaskDataEntries, Worker};
+use crate::worker::SingleWriteMultiRead;
+use crate::worker::worker_service::{ResultTaskData, TaskDataEntries, Worker};
 use datafusion::common::exec_datafusion_err;
 use datafusion::common::{Result, exec_err};
 use datafusion::error::DataFusionError;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 use std::time::Duration;
 
 const WAIT_PLAN_TIMEOUT_SECS: u64 = 10;
+
+#[derive(Debug)]
+pub(crate) struct UnregisteredTaskDuringDrain {
+    task_key: crate::TaskKey,
+}
+
+impl UnregisteredTaskDuringDrain {
+    fn new(task_key: crate::TaskKey) -> Self {
+        Self { task_key }
+    }
+}
+
+impl Display for UnregisteredTaskDuringDrain {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "worker is draining and task key {:?} is not registered",
+            self.task_key
+        )
+    }
+}
+
+impl Error for UnregisteredTaskDuringDrain {}
 
 /// Builds several per-partition streams by retrieving the appropriate entry from [TaskDataEntries]
 /// based on the task key extracted from [ExecuteTaskRequest].
@@ -20,7 +46,22 @@ impl Worker {
         &self,
         request: ExecuteTaskRequest,
     ) -> Result<(Vec<SendableRecordBatchStream>, Arc<TaskContext>)> {
-        Self::execute_task_static(Arc::clone(&self.task_data_entries), request).await
+        let entry = if self.rejects_unregistered_execute_tasks() {
+            self.task_data_entries
+                .get(&request.task_key)
+                .await
+                .ok_or_else(|| {
+                    DataFusionError::External(Box::new(UnregisteredTaskDuringDrain::new(
+                        request.task_key,
+                    )))
+                })?
+        } else {
+            self.task_data_entries
+                .get_with(request.task_key, async { Default::default() })
+                .await
+        };
+
+        Self::execute_task_with_entry(entry, request).await
     }
 
     pub(crate) async fn execute_task_static(
@@ -31,6 +72,13 @@ impl Worker {
             .get_with(request.task_key, async { Default::default() })
             .await;
 
+        Self::execute_task_with_entry(entry, request).await
+    }
+
+    async fn execute_task_with_entry(
+        entry: Arc<SingleWriteMultiRead<ResultTaskData>>,
+        request: ExecuteTaskRequest,
+    ) -> Result<(Vec<SendableRecordBatchStream>, Arc<TaskContext>)> {
         // Other request is responsible for writing the plan that belongs to this TaskKey, so
         // we'll resolve immediately if it was already there, or wait until it's ready.
         let task_data = entry
@@ -62,5 +110,70 @@ impl Worker {
             streams.push(Box::pin(RecordBatchStreamAdapter::new(stream_schema, stream)) as _);
         }
         Ok((streams, task_ctx))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::worker::test_utils::worker_handles::register_plan_on_worker;
+    use crate::{ProducerHeadSpec, TaskKey};
+    use datafusion::arrow::datatypes::Schema;
+    use datafusion::physical_plan::empty::EmptyExec;
+    use datafusion::prelude::SessionContext;
+    use std::time::Duration;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn draining_worker_executes_registered_tasks_and_rejects_unknown_tasks() {
+        let worker = Worker::default();
+        let registered_key = task_key(1);
+        register_plan_on_worker(
+            &worker,
+            SessionContext::new().task_ctx(),
+            Arc::new(EmptyExec::new(Arc::new(Schema::empty()))),
+            registered_key,
+        )
+        .await;
+
+        worker.clone().reject_unregistered_execute_tasks();
+
+        let (streams, _) = worker
+            .execute_task(execute_request(registered_key))
+            .await
+            .expect("registered task should remain executable during drain");
+        assert_eq!(streams.len(), 1);
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(100),
+            worker.execute_task(execute_request(task_key(2))),
+        )
+        .await
+        .expect("unregistered task should fail immediately");
+        let Err(error) = result else {
+            panic!("unregistered task should be rejected during drain");
+        };
+        let DataFusionError::External(source) = error else {
+            panic!("expected external drain error");
+        };
+        assert!(source.is::<UnregisteredTaskDuringDrain>());
+        assert_eq!(worker.tasks_running().await, 1);
+    }
+
+    fn task_key(task_number: usize) -> TaskKey {
+        TaskKey {
+            query_id: Uuid::nil(),
+            stage_id: 0,
+            task_number,
+        }
+    }
+
+    fn execute_request(task_key: TaskKey) -> ExecuteTaskRequest {
+        ExecuteTaskRequest {
+            task_key,
+            target_partition_start: 0,
+            target_partition_end: 1,
+            producer_head_spec: ProducerHeadSpec::None,
+        }
     }
 }

--- a/src/worker/impl_execute_task.rs
+++ b/src/worker/impl_execute_task.rs
@@ -1,4 +1,5 @@
 use crate::ExecuteTaskRequest;
+use crate::worker::errors::UnregisteredTaskDuringDrainError;
 use crate::worker::SingleWriteMultiRead;
 use crate::worker::worker_service::{ResultTaskData, TaskDataEntries, Worker};
 use datafusion::common::exec_datafusion_err;
@@ -6,35 +7,10 @@ use datafusion::common::{Result, exec_err};
 use datafusion::error::DataFusionError;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
-use std::error::Error;
-use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 use std::time::Duration;
 
 const WAIT_PLAN_TIMEOUT_SECS: u64 = 10;
-
-#[derive(Debug)]
-pub(crate) struct UnregisteredTaskDuringDrain {
-    task_key: crate::TaskKey,
-}
-
-impl UnregisteredTaskDuringDrain {
-    fn new(task_key: crate::TaskKey) -> Self {
-        Self { task_key }
-    }
-}
-
-impl Display for UnregisteredTaskDuringDrain {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "worker is draining and task key {:?} is not registered",
-            self.task_key
-        )
-    }
-}
-
-impl Error for UnregisteredTaskDuringDrain {}
 
 /// Builds several per-partition streams by retrieving the appropriate entry from [TaskDataEntries]
 /// based on the task key extracted from [ExecuteTaskRequest].
@@ -51,7 +27,7 @@ impl Worker {
                 .get(&request.task_key)
                 .await
                 .ok_or_else(|| {
-                    DataFusionError::External(Box::new(UnregisteredTaskDuringDrain::new(
+                    DataFusionError::External(Box::new(UnregisteredTaskDuringDrainError::new(
                         request.task_key,
                     )))
                 })?
@@ -156,7 +132,7 @@ mod tests {
         let DataFusionError::External(source) = error else {
             panic!("expected external drain error");
         };
-        assert!(source.is::<UnregisteredTaskDuringDrain>());
+        assert!(source.is::<UnregisteredTaskDuringDrainError>());
         assert_eq!(worker.tasks_running().await, 1);
     }
 

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod test_utils;
 mod worker_connection_pool;
 mod worker_service;
 
+pub(crate) use impl_execute_task::UnregisteredTaskDuringDrain;
 pub(crate) use single_write_multi_read::SingleWriteMultiRead;
 pub(crate) use worker_connection_pool::WorkerConnectionPool;
 

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -1,3 +1,4 @@
+mod errors;
 mod impl_coordinator_channel;
 mod impl_execute_task;
 mod session_builder;
@@ -8,7 +9,8 @@ pub(crate) mod test_utils;
 mod worker_connection_pool;
 mod worker_service;
 
-pub(crate) use impl_execute_task::UnregisteredTaskDuringDrain;
+#[cfg(feature = "grpc")]
+pub(crate) use errors::execute_task_error_to_tonic_status;
 pub(crate) use single_write_multi_read::SingleWriteMultiRead;
 pub(crate) use worker_connection_pool::WorkerConnectionPool;
 

--- a/src/worker/worker_service.rs
+++ b/src/worker/worker_service.rs
@@ -5,6 +5,7 @@ use datafusion::execution::runtime_env::RuntimeEnv;
 use moka::future::Cache;
 use std::borrow::Cow;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use url::Url;
 
@@ -20,6 +21,7 @@ pub struct Worker {
     /// TASK_CACHE_TTI seconds. This prevents memory leaks from abandoned or incomplete queries
     /// while allowing concurrent access to task results across multiple partition requests.
     pub(crate) task_data_entries: Arc<TaskDataEntries>,
+    reject_unregistered_execute_tasks: Arc<AtomicBool>,
     pub(super) session_builder: Arc<dyn WorkerSessionBuilder + Send + Sync>,
     pub(crate) max_message_size: Option<usize>,
     pub(super) version: Cow<'static, str>,
@@ -31,6 +33,7 @@ impl Default for Worker {
         Self {
             runtime: Arc::new(RuntimeEnv::default()),
             task_data_entries: Arc::new(cache),
+            reject_unregistered_execute_tasks: Arc::new(AtomicBool::new(false)),
             session_builder: Arc::new(DefaultSessionBuilder),
             max_message_size: Some(usize::MAX),
             version: Cow::Borrowed(""),
@@ -39,6 +42,17 @@ impl Default for Worker {
 }
 
 impl Worker {
+    /// Enters drain mode for task execution.
+    ///
+    /// Once enabled, [`Self::execute_task`] accepts only task keys that are already registered on
+    /// this worker. Calls for unregistered keys fail immediately, while registered tasks remain
+    /// available to drain. This transition is irreversible and applies to all clones of this
+    /// worker.
+    pub fn reject_unregistered_execute_tasks(&self) {
+        self.reject_unregistered_execute_tasks
+            .store(true, Ordering::Release);
+    }
+
     /// Builds a [Worker] with a custom [WorkerSessionBuilder]. Use this
     /// method whenever you need to add custom stuff to the `SessionContext` that executes the query.
     pub fn from_session_builder(
@@ -101,5 +115,10 @@ impl Worker {
         // `entry_count()` task data.
         self.task_data_entries.run_pending_tasks().await;
         self.task_data_entries.entry_count() as usize
+    }
+
+    pub(super) fn rejects_unregistered_execute_tasks(&self) -> bool {
+        self.reject_unregistered_execute_tasks
+            .load(Ordering::Acquire)
     }
 }


### PR DESCRIPTION
This change adds a method on `reject_unregistered_execute_tasks()` to make the worker reject any 