### PR TITLE
fix: preserve broadcast build-side fetch

### DIFF
--- a/src/distributed_planner/insert_broadcast.rs
+++ b/src/distributed_planner/insert_broadcast.rs
@@ -133,17 +133,17 @@ pub(super) fn insert_broadcast_execs(
             return Ok(Transformed::no(node));
         };
 
-        let broadcast_input = build_child
+        let (broadcast_input, coalesce_fetch) = build_child
             .downcast_ref::<CoalescePartitionsExec>()
             .map_or_else(
-                || Arc::clone(build_child),
-                |coalesce| Arc::clone(coalesce.input()),
+                || (Arc::clone(build_child), None),
+                |coalesce| (Arc::clone(coalesce.input()), coalesce.fetch()),
             );
 
         // consumer_task_count=1 is a placeholder and will be corrected during optimizer rule.
         let broadcast: Arc<dyn ExecutionPlan> = Arc::new(BroadcastExec::new(broadcast_input, 1));
         let new_build_child: Arc<dyn ExecutionPlan> =
-            Arc::new(CoalescePartitionsExec::new(broadcast));
+            Arc::new(CoalescePartitionsExec::new(broadcast).with_fetch(coalesce_fetch));
 
         let mut new_children: Vec<Arc<dyn ExecutionPlan>> = children.into_iter().cloned().collect();
         new_children[0] = new_build_child;

--- a/tests/multi_task_collect_join_repros.rs
+++ b/tests/multi_task_collect_join_repros.rs
@@ -343,6 +343,20 @@ mod tests {
         .unwrap();
     }
 
+    /// A build-side `LIMIT` is carried by the `CoalescePartitionsExec` that a
+    /// broadcast rewrite replaces. The replacement must preserve that fetch or
+    /// the join observes every build row instead of the requested 50.
+    #[tokio::test]
+    async fn build_side_fetch_is_preserved_by_broadcast() {
+        assert_distributed_matches_single_node(
+            "SELECT count(*) FROM (SELECT id FROM build_side LIMIT 50) b \
+             JOIN probe_side p ON b.id = p.id",
+            true,
+        )
+        .await
+        .unwrap();
+    }
+
     fn data_dir() -> PathBuf {
         Path::new(env!("CARGO_MANIFEST_DIR")).join("target/multi_task_collect_join_repros")
     }


### PR DESCRIPTION
## Summary

- preserve the `fetch` value when replacing a build-side `CoalescePartitionsExec` during broadcast insertion
- add an integration regression that compares distributed and single-node results for a limited build side

## Testing

- `cargo test --features integration --test multi_task_collect_join_repros` (8 passed, 2 ignored)
- `cargo test distributed_planner::insert_broadcast::tests --lib` (7 passed)
- `cargo test distributed_planner::normalize_collect_joins::tests --lib` (7 passed)
- `cargo test --features integration --lib -- --skip protocol::grpc::channel_resolver::tests::fails_establishing_connection` (288 passed, 1 ignored, 1 filtered)
- `cargo fmt --all -- --check`
- `cargo check --lib`
- `cargo clippy --lib -- -D warnings`
- `git diff --check`

Closes #591

Assisted-by: OpenAI Codex