### PR TITLE
Upgrade Rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.91"
+channel = "1.94.0"
 profile = "default"

--- a/src/execution_plans/sampler.rs
+++ b/src/execution_plans/sampler.rs
@@ -255,6 +255,7 @@ impl PartitionSampler {
                 // The input produced nothing at all: the stream is exhausted, so this partition
                 // reached EOS with zero rows.
                 reporter.load_info.reached_eos = true;
+                reporter.report(&peek);
                 return Ok(peek.chain(input_stream).boxed());
             };
             let _guard = elapsed_compute.timer();


### PR DESCRIPTION
Upgrades the Rust Toolchain in preparation to some follow up work that brings
iceberg-rust as a dependency

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>