### PR TITLE
Expand documentation about `scale_up_leaf_node` guarantees.

### DIFF
--- a/docs/source/advanced/05-custom-distributed-plans.md
+++ b/docs/source/advanced/05-custom-distributed-plans.md
@@ -82,7 +82,10 @@ automatic path. You only place the boundaries; the leaves are scaled for you.
 
 This means a custom leaf node still needs its desired task-count and leaf-scale handlers (or
 `DistributedTaskContext`-based dispatch) registered, just as it would for automatic planning — you do
-**not** need to hand-build `DistributedLeafExec` in your boundary-injection rule.
+**not** need to hand-build `DistributedLeafExec` in your boundary-injection rule. Regardless of how
+`ScaleUpLeafNodeHandler` splits the leaf (via `DistributedLeafExec` variants or a single plan), each node
+must handle `execute(partition, context)` for any partition index probed by upstream stage operators
+(such as `RepartitionExec`), returning an empty stream for unassigned partitions to prevent duplicate rows.
 
 ## Example: a progressive partial-reduction tree
 

--- a/docs/source/user-guide/04-distribute-custom-plan.md
+++ b/docs/source/user-guide/04-distribute-custom-plan.md
@@ -178,11 +178,18 @@ that task's worker:
 ```
 
 ```{note}
+When a task runs on a worker, upstream stage operators (such as `RepartitionExec`)
+may call `execute(partition, context)` for every partition index in the stage's
+requested partition range. Any leaf node returned by a `ScaleUpLeafNodeHandler` —
+whether wrapped in per-task `DistributedLeafExec` variants or as a single plan that
+dispatches internally — must return an empty record batch stream (such as
+`EmptyRecordBatchStream`) for any unassigned `partition` index. If unassigned
+partitions emit data instead of empty streams, duplicate rows will be produced.
+
 If your node dispatches internally — reading
 `DistributedTaskContext::from_ctx(&ctx).task_index` inside `execute()` to decide
 what to produce — you can skip `DistributedLeafExec` and return a single prepared
-plan directly. The runnable `numbers(start, end)` example linked below takes this
-route; the choice is yours.
+plan directly (as in the `numbers(start, end)` example linked below).
 ```
 
 ## Putting it together

--- a/examples/custom_execution_plan.rs
+++ b/examples/custom_execution_plan.rs
@@ -184,6 +184,12 @@ impl ExecutionPlan for NumbersExec {
         _partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
+        // Upstream stage operators (such as RepartitionExec) may call execute() for any
+        // partition index in the stage. Leaf plans returned by scale_up_leaf_node handlers
+        // must return an empty stream for unassigned partition indices to avoid emitting
+        // duplicate rows. NumbersExec exposes a single partition (UnknownPartitioning(1)),
+        // so _partition is 0 here.
+        //
         // Get the distributed task context to determine which subset of numbers
         // this task should generate
         let dist_ctx = DistributedTaskContext::from_ctx(&context);

--- a/examples/custom_worker_url_routing.rs
+++ b/examples/custom_worker_url_routing.rs
@@ -164,6 +164,11 @@ fn cached_file_scan_desired_task_count_handler(
     Some(DesiredTaskCountEventResponse::desired(usize::MAX))
 }
 
+/// Assigns each file to a task slot by hashing its path so the same file always lands in the
+/// same variant slot. Returns a `DistributedLeafExec` containing the per-task variants.
+/// Any leaf node returned by `scale_up_leaf_node` must handle `execute(partition, context)` for
+/// any partition index probed by upstream stage operators (such as `RepartitionExec`), returning
+/// an empty stream for unassigned partitions to prevent duplicate rows.
 fn cached_file_scan_scale_up_leaf_node_handler(
     ev: ScaleUpLeafNodeEvent,
 ) -> Option<Result<ScaleUpLeafNodeEventResponse>> {

--- a/src/distributed_ext.rs
+++ b/src/distributed_ext.rs
@@ -614,6 +614,11 @@ pub trait DistributedExt: Sized {
     /// Registers a handler that can replace leaf nodes with distributed variants once the
     /// distributed planner has decided a final task count.
     ///
+    /// Any leaf node returned by a leaf scaling handler (whether as per-task variants in
+    /// [DistributedLeafExec] or a single plan) must handle `execute(partition, context)` for
+    /// all partition indices in the stage's requested range. Returning data on unassigned
+    /// partitions causes duplicate rows; unassigned partition requests must return an empty stream.
+    ///
     /// A function with the following signature can be provided as argument:
     ///
     /// ```rust

--- a/src/execution_plans/distributed_leaf.rs
+++ b/src/execution_plans/distributed_leaf.rs
@@ -60,6 +60,16 @@ use std::sync::Arc;
 ///
 /// This way, the different workers get to execute different versions of the same plan, each
 /// handling its own range of non-overlapping data.
+///
+/// ## Leaf Execution Contract
+/// When a scaled-up leaf node (or a per-task variant in `DistributedLeafExec`) is executed on a
+/// worker, upstream stage operators (such as `RepartitionExec`) may call
+/// `leaf.execute(partition, context)` for every partition index `partition` in the stage's
+/// requested partition range. Leaf plans or variants that map to a specific physical partition
+/// must return an empty record batch stream (such as `EmptyRecordBatchStream`) when `partition`
+/// does not match their assigned partition, allowing multi-partition stage pipelines to pull and
+/// repartition data without failing. If unassigned partitions emit data instead of returning an
+/// empty stream, duplicate rows will be produced.
 #[derive(Debug)]
 pub struct DistributedLeafExec {
     pub(crate) original: Arc<dyn ExecutionPlan>,


### PR DESCRIPTION
The required behavior of nodes which have been scaled up with `scale_up_leaf_node` can be a bit unintuitive. If you don't correctly modify your `ExecutionPlan` and all partitions continue to emit data, then you will have duplicate rows. 

It would be great to find an approach that didn't require the "empty for all but one partition" behavior, but I couldn't think of one. So this is a PR to expand the docs, rather than a ticket discussing changing this behavior.