### PR TITLE
Adjust documentation about `scale_up_leaf_node` partition counts.

### DIFF
--- a/docs/source/advanced/05-custom-distributed-plans.md
+++ b/docs/source/advanced/05-custom-distributed-plans.md
@@ -82,7 +82,10 @@ automatic path. You only place the boundaries; the leaves are scaled for you.
 
 This means a custom leaf node still needs its desired task-count and leaf-scale handlers (or
 `DistributedTaskContext`-based dispatch) registered, just as it would for automatic planning — you do
-**not** need to hand-build `DistributedLeafExec` in your boundary-injection rule.
+**not** need to hand-build `DistributedLeafExec` in your boundary-injection rule. Leaf scaling runs
+during stage finalization after network boundary injection and physical optimization rules are complete,
+so per-task leaf variants may adjust their partition counts independently of the original plan without
+affecting upstream boundary placement.
 
 ## Example: a progressive partial-reduction tree
 

--- a/docs/source/user-guide/04-distribute-custom-plan.md
+++ b/docs/source/user-guide/04-distribute-custom-plan.md
@@ -165,9 +165,19 @@ fn sharded_scan_scale_up_leaf_node(
 ```
 
 `DistributedLeafExec` holds the original node plus the per-task variants. Every
-variant must expose the **same schema and partition count** (`try_new` enforces
-this) — that is what keeps the node transparent to the network boundaries above
-it. At execution time only the variant for task `i` is serialized and shipped to
+variant must expose the **same schema and partition count as every other variant**
+(`try_new` enforces this) — that is what keeps the node transparent to the network
+boundaries above it. Note that variants do **not** need to match the partition
+count of the original leaf `ExecutionPlan` or `target_partitions`; variants can
+scale their partition count higher or lower as needed for worker execution, as long
+as all variants agree on the same partition count.
+
+Trimming each variant to contain only its assigned slice of work ensures that each
+worker task emits only its assigned data. If instead you pass untrimmed copies of the
+original plan to all variants, every task will re-process all data and produce duplicate
+rows.
+
+At execution time only the variant for task `i` is serialized and shipped to
 that task's worker:
 
 ```text

--- a/src/distributed_ext.rs
+++ b/src/distributed_ext.rs
@@ -622,17 +622,18 @@ pub trait DistributedExt: Sized {
     /// # use std::sync::Arc;
     /// # use datafusion::error::Result;
     /// # use datafusion::execution::SessionStateBuilder;
+    /// # use datafusion::physical_plan::ExecutionPlan;
     /// # use datafusion::physical_plan::empty::EmptyExec;
     /// # use datafusion_distributed::{DistributedExt, DistributedLeafExec, ScaleUpLeafNodeEvent, ScaleUpLeafNodeEventResponse};
     ///
     /// fn handle_custom_scale_up_leaf_node(event: ScaleUpLeafNodeEvent) -> Option<Result<ScaleUpLeafNodeEventResponse>> {
-    ///     let _exec = event.plan.downcast_ref::<EmptyExec>()?;
+    ///     let exec = event.plan.downcast_ref::<EmptyExec>()?;
+    ///     // Build per-task plan variants, each handling its own non-overlapping subset of data.
+    ///     let variants = (0..event.task_count)
+    ///         .map(|_| Arc::new(EmptyExec::new(exec.schema())) as _);
     ///     Some(
-    ///         DistributedLeafExec::try_new(
-    ///             Arc::clone(event.plan),
-    ///             vec![Arc::clone(event.plan); event.task_count],
-    ///         )
-    ///         .map(|exec| ScaleUpLeafNodeEventResponse::new(Arc::new(exec))),
+    ///         DistributedLeafExec::try_new(Arc::clone(event.plan), variants)
+    ///             .map(|exec| ScaleUpLeafNodeEventResponse::new(Arc::new(exec))),
     ///     )
     /// }
     ///

--- a/src/execution_plans/distributed_leaf.rs
+++ b/src/execution_plans/distributed_leaf.rs
@@ -60,6 +60,11 @@ use std::sync::Arc;
 ///
 /// This way, the different workers get to execute different versions of the same plan, each
 /// handling its own range of non-overlapping data.
+///
+/// Note that every variant in `variants` must agree on the same schema and partition count with
+/// every other variant, but variants are **not** required to match the partition count of the
+/// `original` leaf plan. Variants can scale their partition count higher or lower as needed for
+/// worker execution.
 #[derive(Debug)]
 pub struct DistributedLeafExec {
     pub(crate) original: Arc<dyn ExecutionPlan>,
@@ -69,8 +74,10 @@ pub struct DistributedLeafExec {
 
 impl DistributedLeafExec {
     /// Builds a new [DistributedLeafExec] based on the provided original plan and its per-task
-    /// variants. Every variant must expose the same schema and partition count as every other
-    /// variant.
+    /// variants.
+    ///
+    /// Every variant must expose the same schema and partition count as every other variant.
+    /// Variants do not need to match the partition count of the `original` plan.
     pub fn try_new(
         original: Arc<dyn ExecutionPlan>,
         variants: impl IntoIterator<Item = Arc<dyn ExecutionPlan>>,


### PR DESCRIPTION
As discussed in https://github.com/datafusion-contrib/datafusion-distributed/pull/590#pullrequestreview-4872701077 : adjust the docs for `scale_up_leaf_node` to make it clear that partition counts can be adjusted arbitrarily. 