### PR TITLE
feat: allow fractional desired task counts

### DIFF
--- a/docs/source/user-guide/04-distribute-custom-plan.md
+++ b/docs/source/user-guide/04-distribute-custom-plan.md
@@ -115,15 +115,18 @@ fn sharded_scan_desired_task_count(
     // Only handle our own node; returning None lets other handlers try.
     let scan = event.plan.downcast_ref::<ShardedScanExec>()?;
     // One task per shard — the planner caps this at the number of workers.
-    Some(Ok(DesiredTaskCountEventResponse::desired(scan.shards.len())))
+    Some(Ok(DesiredTaskCountEventResponse::desired(
+        scan.shards.len() as f64,
+    )))
 }
 ```
 
 What the return value means:
 
-- `DesiredTaskCountEventResponse::desired(n)` — a **soft** hint. The planner may land on a
-  different number: within a stage the largest `desired` wins, and the count is
-  capped at the number of available workers.
+- `DesiredTaskCountEventResponse::desired(n)` — a **soft** `f64` hint. Fractional hints stay
+  fractional while the planner combines them, then the final stage task count is rounded up.
+  Within a stage the largest `desired` wins, and the count is capped at the number of
+  available workers.
 - `DesiredTaskCountEventResponse::maximum(n)` — a **hard** cap. `maximum(1)` means "this node
   cannot be distributed."
 - `None` — defer to the other registered handlers (and finally the built-in

--- a/docs/upgrade/3.0.0.md
+++ b/docs/upgrade/3.0.0.md
@@ -119,7 +119,9 @@ fn desired_task_count(
 ) -> Option<Result<DesiredTaskCountEventResponse>> {
     // event.plan replaces `plan`; event.session_config replaces `cfg`.
     let my_leaf = event.plan.downcast_ref::<MyLeaf>()?;
-    Some(Ok(DesiredTaskCountEventResponse::desired(my_leaf.task_count())))
+    Some(Ok(DesiredTaskCountEventResponse::desired(
+        my_leaf.task_count() as f64,
+    )))
 }
 
 fn scale_up_leaf(
@@ -144,6 +146,11 @@ let state = SessionStateBuilder::new()
     .with_distributed_route_tasks_handler(route_tasks)
     .build();
 ```
+
+`DesiredTaskCountEventResponse::desired` and `TaskCountAnnotation::Desired` now use
+`f64`. Cast integer expressions passed to `desired`, as above. Fractional hints remain
+fractional while the planner combines them and are rounded up when the final stage task
+count is resolved. `maximum` remains an integer hard cap.
 
 Registration order matters, same as with multiple `TaskEstimator`s. User
 handlers run in registration order before built-in fallbacks. For the

--- a/docs/upgrade/3.0.0.md
+++ b/docs/upgrade/3.0.0.md
@@ -119,9 +119,7 @@ fn desired_task_count(
 ) -> Option<Result<DesiredTaskCountEventResponse>> {
     // event.plan replaces `plan`; event.session_config replaces `cfg`.
     let my_leaf = event.plan.downcast_ref::<MyLeaf>()?;
-    Some(Ok(DesiredTaskCountEventResponse::desired(
-        my_leaf.task_count() as f64,
-    )))
+    Some(Ok(DesiredTaskCountEventResponse::desired(my_leaf.task_count())))
 }
 
 fn scale_up_leaf(
@@ -146,11 +144,6 @@ let state = SessionStateBuilder::new()
     .with_distributed_route_tasks_handler(route_tasks)
     .build();
 ```
-
-`DesiredTaskCountEventResponse::desired` and `TaskCountAnnotation::Desired` now use
-`f64`. Cast integer expressions passed to `desired`, as above. Fractional hints remain
-fractional while the planner combines them and are rounded up when the final stage task
-count is resolved. `maximum` remains an integer hard cap.
 
 Registration order matters, same as with multiple `TaskEstimator`s. User
 handlers run in registration order before built-in fallbacks. For the

--- a/docs/upgrade/5.0.0.md
+++ b/docs/upgrade/5.0.0.md
@@ -1,0 +1,21 @@
+# Upgrading from 4.0.0 to 5.0.0
+
+This guide covers the source and behavioural changes merged after the
+`v4.0.0` tag.
+
+## 1. `DesiredTaskCountEventResponse::desired` now takes `f64`
+
+`DesiredTaskCountEventResponse::desired` and `TaskCountAnnotation::Desired` now
+use `f64`. Cast integer expressions passed to `desired`. Fractional hints remain
+fractional while the planner combines them and are rounded up when the final
+stage task count is resolved. `maximum` remains an integer hard cap.
+
+```rust
+// 4.0
+Some(Ok(DesiredTaskCountEventResponse::desired(scan.shards.len())))
+
+// 5.0
+Some(Ok(DesiredTaskCountEventResponse::desired(
+    scan.shards.len() as f64,
+)))
+```

--- a/examples/custom_execution_plan.rs
+++ b/examples/custom_execution_plan.rs
@@ -321,9 +321,7 @@ fn numbers_desired_task_count_handler(
     let task_count = (plan.ranges_per_task[0].end - plan.ranges_per_task[0].start) as f64
         / cfg.numbers_per_task as f64;
 
-    Some(Ok(DesiredTaskCountEventResponse::desired(
-        task_count.ceil() as usize,
-    )))
+    Some(Ok(DesiredTaskCountEventResponse::desired(task_count)))
 }
 
 fn numbers_scale_up_leaf_node_handler(

--- a/examples/custom_worker_url_routing.rs
+++ b/examples/custom_worker_url_routing.rs
@@ -169,9 +169,7 @@ fn cached_file_scan_desired_task_count_handler(
     ev: DesiredTaskCountEvent,
 ) -> Option<Result<DesiredTaskCountEventResponse>> {
     ev.plan.downcast_ref::<CacheExec>()?;
-    Some(Ok(DesiredTaskCountEventResponse::desired(
-        usize::MAX as f64,
-    )))
+    Some(Ok(DesiredTaskCountEventResponse::desired(f64::MAX)))
 }
 
 fn cached_file_scan_scale_up_leaf_node_handler(

--- a/examples/custom_worker_url_routing.rs
+++ b/examples/custom_worker_url_routing.rs
@@ -169,7 +169,9 @@ fn cached_file_scan_desired_task_count_handler(
     ev: DesiredTaskCountEvent,
 ) -> Option<Result<DesiredTaskCountEventResponse>> {
     ev.plan.downcast_ref::<CacheExec>()?;
-    Some(Ok(DesiredTaskCountEventResponse::desired(usize::MAX)))
+    Some(Ok(DesiredTaskCountEventResponse::desired(
+        usize::MAX as f64,
+    )))
 }
 
 fn cached_file_scan_scale_up_leaf_node_handler(

--- a/examples/work_unit_feed.rs
+++ b/examples/work_unit_feed.rs
@@ -266,7 +266,9 @@ fn remote_scan_desired_task_count_handler(
         .feed
         .inner()?
         .task_count;
-    Some(Ok(DesiredTaskCountEventResponse::desired(task_count)))
+    Some(Ok(DesiredTaskCountEventResponse::desired(
+        task_count as f64,
+    )))
 }
 
 fn remote_scan_scale_up_leaf_node_handler(

--- a/src/common/recursion.rs
+++ b/src/common/recursion.rs
@@ -117,10 +117,15 @@ impl TreeNodeExt for Arc<dyn ExecutionPlan> {
             f(plan, ctx)?.visit_children(|| {
                 if let Some(ciu) = plan.downcast_ref::<ChildrenIsolatorUnionExec>() {
                     // Just recurse to children that will actually get executed by this
-                    // ChildrenIsolatorUnionExec.
-                    ciu.task_idx_map[ctx.task_index].iter().apply_until_stop(
-                        |(child_i, child_ctx)| recurse(&ciu.children[*child_i], *child_ctx, f),
-                    )
+                    // ChildrenIsolatorUnionExec. A zero-task (empty) stage has no slots.
+                    ciu.task_idx_map
+                        .get(ctx.task_index)
+                        .map(Vec::as_slice)
+                        .unwrap_or(&[])
+                        .iter()
+                        .apply_until_stop(|(child_i, child_ctx)| {
+                            recurse(&ciu.children[*child_i], *child_ctx, f)
+                        })
                 } else if plan.is_network_boundary() {
                     Ok(TreeNodeRecursion::Continue)
                 } else {
@@ -194,8 +199,10 @@ impl TreeNodeExt for Arc<dyn ExecutionPlan> {
             let node = &transformed.data;
             if let Some(ciu) = node.downcast_ref::<ChildrenIsolatorUnionExec>() {
                 let mut child_ctxs = vec![None; ciu.children.len()];
-                for (child_idx, child_ctx) in &ciu.task_idx_map[dt_ctx.task_index] {
-                    child_ctxs[*child_idx] = Some(*child_ctx);
+                if let Some(children_in_task) = ciu.task_idx_map.get(dt_ctx.task_index) {
+                    for (child_idx, child_ctx) in children_in_task {
+                        child_ctxs[*child_idx] = Some(*child_ctx);
+                    }
                 }
                 stack.extend(child_ctxs.into_iter().rev());
             } else {

--- a/src/coordinator/prepare_dynamic_plan.rs
+++ b/src/coordinator/prepare_dynamic_plan.rs
@@ -107,10 +107,13 @@ pub(super) async fn prepare_dynamic_plan(
                     let (stats, new_metrics) =
                         gather_runtime_statistics(load_info_rxs, &input_stage.plan).await?;
                     metrics.extend(new_metrics);
-                    // returning Desired(1) here is our way to tell the planner that we don't care
+                    // returning Desired(0) here is our way to tell the planner that we don't care
                     // about the task count assigned to the network boundary in the consumer stage,
-                    // and we don't want it to affect other task count decisions.
-                    (Some(Arc::new(stats)), Desired(1.0))
+                    // and we don't want it to affect other task count decisions. A 0.0 hint does
+                    // not mask smaller fractional values via max-merge, and does not inflate
+                    // UNION sums when this boundary sits under a child of a
+                    // ChildrenIsolatorUnionExec.
+                    (Some(Arc::new(stats)), Desired(0.0))
                 };
 
                 // Capture the output partitioning of the (rescaled, sampler-wrapped) input plan

--- a/src/coordinator/prepare_dynamic_plan.rs
+++ b/src/coordinator/prepare_dynamic_plan.rs
@@ -68,7 +68,7 @@ pub(super) async fn prepare_dynamic_plan(
                 .clamp(1, nb_ctx.max_tasks()?);
             let task_count = nb_ctx
                 .task_count(&input_stage.plan)?
-                .merge(Desired(compute_based_task_count));
+                .merge(Desired(compute_based_task_count as f64));
 
             // Propagate the final task_count inferred based on runtime statistics and compute cost.
             // Here is where leaf nodes are scaled up by ScaleUpLeafNodeHandler, and the
@@ -110,7 +110,7 @@ pub(super) async fn prepare_dynamic_plan(
                     // returning Desired(1) here is our way to tell the planner that we don't care
                     // about the task count assigned to the network boundary in the consumer stage,
                     // and we don't want it to affect other task count decisions.
-                    (Some(Arc::new(stats)), Desired(1))
+                    (Some(Arc::new(stats)), Desired(1.0))
                 };
 
                 // Capture the output partitioning of the (rescaled, sampler-wrapped) input plan

--- a/src/distributed_ext.rs
+++ b/src/distributed_ext.rs
@@ -589,7 +589,7 @@ pub trait DistributedExt: Sized {
     ///
     /// fn handle_custom_desired_task_count(event: DesiredTaskCountEvent) -> Option<Result<DesiredTaskCountEventResponse>> {
     ///     let _exec = event.plan.downcast_ref::<EmptyExec>()?;
-    ///     Some(Ok(DesiredTaskCountEventResponse::desired(3)))
+    ///     Some(Ok(DesiredTaskCountEventResponse::desired(3.0)))
     /// }
     ///
     /// SessionStateBuilder::new()

--- a/src/distributed_planner/inject_network_boundaries.rs
+++ b/src/distributed_planner/inject_network_boundaries.rs
@@ -790,8 +790,8 @@ mod tests {
             .broadcast_joins(false);
         let annotated = annotate_test_plan(test_plan_builder, query).await;
         assert_snapshot!(annotated, @"
-        HashJoinExec: task_count=Desired(2)
-          NetworkShuffleExec: task_count=Desired(2)
+        HashJoinExec: task_count=Desired(1.3333333333333333)
+          NetworkShuffleExec: task_count=Desired(1.3333333333333333)
             RepartitionExec: task_count=Desired(2)
               ProjectionExec: task_count=Desired(2)
                 AggregateExec: task_count=Desired(2)
@@ -801,7 +801,7 @@ mod tests {
                         FilterExec: task_count=Desired(4)
                           RepartitionExec: task_count=Desired(4)
                             DistributedLeafExec: task_count=Desired(4)
-          NetworkShuffleExec: task_count=Desired(2)
+          NetworkShuffleExec: task_count=Desired(1.3333333333333333)
             RepartitionExec: task_count=Desired(2)
               ProjectionExec: task_count=Desired(2)
                 AggregateExec: task_count=Desired(2)
@@ -850,8 +850,8 @@ mod tests {
             .broadcast_joins(false);
         let annotated = annotate_test_plan(test_plan_builder, query).await;
         assert_snapshot!(annotated, @r"
-        AggregateExec: task_count=Desired(3)
-          NetworkShuffleExec: task_count=Desired(3)
+        AggregateExec: task_count=Desired(2.6666666666666665)
+          NetworkShuffleExec: task_count=Desired(2.6666666666666665)
             RepartitionExec: task_count=Desired(4)
               AggregateExec: task_count=Desired(4)
                 DistributedLeafExec: task_count=Desired(4)
@@ -1003,8 +1003,8 @@ mod tests {
             .desired_task_count_handler(repartition_max_one_desired_task_count_handler);
         let annotated = annotate_test_plan(test_plan_builder, query).await;
         assert_snapshot!(annotated, @r"
-        AggregateExec: task_count=Desired(1)
-          NetworkShuffleExec: task_count=Desired(1)
+        AggregateExec: task_count=Desired(0.6666666666666666)
+          NetworkShuffleExec: task_count=Desired(0.6666666666666666)
             RepartitionExec: task_count=Desired(1)
               AggregateExec: task_count=Desired(1)
                 DistributedLeafExec: task_count=Desired(1)

--- a/src/distributed_planner/inject_network_boundaries.rs
+++ b/src/distributed_planner/inject_network_boundaries.rs
@@ -790,8 +790,8 @@ mod tests {
             .broadcast_joins(false);
         let annotated = annotate_test_plan(test_plan_builder, query).await;
         assert_snapshot!(annotated, @"
-        HashJoinExec: task_count=Desired(1.3333333333333333)
-          NetworkShuffleExec: task_count=Desired(1.3333333333333333)
+        HashJoinExec: task_count=Desired(1.33)
+          NetworkShuffleExec: task_count=Desired(1.33)
             RepartitionExec: task_count=Desired(2)
               ProjectionExec: task_count=Desired(2)
                 AggregateExec: task_count=Desired(2)
@@ -801,7 +801,7 @@ mod tests {
                         FilterExec: task_count=Desired(4)
                           RepartitionExec: task_count=Desired(4)
                             DistributedLeafExec: task_count=Desired(4)
-          NetworkShuffleExec: task_count=Desired(1.3333333333333333)
+          NetworkShuffleExec: task_count=Desired(1.33)
             RepartitionExec: task_count=Desired(2)
               ProjectionExec: task_count=Desired(2)
                 AggregateExec: task_count=Desired(2)
@@ -850,8 +850,8 @@ mod tests {
             .broadcast_joins(false);
         let annotated = annotate_test_plan(test_plan_builder, query).await;
         assert_snapshot!(annotated, @r"
-        AggregateExec: task_count=Desired(2.6666666666666665)
-          NetworkShuffleExec: task_count=Desired(2.6666666666666665)
+        AggregateExec: task_count=Desired(2.67)
+          NetworkShuffleExec: task_count=Desired(2.67)
             RepartitionExec: task_count=Desired(4)
               AggregateExec: task_count=Desired(4)
                 DistributedLeafExec: task_count=Desired(4)
@@ -911,6 +911,32 @@ mod tests {
               RepartitionExec: task_count=Maximum(1)
                 DistributedLeafExec: task_count=Maximum(1)
         ")
+    }
+
+    #[tokio::test]
+    async fn test_union_all_zero_task_count_leaves() {
+        let query = r#"
+        SELECT "MinTemp" FROM weather WHERE "RainToday" = 'yes'
+        UNION ALL
+        SELECT "MaxTemp" FROM weather WHERE "RainToday" = 'no'
+        "#;
+        let test_plan_builder = TestPlanBuilder::new()
+            .target_partitions(4)
+            .num_workers(4)
+            .distributed_planner(false)
+            .broadcast_joins(false)
+            .desired_task_count_handler(zero_leaf_desired_task_count_handler);
+        // Two 0.0 leaf hints sum to Desired(0) before rounding. The isolator
+        // then rejects a zero-task union as an internal planning error rather
+        // than silently collapsing to a single task.
+        let err = annotate_test_plan_result(test_plan_builder, query)
+            .await
+            .expect_err("zero-task union should fail planning");
+        assert!(
+            err.to_string()
+                .contains("ChildrenIsolatorUnionExec had a task count 0"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]
@@ -1003,8 +1029,8 @@ mod tests {
             .desired_task_count_handler(repartition_max_one_desired_task_count_handler);
         let annotated = annotate_test_plan(test_plan_builder, query).await;
         assert_snapshot!(annotated, @r"
-        AggregateExec: task_count=Desired(0.6666666666666666)
-          NetworkShuffleExec: task_count=Desired(0.6666666666666666)
+        AggregateExec: task_count=Desired(0.67)
+          NetworkShuffleExec: task_count=Desired(0.67)
             RepartitionExec: task_count=Desired(1)
               AggregateExec: task_count=Desired(1)
                 DistributedLeafExec: task_count=Desired(1)
@@ -1373,6 +1399,15 @@ mod tests {
             .then(|| Ok(DesiredTaskCountEventResponse::desired(0.5)))
     }
 
+    fn zero_leaf_desired_task_count_handler(
+        ev: DesiredTaskCountEvent,
+    ) -> Option<Result<DesiredTaskCountEventResponse>> {
+        ev.plan
+            .children()
+            .is_empty()
+            .then(|| Ok(DesiredTaskCountEventResponse::desired(0.0)))
+    }
+
     fn broadcast_build_coalesce_max_desired_task_count_handler(
         ev: DesiredTaskCountEvent,
     ) -> Option<Result<DesiredTaskCountEventResponse>> {
@@ -1384,16 +1419,22 @@ mod tests {
     }
 
     async fn annotate_test_plan(test_plan_builder: TestPlanBuilder, query: &str) -> String {
+        annotate_test_plan_result(test_plan_builder, query)
+            .await
+            .expect("failed to annotate plan")
+    }
+
+    async fn annotate_test_plan_result(
+        test_plan_builder: TestPlanBuilder,
+        query: &str,
+    ) -> datafusion::error::Result<String> {
         let test_plan = test_plan_builder.build().await;
         let plan = test_plan.physical_plan(query).await;
         let session_config = test_plan.get_ctx().copied_config();
 
-        let plan = normalize_collect_joins(plan, session_config.options())
-            .expect("failed to normalize collect joins");
-        let plan = insert_broadcast_execs(plan, session_config.options())
-            .expect("failed to insert broadcasts");
-        let plan = insert_children_isolator_unions(plan, session_config.options())
-            .expect("failed to insert children isolator unions");
+        let plan = normalize_collect_joins(plan, session_config.options())?;
+        let plan = insert_broadcast_execs(plan, session_config.options())?;
+        let plan = insert_children_isolator_unions(plan, session_config.options())?;
         let network_boundaries_ctx = InjectNetworkBoundaryContext {
             cfg: &session_config,
             d_cfg: DistributedConfig::from_config_options(session_config.options()).unwrap(),
@@ -1404,10 +1445,8 @@ mod tests {
             nb_builder: &CardinalityBasedNetworkBoundaryBuilder,
         };
 
-        let annotated = _inject_network_boundaries(plan, None, &network_boundaries_ctx)
-            .await
-            .expect("failed to annotate plan");
-        debug_annotated(&annotated, 0, &network_boundaries_ctx)
+        let annotated = _inject_network_boundaries(plan, None, &network_boundaries_ctx).await?;
+        Ok(debug_annotated(&annotated, 0, &network_boundaries_ctx))
     }
 
     fn debug_annotated(

--- a/src/distributed_planner/inject_network_boundaries.rs
+++ b/src/distributed_planner/inject_network_boundaries.rs
@@ -263,9 +263,9 @@ async fn _inject_network_boundaries(
         // Isolating unions have the chance to decide how many tasks they should run on. If there
         // is a union with a bunch of children, the user might want to increase parallelism and the
         // task count for the stage running that.
-        let mut count = 0;
+        let mut count = 0.0;
         for processed_child in processed_children.iter() {
-            count += nb_ctx.task_count(processed_child)?.as_usize();
+            count += nb_ctx.task_count(processed_child)?.as_f64();
         }
         Desired(count)
     } else if let Some(node) = plan.downcast_ref::<HashJoinExec>()
@@ -302,7 +302,9 @@ async fn _inject_network_boundaries(
         // broadcasts are unavailable.
         Maximum(1)
     } else {
-        let mut task_count = desired_task_count.unwrap_or(Desired(1));
+        // Default to 0.0 so an absent hint does not inflate children's fractional
+        // values via max-merge.
+        let mut task_count = desired_task_count.unwrap_or(Desired(0.0));
         // The task count for this plan is decided by the biggest task count from the children; unless
         // a child specifies a maximum task count, in that case, the maximum is respected. Some
         // nodes can only run in one task. If there is a subplan with a single node declaring that
@@ -485,7 +487,7 @@ impl InjectNetworkBoundaryContext<'_> {
                 children
                     .iter()
                     .map(|v| match self.task_count(v)? {
-                        Desired(n) => Ok(ChildWeight::desired(n as f64)),
+                        Desired(n) => Ok(ChildWeight::desired(n)),
                         Maximum(n) => Ok(ChildWeight::maximum(n)),
                     })
                     .collect::<Result<Vec<_>>>()?,
@@ -614,7 +616,7 @@ impl NetworkBoundaryBuilder for CardinalityBasedNetworkBoundaryBuilder {
     ) -> Result<NetworkBoundaryBuilderResult> {
         input_stage.plan = nb_ctx.propagate_task_count_until_network_boundaries(
             &input_stage.plan,
-            Desired(input_stage.tasks),
+            Desired(input_stage.tasks as f64),
         )?;
         let input_properties = Arc::clone(input_stage.plan.properties());
 
@@ -650,7 +652,7 @@ impl NetworkBoundaryBuilder for CardinalityBasedNetworkBoundaryBuilder {
         let f = calculate_scale_factor(&input_stage.plan, nb_ctx.d_cfg);
 
         Ok(NetworkBoundaryBuilderResult {
-            consumer_task_count: Desired((f * input_stage.tasks as f64).ceil() as usize),
+            consumer_task_count: Desired(f * input_stage.tasks as f64),
             input_stage: Stage::Local(input_stage),
             input_properties,
         })
@@ -879,6 +881,32 @@ mod tests {
             FilterExec: task_count=Maximum(2)
               RepartitionExec: task_count=Maximum(2)
                 DistributedLeafExec: task_count=Maximum(2)
+        ")
+    }
+
+    #[tokio::test]
+    async fn test_union_all_sums_fractional_task_counts_before_rounding() {
+        let query = r#"
+        SELECT "MinTemp" FROM weather WHERE "RainToday" = 'yes'
+        UNION ALL
+        SELECT "MaxTemp" FROM weather WHERE "RainToday" = 'no'
+        "#;
+        let test_plan_builder = TestPlanBuilder::new()
+            .target_partitions(4)
+            .num_workers(4)
+            .distributed_planner(false)
+            .broadcast_joins(false)
+            .desired_task_count_handler(0.5);
+        let annotated = annotate_test_plan(test_plan_builder, query).await;
+        assert_snapshot!(annotated, @r"
+        ChildrenIsolatorUnionExec: task_count=Desired(1)
+          FilterExec: task_count=Maximum(1)
+            RepartitionExec: task_count=Maximum(1)
+              DistributedLeafExec: task_count=Maximum(1)
+          ProjectionExec: task_count=Maximum(1)
+            FilterExec: task_count=Maximum(1)
+              RepartitionExec: task_count=Maximum(1)
+                DistributedLeafExec: task_count=Maximum(1)
         ")
     }
 

--- a/src/distributed_planner/inject_network_boundaries.rs
+++ b/src/distributed_planner/inject_network_boundaries.rs
@@ -896,8 +896,11 @@ mod tests {
             .num_workers(4)
             .distributed_planner(false)
             .broadcast_joins(false)
-            .desired_task_count_handler(0.5);
+            .desired_task_count_handler(fractional_leaf_desired_task_count_handler);
         let annotated = annotate_test_plan(test_plan_builder, query).await;
+        // Desired(1) proves the two 0.5 leaf hints were summed before the final rounding.
+        // The children are Maximum(1) because union slot allocation then propagates each
+        // child's assigned task count as a hard cap.
         assert_snapshot!(annotated, @r"
         ChildrenIsolatorUnionExec: task_count=Desired(1)
           FilterExec: task_count=Maximum(1)
@@ -1359,6 +1362,15 @@ mod tests {
     ) -> Option<Result<DesiredTaskCountEventResponse>> {
         ev.plan.downcast_ref::<RepartitionExec>()?;
         Some(Ok(DesiredTaskCountEventResponse::maximum(1)))
+    }
+
+    fn fractional_leaf_desired_task_count_handler(
+        ev: DesiredTaskCountEvent,
+    ) -> Option<Result<DesiredTaskCountEventResponse>> {
+        ev.plan
+            .children()
+            .is_empty()
+            .then(|| Ok(DesiredTaskCountEventResponse::desired(0.5)))
     }
 
     fn broadcast_build_coalesce_max_desired_task_count_handler(

--- a/src/distributed_planner/inject_network_boundaries.rs
+++ b/src/distributed_planner/inject_network_boundaries.rs
@@ -445,6 +445,10 @@ impl InjectNetworkBoundaryContext<'_> {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // Handle leaf nodes.
         if plan.children().is_empty() {
+            // A zero-task stage (empty datasets) has nothing to distribute.
+            if task_count.as_usize() == 0 {
+                return Ok(self.plan_with_task_count(Arc::clone(plan), task_count));
+            }
             let ev = ScaleUpLeafNodeEvent {
                 plan,
                 task_count: task_count.as_usize(),
@@ -926,17 +930,19 @@ mod tests {
             .distributed_planner(false)
             .broadcast_joins(false)
             .desired_task_count_handler(zero_leaf_desired_task_count_handler);
-        // Two 0.0 leaf hints sum to Desired(0) before rounding. The isolator
-        // then rejects a zero-task union as an internal planning error rather
-        // than silently collapsing to a single task.
-        let err = annotate_test_plan_result(test_plan_builder, query)
-            .await
-            .expect_err("zero-task union should fail planning");
-        assert!(
-            err.to_string()
-                .contains("ChildrenIsolatorUnionExec had a task count 0"),
-            "unexpected error: {err}"
-        );
+        let annotated = annotate_test_plan(test_plan_builder, query).await;
+        // Two 0.0 leaf hints sum to Desired(0). That is a valid empty stage
+        // (every dataset under the union is empty), not a planning error.
+        assert_snapshot!(annotated, @r"
+        ChildrenIsolatorUnionExec: task_count=Desired(0)
+          FilterExec: task_count=Maximum(0)
+            RepartitionExec: task_count=Maximum(0)
+              DataSourceExec: task_count=Maximum(0)
+          ProjectionExec: task_count=Maximum(0)
+            FilterExec: task_count=Maximum(0)
+              RepartitionExec: task_count=Maximum(0)
+                DataSourceExec: task_count=Maximum(0)
+        ")
     }
 
     #[tokio::test]
@@ -1419,22 +1425,16 @@ mod tests {
     }
 
     async fn annotate_test_plan(test_plan_builder: TestPlanBuilder, query: &str) -> String {
-        annotate_test_plan_result(test_plan_builder, query)
-            .await
-            .expect("failed to annotate plan")
-    }
-
-    async fn annotate_test_plan_result(
-        test_plan_builder: TestPlanBuilder,
-        query: &str,
-    ) -> datafusion::error::Result<String> {
         let test_plan = test_plan_builder.build().await;
         let plan = test_plan.physical_plan(query).await;
         let session_config = test_plan.get_ctx().copied_config();
 
-        let plan = normalize_collect_joins(plan, session_config.options())?;
-        let plan = insert_broadcast_execs(plan, session_config.options())?;
-        let plan = insert_children_isolator_unions(plan, session_config.options())?;
+        let plan = normalize_collect_joins(plan, session_config.options())
+            .expect("failed to normalize collect joins");
+        let plan = insert_broadcast_execs(plan, session_config.options())
+            .expect("failed to insert broadcasts");
+        let plan = insert_children_isolator_unions(plan, session_config.options())
+            .expect("failed to insert children isolator unions");
         let network_boundaries_ctx = InjectNetworkBoundaryContext {
             cfg: &session_config,
             d_cfg: DistributedConfig::from_config_options(session_config.options()).unwrap(),
@@ -1445,8 +1445,10 @@ mod tests {
             nb_builder: &CardinalityBasedNetworkBoundaryBuilder,
         };
 
-        let annotated = _inject_network_boundaries(plan, None, &network_boundaries_ctx).await?;
-        Ok(debug_annotated(&annotated, 0, &network_boundaries_ctx))
+        let annotated = _inject_network_boundaries(plan, None, &network_boundaries_ctx)
+            .await
+            .expect("failed to annotate plan");
+        debug_annotated(&annotated, 0, &network_boundaries_ctx)
     }
 
     fn debug_annotated(

--- a/src/events/defaults/file_scan_config.rs
+++ b/src/events/defaults/file_scan_config.rs
@@ -30,7 +30,9 @@ pub(crate) fn file_scan_config_desired_task_count(
         .div_ceil(d_cfg.file_scan_config_bytes_per_partition)
         .div_ceil(cfg.target_partitions());
 
-    Some(Ok(DesiredTaskCountEventResponse::desired(task_count)))
+    Some(Ok(DesiredTaskCountEventResponse::desired(
+        task_count as f64,
+    )))
 }
 
 pub(crate) fn file_scan_config_scale_up_leaf_node(
@@ -200,11 +202,11 @@ mod tests {
     }
 
     fn desired_ten(_: DesiredTaskCountEvent) -> Option<Result<DesiredTaskCountEventResponse>> {
-        Some(Ok(DesiredTaskCountEventResponse::desired(10)))
+        Some(Ok(DesiredTaskCountEventResponse::desired(10.0)))
     }
 
     fn desired_twenty(_: DesiredTaskCountEvent) -> Option<Result<DesiredTaskCountEventResponse>> {
-        Some(Ok(DesiredTaskCountEventResponse::desired(20)))
+        Some(Ok(DesiredTaskCountEventResponse::desired(20.0)))
     }
 
     fn no_desired_task_count(
@@ -214,6 +216,6 @@ mod tests {
     }
 
     fn desired_thirty(_: DesiredTaskCountEvent) -> Option<Result<DesiredTaskCountEventResponse>> {
-        Some(Ok(DesiredTaskCountEventResponse::desired(30)))
+        Some(Ok(DesiredTaskCountEventResponse::desired(30.0)))
     }
 }

--- a/src/events/defaults/file_scan_config.rs
+++ b/src/events/defaults/file_scan_config.rs
@@ -38,6 +38,10 @@ pub(crate) fn file_scan_config_scale_up_leaf_node(
 ) -> Option<Result<ScaleUpLeafNodeEventResponse>> {
     let dse = ev.plan.downcast_ref::<DataSourceExec>()?;
     let file_scan = dse.data_source().downcast_ref::<FileScanConfig>()?;
+    // Empty stages have nothing to split across tasks.
+    if ev.task_count == 0 {
+        return None;
+    }
     let partition_count = ev.plan.output_partitioning().partition_count();
 
     let rebalanced = if file_scan.output_partitioning.is_some() {

--- a/src/events/defaults/file_scan_config.rs
+++ b/src/events/defaults/file_scan_config.rs
@@ -26,13 +26,11 @@ pub(crate) fn file_scan_config_desired_task_count(
         }
     }
 
-    let task_count = total_bytes
-        .div_ceil(d_cfg.file_scan_config_bytes_per_partition)
-        .div_ceil(cfg.target_partitions());
+    let bytes_per_partition = d_cfg.file_scan_config_bytes_per_partition.max(1) as f64;
+    let target_partitions = cfg.target_partitions().max(1) as f64;
+    let task_count = total_bytes as f64 / bytes_per_partition / target_partitions;
 
-    Some(Ok(DesiredTaskCountEventResponse::desired(
-        task_count as f64,
-    )))
+    Some(Ok(DesiredTaskCountEventResponse::desired(task_count)))
 }
 
 pub(crate) fn file_scan_config_scale_up_leaf_node(

--- a/src/events/desired_task_count.rs
+++ b/src/events/desired_task_count.rs
@@ -176,19 +176,6 @@ impl DesiredTaskCountHandler for usize {
 }
 
 #[async_trait]
-impl DesiredTaskCountHandler for f64 {
-    async fn handle(
-        &self,
-        ev: DesiredTaskCountEvent<'_>,
-    ) -> Option<Result<DesiredTaskCountEventResponse>> {
-        ev.plan
-            .children()
-            .is_empty()
-            .then(|| Ok(DesiredTaskCountEventResponse::desired(*self)))
-    }
-}
-
-#[async_trait]
 impl DesiredTaskCountHandler for Arc<dyn DesiredTaskCountHandler> {
     async fn handle(
         &self,
@@ -213,16 +200,5 @@ impl DesiredTaskCountHandlers {
             }
         }
         None
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn fractional_desired_task_count_rounds_up_when_resolved() {
-        assert_eq!(Desired(0.5).as_usize(), 1);
-        assert_eq!(Desired(1.25).as_usize(), 2);
     }
 }

--- a/src/events/desired_task_count.rs
+++ b/src/events/desired_task_count.rs
@@ -4,19 +4,30 @@ use async_trait::async_trait;
 use datafusion::common::Result;
 use datafusion::execution::config::SessionConfig;
 use datafusion::physical_plan::ExecutionPlan;
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 /// Annotation attached to a single [ExecutionPlan] that determines how many distributed tasks
 /// it should run on.
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub enum TaskCountAnnotation {
     /// The desired number of distributed tasks for this node. The final task count for the
     /// annotated node might not be exactly this number, it is more like a hint, so depending
     /// on the desired task count of adjacent nodes, the final task count might change.
-    Desired(usize),
+    /// Fractional values are kept while hints are combined and rounded up when the final task
+    /// count is resolved.
+    Desired(f64),
     /// Sets a maximum number of distributed tasks for this node. Typically used with the inner
     /// value of 1, stating that this node cannot be executed in a distributed fashion.
     Maximum(usize),
+}
+
+impl fmt::Debug for TaskCountAnnotation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Desired(desired) => write!(f, "Desired({desired})"),
+            Maximum(maximum) => write!(f, "Maximum({maximum})"),
+        }
+    }
 }
 
 /// Information supplied when the planner asks a handler for a node's desired task count.
@@ -68,7 +79,7 @@ impl DesiredTaskCountEventResponse {
     /// - Other nodes providing a `DesiredTaskCountEventResponse::desired(M)` where `M` > `N`.
     /// - Any other node providing a `DesiredTaskCountEventResponse::maximum(M)` where `M` can be
     ///   anything.
-    pub fn desired(value: usize) -> Self {
+    pub fn desired(value: f64) -> Self {
         DesiredTaskCountEventResponse {
             task_count: Desired(value),
         }
@@ -108,21 +119,28 @@ impl From<TaskCountAnnotation> for usize {
 impl TaskCountAnnotation {
     pub fn as_usize(&self) -> usize {
         match self {
-            Desired(desired) => *desired,
+            Desired(desired) => desired.ceil() as usize,
             Maximum(maximum) => *maximum,
+        }
+    }
+
+    pub(crate) fn as_f64(&self) -> f64 {
+        match self {
+            Desired(desired) => *desired,
+            Maximum(maximum) => *maximum as f64,
         }
     }
 
     pub(crate) fn limit(self, limit: usize) -> Self {
         match self {
-            Desired(desired) => Desired(desired.min(limit)),
+            Desired(desired) => Desired(desired.min(limit as f64)),
             Maximum(maximum) => Maximum(maximum.min(limit)),
         }
     }
 
     pub(crate) fn merge(self, other: TaskCountAnnotation) -> Self {
         match (self, other) {
-            (Desired(a), Desired(b)) => Desired(std::cmp::max(a, b)),
+            (Desired(a), Desired(b)) => Desired(a.max(b)),
             (Desired(_), Maximum(b)) => Maximum(b),
             (Maximum(a), Desired(_)) => Maximum(a),
             (Maximum(a), Maximum(b)) => Maximum(std::cmp::min(a, b)),
@@ -146,6 +164,19 @@ where
 
 #[async_trait]
 impl DesiredTaskCountHandler for usize {
+    async fn handle(
+        &self,
+        ev: DesiredTaskCountEvent<'_>,
+    ) -> Option<Result<DesiredTaskCountEventResponse>> {
+        ev.plan
+            .children()
+            .is_empty()
+            .then(|| Ok(DesiredTaskCountEventResponse::desired(*self as f64)))
+    }
+}
+
+#[async_trait]
+impl DesiredTaskCountHandler for f64 {
     async fn handle(
         &self,
         ev: DesiredTaskCountEvent<'_>,
@@ -182,5 +213,16 @@ impl DesiredTaskCountHandlers {
             }
         }
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fractional_desired_task_count_rounds_up_when_resolved() {
+        assert_eq!(Desired(0.5).as_usize(), 1);
+        assert_eq!(Desired(1.25).as_usize(), 2);
     }
 }

--- a/src/events/desired_task_count.rs
+++ b/src/events/desired_task_count.rs
@@ -24,7 +24,8 @@ pub enum TaskCountAnnotation {
 impl fmt::Debug for TaskCountAnnotation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Desired(desired) => write!(f, "Desired({desired})"),
+            Desired(desired) if desired.fract() == 0.0 => write!(f, "Desired({desired})"),
+            Desired(desired) => write!(f, "Desired({desired:.2})"),
             Maximum(maximum) => write!(f, "Maximum({maximum})"),
         }
     }

--- a/src/execution_plans/children_isolator_union.rs
+++ b/src/execution_plans/children_isolator_union.rs
@@ -171,11 +171,15 @@ impl ChildrenIsolatorUnionExec {
                 partition_counts[t] += children[*child_idx].output_partitioning().partition_count();
             }
         }
-        let Some(partition_count) = partition_counts.iter().max() else {
-            return internal_err!(
-                "ChildrenIsolatorUnionExec built an empty task_idx_map. This is a bug in the distributed planning logic, please report it"
-            );
-        };
+        // A `Desired(0)` union (every leaf empty) produces an empty task map. Advertise the
+        // children's partition counts so the node stays a valid empty stage rather than erroring.
+        let partition_count = partition_counts.iter().copied().max().unwrap_or_else(|| {
+            children
+                .iter()
+                .map(|c| c.output_partitioning().partition_count())
+                .max()
+                .unwrap_or(0)
+        });
 
         // It's not supper efficient to build a UnionExec just to get the properties out, but the
         // other solution is to copy-paste a bunch of code from upstream for computing the properties
@@ -184,7 +188,7 @@ impl ChildrenIsolatorUnionExec {
             .properties()
             .as_ref()
             .clone();
-        properties.partitioning = Partitioning::UnknownPartitioning(*partition_count);
+        properties.partitioning = Partitioning::UnknownPartitioning(partition_count);
         Ok(Self {
             properties: Arc::new(properties),
             metrics: ExecutionPlanMetricsSet::default(),
@@ -210,7 +214,7 @@ impl ChildrenIsolatorUnionExec {
     /// task index. These children are replaced by [EmptyExec] as placeholders.
     pub(crate) fn to_task_specialized(&self, task_i: usize) -> Self {
         let mut children_to_keep = vec![];
-        for (child_i, _) in &self.task_idx_map[task_i] {
+        for (child_i, _) in self.task_idx_map.get(task_i).into_iter().flatten() {
             children_to_keep.push(*child_i);
         }
         let new_children = self
@@ -317,7 +321,11 @@ impl ExecutionPlan for ChildrenIsolatorUnionExec {
     ) -> datafusion::common::Result<SendableRecordBatchStream> {
         let d_ctx = DistributedTaskContext::from_ctx(&context);
 
-        let children = self.task_idx_map[d_ctx.task_index].clone();
+        let children = self
+            .task_idx_map
+            .get(d_ctx.task_index)
+            .cloned()
+            .unwrap_or_default();
 
         let baseline_metrics = BaselineMetrics::new(&self.metrics, partition);
 
@@ -457,11 +465,6 @@ fn split_children(
     >,
     DataFusionError,
 > {
-    if task_count_budget == 0 {
-        return internal_err!(
-            "ChildrenIsolatorUnionExec had a task count {task_count_budget}. This is a bug in the distributed planning logic, please report it"
-        );
-    }
     if children.is_empty() {
         return internal_err!(
             "ChildrenIsolatorUnionExec built with no children. This is a bug in the distributed planning logic, please report it"
@@ -485,6 +488,12 @@ fn split_children(
                 weight.weight
             );
         }
+    }
+
+    // `Desired(0)` is a valid planning outcome (e.g. every leaf dataset is empty).
+    // An empty task map is an empty stage, not an internal error.
+    if task_count_budget == 0 {
+        return Ok(vec![]);
     }
 
     // Two running examples (A and B) traced through every step below.
@@ -804,6 +813,20 @@ mod tests {
                 vec![(1, ctx(0, 1))],
                 vec![(2, ctx(0, 1))],
             ]
+        );
+        Ok(())
+    }
+
+    /// A zero task budget is a valid empty stage (every leaf dataset empty).
+    #[test]
+    fn split_children_zero_budget_is_empty() -> Result<(), Box<dyn std::error::Error>> {
+        assert_eq!(
+            split_children(&[des(0.0), des(0.0)], 0)?,
+            Vec::<Vec<(usize, DistributedTaskContext)>>::new()
+        );
+        assert_eq!(
+            split_children(&[des(1.0), des(1.0)], 0)?,
+            Vec::<Vec<(usize, DistributedTaskContext)>>::new()
         );
         Ok(())
     }

--- a/src/test_utils/routing.rs
+++ b/src/test_utils/routing.rs
@@ -258,9 +258,11 @@ fn url_emitter_schema() -> SchemaRef {
 pub fn url_emitter_desired_task_count(
     ev: DesiredTaskCountEvent,
 ) -> Option<Result<DesiredTaskCountEventResponse>> {
-    ev.plan
-        .downcast_ref::<URLEmitterExec>()
-        .map(|exec| Ok(DesiredTaskCountEventResponse::desired(exec.task_count)))
+    ev.plan.downcast_ref::<URLEmitterExec>().map(|exec| {
+        Ok(DesiredTaskCountEventResponse::desired(
+            exec.task_count as f64,
+        ))
+    })
 }
 
 pub fn url_emitter_scale_up_leaf_node(

--- a/src/test_utils/test_work_unit_feed.rs
+++ b/src/test_utils/test_work_unit_feed.rs
@@ -325,7 +325,7 @@ pub fn row_generator_desired_task_count_handler(
     let exec = ev.plan.downcast_ref::<RowGeneratorExec>()?;
     let provider = exec.feed.clone().try_into_inner().ok()?;
     Some(Ok(DesiredTaskCountEventResponse::desired(
-        provider.task_count,
+        provider.task_count as f64,
     )))
 }
 

--- a/src/test_utils/work_unit_file_scan.rs
+++ b/src/test_utils/work_unit_file_scan.rs
@@ -390,7 +390,9 @@ pub fn work_unit_file_scan_desired_task_count(
         .div_ceil(d_cfg.file_scan_config_bytes_per_partition)
         .div_ceil(cfg.target_partitions());
 
-    Some(Ok(DesiredTaskCountEventResponse::desired(task_count)))
+    Some(Ok(DesiredTaskCountEventResponse::desired(
+        task_count as f64,
+    )))
 }
 
 /// Rebuilds a work-unit file scan after the stage task count is finalized.

--- a/src/test_utils/work_unit_file_scan.rs
+++ b/src/test_utils/work_unit_file_scan.rs
@@ -386,13 +386,11 @@ pub fn work_unit_file_scan_desired_task_count(
         }
     }
 
-    let task_count = total_bytes
-        .div_ceil(d_cfg.file_scan_config_bytes_per_partition)
-        .div_ceil(cfg.target_partitions());
+    let bytes_per_partition = d_cfg.file_scan_config_bytes_per_partition.max(1) as f64;
+    let target_partitions = cfg.target_partitions().max(1) as f64;
+    let task_count = total_bytes as f64 / bytes_per_partition / target_partitions;
 
-    Some(Ok(DesiredTaskCountEventResponse::desired(
-        task_count as f64,
-    )))
+    Some(Ok(DesiredTaskCountEventResponse::desired(task_count)))
 }
 
 /// Rebuilds a work-unit file scan after the stage task count is finalized.


### PR DESCRIPTION
## Summary

- allow `DesiredTaskCountHandler` responses to use fractional `f64` task-count hints
- preserve fractions through hint merging and union aggregation, then round up when resolving an integer task count
- migrate built-in handlers, examples, public docs, and the 3.0 upgrade guide

Closes #562

## Validation

- `cargo fmt --all -- --check`
- `cargo check --lib`
- `cargo clippy --lib -- -D warnings`
- `cargo test --features integration --lib -- --skip protocol::grpc::channel_resolver::tests::fails_establishing_connection` (289 passed, 0 failed, 1 ignored, 1 filtered out)
- `cargo check --example custom_worker_url_routing --features integration`

The library suite and example check passed locally with the benchmark-only dev-dependency edge temporarily excluded to avoid its unrelated vendored-OpenSSL Windows build. The snapshot path filter was normalized only for the Windows test run, and the Windows-only connection-failure assertion was skipped because its socket error text differs by platform. `Cargo.toml`, `Cargo.lock`, and the snapshot helper were restored with no diff before commit.

Assisted-by: OpenAI Codex