### PR TITLE
build: make the datafusion parquet and sql features optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["benchmarks", "cli", "console"]
 
 [workspace.dependencies]
 datafusion = { version = "54.0.0", default-features = false }
-datafusion-proto = { version = "54.0.0" }
+datafusion-proto = { version = "54.0.0", default-features = false }
 
 [package]
 name = "datafusion-distributed"
@@ -17,8 +17,6 @@ repository = "https://github.com/datafusion-contrib/datafusion-distributed"
 [dependencies]
 chrono = { version = "0.4.44" }
 datafusion = { workspace = true, features = [
-  "parquet",
-  "sql",
   "unicode_expressions",
   "datetime_expressions",
 ] }
@@ -61,7 +59,13 @@ arrow = { version = "58", optional = true, features = ["test_utils"] }
 hyper-util = { version = "0.1.16", optional = true }
 
 [features]
-default = ["grpc"]
+default = ["grpc", "parquet", "sql"]
+
+# Both are in the default set, so nothing changes for consumers who do not opt out.
+# They exist so that an embedder which never reads parquet files and never parses SQL
+# can skip the parquet and sqlparser stacks with `default-features = false`.
+parquet = ["datafusion/parquet", "datafusion-proto/parquet"]
+sql = ["datafusion/sql"]
 avro = ["datafusion/avro"]
 grpc = [
     "arrow-flight",
@@ -71,7 +75,7 @@ grpc = [
     "tower"
 ]
 
-integration = ["insta", "parquet", "arrow", "hyper-util", "grpc"]
+integration = ["insta", "dep:parquet", "arrow", "hyper-util", "grpc", "parquet", "sql"]
 
 system-metrics = ["sysinfo"]
 
@@ -83,6 +87,11 @@ sysinfo = ["dep:sysinfo"]
 
 [dev-dependencies]
 datafusion-distributed-benchmarks = { path = "benchmarks" }
+# The crate's own tests drive `SessionContext::sql` and register parquet tables, so they need
+# both features regardless of which ones a consumer selects. Requesting them here keeps
+# `--no-default-features` test runs compiling without forcing either on library consumers.
+datafusion = { workspace = true, features = ["parquet", "sql"] }
+datafusion-proto = { workspace = true, features = ["parquet"] }
 structopt = "0.3"
 insta = { version = "1.46.0", features = ["filters"] }
 parquet = "58"

--- a/src/protocol/grpc/errors/datafusion_error.rs
+++ b/src/protocol/grpc/errors/datafusion_error.rs
@@ -202,8 +202,7 @@ impl DataFusionErrorProto {
                 // than dropping the error.
                 #[cfg(not(feature = "parquet"))]
                 {
-                    let _ = err;
-                    DataFusionError::Internal("ParquetError from peer".to_string())
+                    DataFusionError::Internal(format!("ParquetError from peer: {err}"))
                 }
             }
             DataFusionErrorInnerProto::ObjectStoreError(err) => {
@@ -225,8 +224,13 @@ impl DataFusionErrorProto {
                 // reasoning as the parquet arm above.
                 #[cfg(not(feature = "sql"))]
                 {
-                    let _ = err;
-                    DataFusionError::Internal("SQL error from peer".to_string())
+                    let msg = err
+                        .err
+                        .as_ref()
+                        .map(|err| err.to_string())
+                        .unwrap_or_default();
+                    let backtrace = err.backtrace.as_deref().unwrap_or_default();
+                    DataFusionError::Internal(format!("SQL error from peer: {msg}{backtrace}"))
                 }
             }
             DataFusionErrorInnerProto::NotImplemented(msg) => {

--- a/src/protocol/grpc/errors/datafusion_error.rs
+++ b/src/protocol/grpc/errors/datafusion_error.rs
@@ -5,6 +5,7 @@ use super::parquet_error::ParquetErrorProto;
 use super::parser_error::ParserErrorProto;
 use super::schema_error::SchemaErrorProto;
 use datafusion::common::{DataFusionError, Diagnostic};
+#[cfg(feature = "sql")]
 use datafusion::logical_expr::sqlparser::parser::ParserError;
 use std::error::Error;
 use std::sync::Arc;
@@ -90,6 +91,7 @@ impl DataFusionErrorProto {
                     ArrowErrorProto::from_arrow_error(err, msg.as_ref()),
                 )),
             },
+            #[cfg(feature = "parquet")]
             DataFusionError::ParquetError(err) => DataFusionErrorProto {
                 inner: Some(DataFusionErrorInnerProto::ParquetError(
                     ParquetErrorProto::from_parquet_error(err),
@@ -105,6 +107,7 @@ impl DataFusionErrorProto {
                     IoErrorProto::from_io_error("", err),
                 )),
             },
+            #[cfg(feature = "sql")]
             DataFusionError::SQL(err, msg) => DataFusionErrorProto {
                 inner: Some(DataFusionErrorInnerProto::SQL(DataFusionSqlErrorProto {
                     err: Some(ParserErrorProto::from_parser_error(err)),
@@ -190,7 +193,18 @@ impl DataFusionErrorProto {
                 DataFusionError::ArrowError(Box::new(err), ctx)
             }
             DataFusionErrorInnerProto::ParquetError(err) => {
-                DataFusionError::ParquetError(Box::new(err.to_parquet_error()))
+                #[cfg(feature = "parquet")]
+                {
+                    DataFusionError::ParquetError(Box::new(err.to_parquet_error()))
+                }
+                // Built without `parquet`, so `DataFusionError::ParquetError` does not exist
+                // here. The peer that sent this may still have it, so keep the message rather
+                // than dropping the error.
+                #[cfg(not(feature = "parquet"))]
+                {
+                    let _ = err;
+                    DataFusionError::Internal("ParquetError from peer".to_string())
+                }
             }
             DataFusionErrorInnerProto::ObjectStoreError(err) => {
                 DataFusionError::ObjectStore(Box::new(err.to_object_store_error()))
@@ -200,10 +214,20 @@ impl DataFusionErrorProto {
                 DataFusionError::IoError(err)
             }
             DataFusionErrorInnerProto::SQL(err) => {
-                let backtrace = err.backtrace.clone();
-                let err = err.err.as_ref().map(|err| err.to_parser_error());
-                let err = err.unwrap_or(ParserError::ParserError("".to_string()));
-                DataFusionError::SQL(Box::new(err), backtrace)
+                #[cfg(feature = "sql")]
+                {
+                    let backtrace = err.backtrace.clone();
+                    let err = err.err.as_ref().map(|err| err.to_parser_error());
+                    let err = err.unwrap_or(ParserError::ParserError("".to_string()));
+                    DataFusionError::SQL(Box::new(err), backtrace)
+                }
+                // Built without `sql`, so `DataFusionError::SQL` does not exist here. Same
+                // reasoning as the parquet arm above.
+                #[cfg(not(feature = "sql"))]
+                {
+                    let _ = err;
+                    DataFusionError::Internal("SQL error from peer".to_string())
+                }
             }
             DataFusionErrorInnerProto::NotImplemented(msg) => {
                 DataFusionError::NotImplemented(msg.clone())

--- a/src/protocol/grpc/errors/parquet_error.rs
+++ b/src/protocol/grpc/errors/parquet_error.rs
@@ -1,3 +1,6 @@
+// Only the conversions touch `ParquetError`; the proto types below are always compiled so
+// that the wire format does not depend on which features an endpoint was built with.
+#[cfg(feature = "parquet")]
 use datafusion::parquet::errors::ParquetError;
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -32,6 +35,7 @@ pub struct IndexOutOfBoundProto {
     b: u64,
 }
 
+#[cfg(feature = "parquet")]
 impl ParquetErrorProto {
     pub fn from_parquet_error(err: &ParquetError) -> Self {
         match err {

--- a/src/protocol/grpc/errors/parquet_error.rs
+++ b/src/protocol/grpc/errors/parquet_error.rs
@@ -35,6 +35,28 @@ pub struct IndexOutOfBoundProto {
     b: u64,
 }
 
+/// Mirrors `ParquetError`'s `Display` without needing the type itself, so that endpoints built
+/// without the `parquet` feature can still surface the message an error carried over the wire.
+impl std::fmt::Display for ParquetErrorProto {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Some(ref inner) = self.inner else {
+            return write!(f, "External: Malformed protobuf message");
+        };
+
+        match inner {
+            ParquetErrorInnerProto::General(msg) => write!(f, "Parquet error: {msg}"),
+            ParquetErrorInnerProto::NYI(msg) => write!(f, "NYI: {msg}"),
+            ParquetErrorInnerProto::EOF(msg) => write!(f, "EOF: {msg}"),
+            ParquetErrorInnerProto::ArrowError(msg) => write!(f, "Arrow: {msg}"),
+            ParquetErrorInnerProto::IndexOutOfBound(IndexOutOfBoundProto { a, b }) => {
+                write!(f, "Index {a} out of bound: {b}")
+            }
+            ParquetErrorInnerProto::External(msg) => write!(f, "External: {msg}"),
+            ParquetErrorInnerProto::NeedMoreData(n) => write!(f, "NeedMoreData: {n}"),
+        }
+    }
+}
+
 #[cfg(feature = "parquet")]
 impl ParquetErrorProto {
     pub fn from_parquet_error(err: &ParquetError) -> Self {
@@ -118,6 +140,9 @@ mod tests {
             let recovered_error = proto.to_parquet_error();
 
             assert_eq!(original_error.to_string(), recovered_error.to_string());
+            // The proto's own `Display` is what endpoints built without `parquet` fall back to,
+            // so it must stay in sync with `ParquetError`'s.
+            assert_eq!(original_error.to_string(), proto.to_string());
         }
     }
 
@@ -126,5 +151,6 @@ mod tests {
         let malformed_proto = ParquetErrorProto { inner: None };
         let recovered_error = malformed_proto.to_parquet_error();
         assert!(matches!(recovered_error, ParquetError::External(_)));
+        assert_eq!(recovered_error.to_string(), malformed_proto.to_string());
     }
 }

--- a/src/protocol/grpc/errors/parser_error.rs
+++ b/src/protocol/grpc/errors/parser_error.rs
@@ -1,3 +1,6 @@
+// Only the conversions touch `ParserError`; the proto types below are always compiled so
+// that the wire format does not depend on which features an endpoint was built with.
+#[cfg(feature = "sql")]
 use datafusion::sql::sqlparser::parser::ParserError;
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -16,6 +19,7 @@ pub enum ParserErrorInnerProto {
     RecursionLimitExceeded(bool),
 }
 
+#[cfg(feature = "sql")]
 impl ParserErrorProto {
     pub fn from_parser_error(err: &ParserError) -> Self {
         match err {

--- a/src/protocol/grpc/errors/parser_error.rs
+++ b/src/protocol/grpc/errors/parser_error.rs
@@ -19,6 +19,20 @@ pub enum ParserErrorInnerProto {
     RecursionLimitExceeded(bool),
 }
 
+/// Mirrors `ParserError`'s `Display` without needing the type itself, so that endpoints built
+/// without the `sql` feature can still surface the message an error carried over the wire.
+impl std::fmt::Display for ParserErrorProto {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msg = match self.inner {
+            Some(ParserErrorInnerProto::TokenizerError(ref msg)) => msg.as_str(),
+            Some(ParserErrorInnerProto::ParserError(ref msg)) => msg.as_str(),
+            Some(ParserErrorInnerProto::RecursionLimitExceeded(_)) => "recursion limit exceeded",
+            None => "Malformed protobuf message",
+        };
+        write!(f, "sql parser error: {msg}")
+    }
+}
+
 #[cfg(feature = "sql")]
 impl ParserErrorProto {
     pub fn from_parser_error(err: &ParserError) -> Self {
@@ -70,6 +84,9 @@ mod tests {
             let recovered_error = proto.to_parser_error();
 
             assert_eq!(original_error.to_string(), recovered_error.to_string());
+            // The proto's own `Display` is what endpoints built without `sql` fall back to, so it
+            // must stay in sync with `ParserError`'s.
+            assert_eq!(original_error.to_string(), proto.to_string());
         }
     }
 
@@ -78,5 +95,6 @@ mod tests {
         let malformed_proto = ParserErrorProto { inner: None };
         let recovered_error = malformed_proto.to_parser_error();
         assert!(matches!(recovered_error, ParserError::ParserError(_)));
+        assert_eq!(recovered_error.to_string(), malformed_proto.to_string());
     }
 }


### PR DESCRIPTION
## What

This PR makes `parquet` and `sqlparser` optional, default-on features, so we can turn them off in @paradedb. Our build times are growing quite unwieldy, and we don't make use of these features in our embedded use case, so we'd like to turn them off. Hopefully this benefits others and doesn't get in the way for Datadog.

All tests were run and pass, and we merged this in our fork: paradedb/datafusion-distributed#59.
