### PR TITLE
fix: apply broadcast fetch before fan-out

### DIFF
--- a/src/distributed_planner/insert_broadcast.rs
+++ b/src/distributed_planner/insert_broadcast.rs
@@ -275,6 +275,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_insert_broadcast_keeps_fetch_bearing_coalesce_below_broadcast() {
+        // A LIMIT on the build side is carried by CoalescePartitionsExec::fetch. That
+        // coalesce must stay *below* BroadcastExec so the limit is applied once before
+        // fan-out rather than independently in every consumer task.
+        let query = r#"
+        SELECT a."MinTemp", b."MaxTemp"
+        FROM (SELECT "MinTemp", "RainToday" FROM weather OFFSET 0 LIMIT 50) a
+        INNER JOIN weather b
+        ON a."RainToday" = b."RainToday"
+        "#;
+        let plan = sql_to_plan_with_broadcast(query, true, 4).await;
+        assert_snapshot!(plan, @r"
+        HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(RainToday@1, RainToday@1)], projection=[MinTemp@0, MaxTemp@2]
+          CoalescePartitionsExec
+            BroadcastExec: input_partitions=1, consumer_tasks=1, output_partitions=1
+              DataSourceExec: file_groups={1 group: [[/testdata/weather/result-000000.parquet]]}, projection=[MinTemp, RainToday], limit=50, file_type=parquet
+          DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MaxTemp, RainToday], file_type=parquet, predicate=DynamicFilter [ empty ]
+        ");
+    }
+
+    #[tokio::test]
     async fn test_insert_broadcast_cross_join() {
         let query = r#"
         SELECT a."MinTemp", b."MaxTemp"

--- a/src/distributed_planner/insert_broadcast.rs
+++ b/src/distributed_planner/insert_broadcast.rs
@@ -290,7 +290,7 @@ mod tests {
         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(RainToday@1, RainToday@1)], projection=[MinTemp@0, MaxTemp@2]
           CoalescePartitionsExec
             BroadcastExec: input_partitions=1, consumer_tasks=1, output_partitions=1
-              DataSourceExec: file_groups={1 group: [[/testdata/weather/result-000000.parquet]]}, projection=[MinTemp, RainToday], limit=50, file_type=parquet
+              DataSourceExec: file_groups={1 group: [[/testdata/weather/result-000001.parquet]]}, projection=[MinTemp, RainToday], limit=50, file_type=parquet
           DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MaxTemp, RainToday], file_type=parquet, predicate=DynamicFilter [ empty ]
         ");
     }

--- a/src/distributed_planner/insert_broadcast.rs
+++ b/src/distributed_planner/insert_broadcast.rs
@@ -285,13 +285,19 @@ mod tests {
         INNER JOIN weather b
         ON a."RainToday" = b."RainToday"
         "#;
-        let plan = sql_to_plan_with_broadcast(query, true, 4).await;
+        // LIMIT pushdown may keep a single weather parquet file, but which file
+        // is not stable across platforms (000000 locally vs 000001 on Linux CI).
+        let plan = sql_to_plan_with_broadcast(query, true, 4)
+            .await
+            .replace("result-000000.parquet", "result-<n>.parquet")
+            .replace("result-000001.parquet", "result-<n>.parquet")
+            .replace("result-000002.parquet", "result-<n>.parquet");
         assert_snapshot!(plan, @r"
         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(RainToday@1, RainToday@1)], projection=[MinTemp@0, MaxTemp@2]
           CoalescePartitionsExec
             BroadcastExec: input_partitions=1, consumer_tasks=1, output_partitions=1
-              DataSourceExec: file_groups={1 group: [[/testdata/weather/result-000001.parquet]]}, projection=[MinTemp, RainToday], limit=50, file_type=parquet
-          DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MaxTemp, RainToday], file_type=parquet, predicate=DynamicFilter [ empty ]
+              DataSourceExec: file_groups={1 group: [[/testdata/weather/result-<n>.parquet]]}, projection=[MinTemp, RainToday], limit=50, file_type=parquet
+          DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-<n>.parquet], [/testdata/weather/result-<n>.parquet], [/testdata/weather/result-<n>.parquet]]}, projection=[MaxTemp, RainToday], file_type=parquet, predicate=DynamicFilter [ empty ]
         ");
     }
 

--- a/src/distributed_planner/insert_broadcast.rs
+++ b/src/distributed_planner/insert_broadcast.rs
@@ -276,9 +276,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_insert_broadcast_keeps_fetch_bearing_coalesce_below_broadcast() {
-        // A LIMIT on the build side is carried by CoalescePartitionsExec::fetch. That
-        // coalesce must stay *below* BroadcastExec so the limit is applied once before
-        // fan-out rather than independently in every consumer task.
+        // A LIMIT on the build side is carried by CoalescePartitionsExec::fetch.
+        // That coalesce must stay *below* BroadcastExec so the limit is applied
+        // once before fan-out. Weather LIMIT is often pushed into DataSourceExec,
+        // and the remaining file is not stable across platforms, so assert the
+        // rewrite shape rather than snapshotting file parts.
         let query = r#"
         SELECT a."MinTemp", b."MaxTemp"
         FROM (SELECT "MinTemp", "RainToday" FROM weather OFFSET 0 LIMIT 50) a
@@ -286,13 +288,22 @@ mod tests {
         ON a."RainToday" = b."RainToday"
         "#;
         let plan = sql_to_plan_with_broadcast(query, true, 4).await;
-        assert_snapshot!(plan, @r"
-        HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(RainToday@1, RainToday@1)], projection=[MinTemp@0, MaxTemp@2]
-          CoalescePartitionsExec
-            BroadcastExec: input_partitions=1, consumer_tasks=1, output_partitions=1
-              DataSourceExec: file_groups={1 group: [[/testdata/weather/result-000001.parquet]]}, projection=[MinTemp, RainToday], limit=50, file_type=parquet
-          DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MaxTemp, RainToday], file_type=parquet, predicate=DynamicFilter [ empty ]
-        ");
+        assert!(
+            plan.contains("BroadcastExec"),
+            "expected BroadcastExec:\n{plan}"
+        );
+        assert!(
+            plan.contains("limit=50") || plan.contains("CoalescePartitionsExec: fetch=50"),
+            "expected build-side limit/fetch 50:\n{plan}"
+        );
+        let before_broadcast = plan
+            .split_once("BroadcastExec")
+            .map(|(h, _)| h)
+            .unwrap_or("");
+        assert!(
+            !before_broadcast.contains("CoalescePartitionsExec: fetch="),
+            "fetch-bearing coalesce must stay below BroadcastExec:\n{plan}"
+        );
     }
 
     #[tokio::test]

--- a/src/distributed_planner/insert_broadcast.rs
+++ b/src/distributed_planner/insert_broadcast.rs
@@ -363,7 +363,8 @@ mod tests {
             .await;
         let ctx = test_plan.get_ctx();
         if disable_dynamic_filters {
-            let mut state = ctx.state_ref().write();
+            let state_ref = ctx.state_ref();
+            let mut state = state_ref.write();
             let options = state.config_mut().options_mut();
             options
                 .set(

--- a/src/distributed_planner/insert_broadcast.rs
+++ b/src/distributed_planner/insert_broadcast.rs
@@ -276,11 +276,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_insert_broadcast_keeps_fetch_bearing_coalesce_below_broadcast() {
-        // A LIMIT on the build side is carried by CoalescePartitionsExec::fetch.
-        // That coalesce must stay *below* BroadcastExec so the limit is applied
-        // once before fan-out. Weather LIMIT is often pushed into DataSourceExec,
-        // and the remaining file is not stable across platforms, so assert the
-        // rewrite shape rather than snapshotting file parts.
+        // A LIMIT on the build side is carried by CoalescePartitionsExec::fetch. That
+        // coalesce must stay *below* BroadcastExec so the limit is applied once before
+        // fan-out rather than independently in every consumer task.
         let query = r#"
         SELECT a."MinTemp", b."MaxTemp"
         FROM (SELECT "MinTemp", "RainToday" FROM weather OFFSET 0 LIMIT 50) a
@@ -288,22 +286,13 @@ mod tests {
         ON a."RainToday" = b."RainToday"
         "#;
         let plan = sql_to_plan_with_broadcast(query, true, 4).await;
-        assert!(
-            plan.contains("BroadcastExec"),
-            "expected BroadcastExec:\n{plan}"
-        );
-        assert!(
-            plan.contains("limit=50") || plan.contains("CoalescePartitionsExec: fetch=50"),
-            "expected build-side limit/fetch 50:\n{plan}"
-        );
-        let before_broadcast = plan
-            .split_once("BroadcastExec")
-            .map(|(h, _)| h)
-            .unwrap_or("");
-        assert!(
-            !before_broadcast.contains("CoalescePartitionsExec: fetch="),
-            "fetch-bearing coalesce must stay below BroadcastExec:\n{plan}"
-        );
+        assert_snapshot!(plan, @r"
+        HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(RainToday@1, RainToday@1)], projection=[MinTemp@0, MaxTemp@2]
+          CoalescePartitionsExec
+            BroadcastExec: input_partitions=1, consumer_tasks=1, output_partitions=1
+              DataSourceExec: file_groups={1 group: [[/testdata/weather/result-000001.parquet]]}, projection=[MinTemp, RainToday], limit=50, file_type=parquet
+          DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MaxTemp, RainToday], file_type=parquet, predicate=DynamicFilter [ empty ]
+        ");
     }
 
     #[tokio::test]

--- a/src/distributed_planner/insert_broadcast.rs
+++ b/src/distributed_planner/insert_broadcast.rs
@@ -21,8 +21,9 @@ use super::DistributedConfig;
 /// The pass searches for joins whose left input can be broadcast without duplicating output rows:
 /// CollectLeft [HashJoinExec]s, [NestedLoopJoinExec]s, and [CrossJoinExec]s. Then it does one of
 /// two things:
-///     1. If the build child is a [CoalescePartitionsExec] -> Insert a [BroadcastExec] directly
-///        below it.
+///     1. If the build child is a fetch-less [CoalescePartitionsExec] -> Insert a
+///        [BroadcastExec] directly below it. A fetch-bearing coalesce stays below the broadcast
+///        so its global limit is applied before the rows are replicated to consumers.
 ///     2. Otherwise (means it is already single partitioned going into the join) -> Insert a
 ///        [BroadcastExec] -> [CoalescePartitionsExec] below the join but above its
 ///        original build child.
@@ -133,17 +134,18 @@ pub(super) fn insert_broadcast_execs(
             return Ok(Transformed::no(node));
         };
 
-        let (broadcast_input, coalesce_fetch) = build_child
+        let broadcast_input = build_child
             .downcast_ref::<CoalescePartitionsExec>()
+            .filter(|coalesce| coalesce.fetch().is_none())
             .map_or_else(
-                || (Arc::clone(build_child), None),
-                |coalesce| (Arc::clone(coalesce.input()), coalesce.fetch()),
+                || Arc::clone(build_child),
+                |coalesce| Arc::clone(coalesce.input()),
             );
 
         // consumer_task_count=1 is a placeholder and will be corrected during optimizer rule.
         let broadcast: Arc<dyn ExecutionPlan> = Arc::new(BroadcastExec::new(broadcast_input, 1));
         let new_build_child: Arc<dyn ExecutionPlan> =
-            Arc::new(CoalescePartitionsExec::new(broadcast).with_fetch(coalesce_fetch));
+            Arc::new(CoalescePartitionsExec::new(broadcast));
 
         let mut new_children: Vec<Arc<dyn ExecutionPlan>> = children.into_iter().cloned().collect();
         new_children[0] = new_build_child;

--- a/src/distributed_planner/insert_broadcast.rs
+++ b/src/distributed_planner/insert_broadcast.rs
@@ -285,19 +285,13 @@ mod tests {
         INNER JOIN weather b
         ON a."RainToday" = b."RainToday"
         "#;
-        // LIMIT pushdown may keep a single weather parquet file, but which file
-        // is not stable across platforms (000000 locally vs 000001 on Linux CI).
-        let plan = sql_to_plan_with_broadcast(query, true, 4)
-            .await
-            .replace("result-000000.parquet", "result-<n>.parquet")
-            .replace("result-000001.parquet", "result-<n>.parquet")
-            .replace("result-000002.parquet", "result-<n>.parquet");
+        let plan = sql_to_plan_with_broadcast_opts(query, true, 4, true).await;
         assert_snapshot!(plan, @r"
         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(RainToday@1, RainToday@1)], projection=[MinTemp@0, MaxTemp@2]
           CoalescePartitionsExec
             BroadcastExec: input_partitions=1, consumer_tasks=1, output_partitions=1
-              DataSourceExec: file_groups={1 group: [[/testdata/weather/result-<n>.parquet]]}, projection=[MinTemp, RainToday], limit=50, file_type=parquet
-          DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-<n>.parquet], [/testdata/weather/result-<n>.parquet], [/testdata/weather/result-<n>.parquet]]}, projection=[MaxTemp, RainToday], file_type=parquet, predicate=DynamicFilter [ empty ]
+              DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, RainToday], limit=50, file_type=parquet
+          DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MaxTemp, RainToday], file_type=parquet
         ");
     }
 
@@ -353,12 +347,34 @@ mod tests {
         broadcast_enabled: bool,
         target_partitions: usize,
     ) -> String {
+        sql_to_plan_with_broadcast_opts(query, broadcast_enabled, target_partitions, false).await
+    }
+
+    async fn sql_to_plan_with_broadcast_opts(
+        query: &str,
+        broadcast_enabled: bool,
+        target_partitions: usize,
+        disable_dynamic_filters: bool,
+    ) -> String {
         let test_plan = TestPlanBuilder::new()
             .target_partitions(target_partitions)
             .broadcast_joins(broadcast_enabled)
             .build()
             .await;
         let ctx = test_plan.get_ctx();
+        if disable_dynamic_filters {
+            let mut state = ctx.state_ref().write();
+            let options = state.config_mut().options_mut();
+            options
+                .set(
+                    "datafusion.optimizer.enable_dynamic_filter_pushdown",
+                    "false",
+                )
+                .expect("static dynamic-filter setting should be valid");
+            options
+                .set("datafusion.execution.parquet.pruning", "false")
+                .expect("static parquet pruning setting should be valid");
+        }
         let plan = test_plan.physical_plan(query).await;
         let plan = insert_broadcast_execs(plan, ctx.state_ref().read().config_options().as_ref())
             .expect("failed to insert broadcasts");

--- a/src/test_utils/insta.rs
+++ b/src/test_utils/insta.rs
@@ -38,13 +38,41 @@ fn strip_dynamic_rg_pruning(s: &str) -> String {
     out
 }
 
-struct StripDynamicRgPruning;
+/// LIMIT pushdown may keep a subset of generated parquet parts, and which
+/// `part-N.parquet` files remain is not stable across platforms (part-0..2
+/// locally vs part-1..3 on Linux CI). Grouping structure stays asserted.
+fn redact_part_parquet(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(idx) = rest.find("part-") {
+        out.push_str(&rest[..idx]);
+        let after = &rest[idx + "part-".len()..];
+        let digit_end = after
+            .find(|c: char| !c.is_ascii_digit())
+            .unwrap_or(after.len());
+        if digit_end > 0 && after[digit_end..].starts_with(".parquet") {
+            out.push_str("part-<n>.parquet");
+            rest = &after[digit_end + ".parquet".len()..];
+        } else {
+            out.push_str("part-");
+            rest = after;
+        }
+    }
+    out.push_str(rest);
+    out
+}
 
-impl Comparator for StripDynamicRgPruning {
+fn normalize_display_noise(s: &str) -> String {
+    redact_part_parquet(&strip_dynamic_rg_pruning(s))
+}
+
+struct NormalizeDisplayNoise;
+
+impl Comparator for NormalizeDisplayNoise {
     fn matches(&self, reference: &Snapshot, test: &Snapshot) -> bool {
         match (reference.as_text(), test.as_text()) {
             (Some(a), Some(b)) => {
-                strip_dynamic_rg_pruning(&a.to_string()) == strip_dynamic_rg_pruning(&b.to_string())
+                normalize_display_noise(&a.to_string()) == normalize_display_noise(&b.to_string())
             }
             _ => DefaultComparator.matches(reference, test),
         }
@@ -77,13 +105,14 @@ pub fn settings() -> insta::Settings {
     // Do not use `\S+`: that swallows the comma before a following field such as
     // `pruning_predicate=`.
     settings.add_filter(r", dynamic_rg_pruning=[^\s,]+", "");
-    settings.set_comparator(Box::new(StripDynamicRgPruning));
+    settings.add_filter(r"part-\d+\.parquet", "part-<n>.parquet");
+    settings.set_comparator(Box::new(NormalizeDisplayNoise));
     settings
 }
 
 #[cfg(test)]
 mod tests {
-    use super::strip_dynamic_rg_pruning;
+    use super::{normalize_display_noise, redact_part_parquet, strip_dynamic_rg_pruning};
 
     #[test]
     fn strip_rg_pruning_at_eol_and_before_next_field() {
@@ -94,6 +123,29 @@ mod tests {
         assert_eq!(
             strip_dynamic_rg_pruning("pred, dynamic_rg_pruning=eligible, pruning_predicate=x"),
             "pred, pruning_predicate=x"
+        );
+    }
+
+    #[test]
+    fn redact_part_numbers_without_changing_grouping() {
+        assert_eq!(
+            redact_part_parquet(
+                "[[/build_side/part-0.parquet:<int>..<int>], [/build_side/part-1.parquet:<int>..<int>]]"
+            ),
+            "[[/build_side/part-<n>.parquet:<int>..<int>], [/build_side/part-<n>.parquet:<int>..<int>]]"
+        );
+        assert_eq!(
+            redact_part_parquet(
+                "[[/build_side/part-1.parquet:<int>..<int>], [/build_side/part-2.parquet:<int>..<int>]]"
+            ),
+            "[[/build_side/part-<n>.parquet:<int>..<int>], [/build_side/part-<n>.parquet:<int>..<int>]]"
+        );
+        assert_eq!(redact_part_parquet("part-<n>.parquet"), "part-<n>.parquet");
+        assert_eq!(
+            normalize_display_noise(
+                "part-1.parquet, dynamic_rg_pruning=eligible, pruning_predicate=x"
+            ),
+            "part-<n>.parquet, pruning_predicate=x"
         );
     }
 }

--- a/src/test_utils/insta.rs
+++ b/src/test_utils/insta.rs
@@ -1,5 +1,8 @@
 use std::env;
 
+use insta::Snapshot;
+use insta::comparator::{Comparator, DefaultComparator};
+
 pub use insta;
 
 #[macro_export]
@@ -9,6 +12,47 @@ macro_rules! assert_snapshot {
             $crate::test_utils::insta::insta::assert_snapshot!($($arg)*);
         })
     };
+}
+
+/// DataFusion may append this when a dynamic filter is eligible for parquet
+/// row-group pruning. Eligibility is statistics-dependent and unrelated to DFD
+/// rewrites.
+///
+/// Insta filters run only on the generated value, not the stored inline
+/// snapshot. Linux CI still diffs against stored lines that carry this suffix,
+/// so comparison also strips it from both sides.
+const DYNAMIC_RG_PRUNING: &str = ", dynamic_rg_pruning=";
+
+fn strip_dynamic_rg_pruning(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(idx) = rest.find(DYNAMIC_RG_PRUNING) {
+        out.push_str(&rest[..idx]);
+        rest = &rest[idx + DYNAMIC_RG_PRUNING.len()..];
+        let value_len = rest
+            .find(|c: char| c.is_whitespace() || c == ',')
+            .unwrap_or(rest.len());
+        rest = &rest[value_len..];
+    }
+    out.push_str(rest);
+    out
+}
+
+struct StripDynamicRgPruning;
+
+impl Comparator for StripDynamicRgPruning {
+    fn matches(&self, reference: &Snapshot, test: &Snapshot) -> bool {
+        match (reference.as_text(), test.as_text()) {
+            (Some(a), Some(b)) => {
+                strip_dynamic_rg_pruning(&a.to_string()) == strip_dynamic_rg_pruning(&b.to_string())
+            }
+            _ => DefaultComparator.matches(reference, test),
+        }
+    }
+
+    fn dyn_clone(&self) -> Box<dyn Comparator> {
+        Box::new(Self)
+    }
 }
 
 pub fn settings() -> insta::Settings {
@@ -30,9 +74,26 @@ pub fn settings() -> insta::Settings {
         r"(DynamicFilter \[[^\[\]]*IN \(SET\) \(\[)[^\]]*(\]\))",
         "${1}<values>${2}",
     );
-    // DataFusion may append this when a dynamic filter is eligible for parquet
-    // row-group pruning. Eligibility is statistics-dependent and unrelated to
-    // DFD rewrites, so strip it for stable snapshots.
-    settings.add_filter(r", dynamic_rg_pruning=\S+", "");
+    // Do not use `\S+`: that swallows the comma before a following field such as
+    // `pruning_predicate=`.
+    settings.add_filter(r", dynamic_rg_pruning=[^\s,]+", "");
+    settings.set_comparator(Box::new(StripDynamicRgPruning));
     settings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_dynamic_rg_pruning;
+
+    #[test]
+    fn strip_rg_pruning_at_eol_and_before_next_field() {
+        assert_eq!(
+            strip_dynamic_rg_pruning("pred, dynamic_rg_pruning=eligible"),
+            "pred"
+        );
+        assert_eq!(
+            strip_dynamic_rg_pruning("pred, dynamic_rg_pruning=eligible, pruning_predicate=x"),
+            "pred, pruning_predicate=x"
+        );
+    }
 }

--- a/src/test_utils/insta.rs
+++ b/src/test_utils/insta.rs
@@ -30,5 +30,9 @@ pub fn settings() -> insta::Settings {
         r"(DynamicFilter \[[^\[\]]*IN \(SET\) \(\[)[^\]]*(\]\))",
         "${1}<values>${2}",
     );
+    // DataFusion may append this when a dynamic filter is eligible for parquet
+    // row-group pruning. Eligibility is statistics-dependent and unrelated to
+    // DFD rewrites, so strip it for stable snapshots.
+    settings.add_filter(r", dynamic_rg_pruning=\S+", "");
     settings
 }

--- a/src/test_utils/insta.rs
+++ b/src/test_utils/insta.rs
@@ -1,8 +1,5 @@
 use std::env;
 
-use insta::Snapshot;
-use insta::comparator::{Comparator, DefaultComparator};
-
 pub use insta;
 
 #[macro_export]
@@ -12,75 +9,6 @@ macro_rules! assert_snapshot {
             $crate::test_utils::insta::insta::assert_snapshot!($($arg)*);
         })
     };
-}
-
-/// DataFusion may append this when a dynamic filter is eligible for parquet
-/// row-group pruning. Eligibility is statistics-dependent and unrelated to DFD
-/// rewrites.
-///
-/// Insta filters run only on the generated value, not the stored inline
-/// snapshot. Linux CI still diffs against stored lines that carry this suffix,
-/// so comparison also strips it from both sides.
-const DYNAMIC_RG_PRUNING: &str = ", dynamic_rg_pruning=";
-
-fn strip_dynamic_rg_pruning(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    let mut rest = s;
-    while let Some(idx) = rest.find(DYNAMIC_RG_PRUNING) {
-        out.push_str(&rest[..idx]);
-        rest = &rest[idx + DYNAMIC_RG_PRUNING.len()..];
-        let value_len = rest
-            .find(|c: char| c.is_whitespace() || c == ',')
-            .unwrap_or(rest.len());
-        rest = &rest[value_len..];
-    }
-    out.push_str(rest);
-    out
-}
-
-/// LIMIT pushdown may keep a subset of generated parquet parts, and which
-/// `part-N.parquet` files remain is not stable across platforms (part-0..2
-/// locally vs part-1..3 on Linux CI). Grouping structure stays asserted.
-fn redact_part_parquet(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    let mut rest = s;
-    while let Some(idx) = rest.find("part-") {
-        out.push_str(&rest[..idx]);
-        let after = &rest[idx + "part-".len()..];
-        let digit_end = after
-            .find(|c: char| !c.is_ascii_digit())
-            .unwrap_or(after.len());
-        if digit_end > 0 && after[digit_end..].starts_with(".parquet") {
-            out.push_str("part-<n>.parquet");
-            rest = &after[digit_end + ".parquet".len()..];
-        } else {
-            out.push_str("part-");
-            rest = after;
-        }
-    }
-    out.push_str(rest);
-    out
-}
-
-fn normalize_display_noise(s: &str) -> String {
-    redact_part_parquet(&strip_dynamic_rg_pruning(s))
-}
-
-struct NormalizeDisplayNoise;
-
-impl Comparator for NormalizeDisplayNoise {
-    fn matches(&self, reference: &Snapshot, test: &Snapshot) -> bool {
-        match (reference.as_text(), test.as_text()) {
-            (Some(a), Some(b)) => {
-                normalize_display_noise(&a.to_string()) == normalize_display_noise(&b.to_string())
-            }
-            _ => DefaultComparator.matches(reference, test),
-        }
-    }
-
-    fn dyn_clone(&self) -> Box<dyn Comparator> {
-        Box::new(Self)
-    }
 }
 
 pub fn settings() -> insta::Settings {
@@ -102,50 +30,5 @@ pub fn settings() -> insta::Settings {
         r"(DynamicFilter \[[^\[\]]*IN \(SET\) \(\[)[^\]]*(\]\))",
         "${1}<values>${2}",
     );
-    // Do not use `\S+`: that swallows the comma before a following field such as
-    // `pruning_predicate=`.
-    settings.add_filter(r", dynamic_rg_pruning=[^\s,]+", "");
-    settings.add_filter(r"part-\d+\.parquet", "part-<n>.parquet");
-    settings.set_comparator(Box::new(NormalizeDisplayNoise));
     settings
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{normalize_display_noise, redact_part_parquet, strip_dynamic_rg_pruning};
-
-    #[test]
-    fn strip_rg_pruning_at_eol_and_before_next_field() {
-        assert_eq!(
-            strip_dynamic_rg_pruning("pred, dynamic_rg_pruning=eligible"),
-            "pred"
-        );
-        assert_eq!(
-            strip_dynamic_rg_pruning("pred, dynamic_rg_pruning=eligible, pruning_predicate=x"),
-            "pred, pruning_predicate=x"
-        );
-    }
-
-    #[test]
-    fn redact_part_numbers_without_changing_grouping() {
-        assert_eq!(
-            redact_part_parquet(
-                "[[/build_side/part-0.parquet:<int>..<int>], [/build_side/part-1.parquet:<int>..<int>]]"
-            ),
-            "[[/build_side/part-<n>.parquet:<int>..<int>], [/build_side/part-<n>.parquet:<int>..<int>]]"
-        );
-        assert_eq!(
-            redact_part_parquet(
-                "[[/build_side/part-1.parquet:<int>..<int>], [/build_side/part-2.parquet:<int>..<int>]]"
-            ),
-            "[[/build_side/part-<n>.parquet:<int>..<int>], [/build_side/part-<n>.parquet:<int>..<int>]]"
-        );
-        assert_eq!(redact_part_parquet("part-<n>.parquet"), "part-<n>.parquet");
-        assert_eq!(
-            normalize_display_noise(
-                "part-1.parquet, dynamic_rg_pruning=eligible, pruning_predicate=x"
-            ),
-            "part-<n>.parquet, pruning_predicate=x"
-        );
-    }
 }

--- a/tests/multi_task_collect_join_repros.rs
+++ b/tests/multi_task_collect_join_repros.rs
@@ -365,10 +365,13 @@ mod tests {
     }
 
     /// A build-side `LIMIT` is carried by the `CoalescePartitionsExec` that a
-    /// broadcast rewrite replaces. It must run before broadcasting so the same
-    /// 50 rows reach every consumer, rather than being applied independently after fan-out.
-    /// Every build id has 50 probe matches, so the count is 2500 regardless of which
-    /// unordered 50 ids survive.
+    /// broadcast rewrite keeps below `BroadcastExec`. The fetch must run in a
+    /// single coalesced producer task before fan-out; otherwise each producer
+    /// task applies `fetch=50` locally and the broadcast receives 50 * tasks
+    /// rows. Every build id has 50 probe matches, so `count(*)` is 2500 for any
+    /// unordered 50 ids. The product-sum query below is only used to snapshot
+    /// the stage shape; its value is not compared because `LIMIT` without
+    /// `ORDER BY` may pick different ids on each engine.
     #[tokio::test]
     async fn build_side_fetch_is_preserved_by_broadcast() {
         assert_distributed_matches_single_node(
@@ -378,6 +381,48 @@ mod tests {
         )
         .await
         .unwrap();
+
+        ensure_data().await;
+        let d_ctx = make_distributed_ctx(true).await.unwrap();
+        let (plan, _) = run(
+            &d_ctx,
+            "SELECT sum(b.id * b.id * p.id * p.id) FROM (SELECT id FROM build_side LIMIT 50) b \
+             CROSS JOIN probe_side p",
+        )
+        .await
+        .unwrap();
+        assert_snapshot!(display_plan_ascii(plan.as_ref(), false), @r"
+        ┌───── DistributedExec
+        │ AggregateExec: mode=Final, gby=[], aggr=[sum(b.id * b.id * p.id * p.id)]
+        │   CoalescePartitionsExec
+        │     [Stage 3] => NetworkCoalesceExec: output_partitions=12, input_tasks=4
+        └──────────────────────────────────────────────────
+          ┌───── Stage 3 ── tasks=4, partitions=12
+          │ AggregateExec: mode=Partial, gby=[], aggr=[sum(b.id * b.id * p.id * p.id)]
+          │   RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+          │     CrossJoinExec
+          │       CoalescePartitionsExec
+          │         [Stage 2] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=4, input_tasks=1
+          │       DistributedLeafExec:
+          │         t0: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/probe_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/probe_side/part-2.parquet:<int>..<int>]]}, projection=[id], file_type=parquet
+          │         t1: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/probe_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/probe_side/part-2.parquet:<int>..<int>]]}, projection=[id], file_type=parquet
+          │         t2: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/probe_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/probe_side/part-3.parquet:<int>..<int>]]}, projection=[id], file_type=parquet
+          │         t3: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/probe_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/probe_side/part-3.parquet:<int>..<int>]]}, projection=[id], file_type=parquet
+          └──────────────────────────────────────────────────
+            ┌───── Stage 2 ── tasks=1, partitions=4
+            │ BroadcastExec: input_partitions=1, consumer_tasks=4, output_partitions=4
+            │   CoalescePartitionsExec: fetch=50
+            │     [Stage 1] => NetworkCoalesceExec: output_partitions=12, input_tasks=4
+            └──────────────────────────────────────────────────
+              ┌───── Stage 1 ── tasks=4, partitions=12
+              │ LocalLimitExec: fetch=50
+              │   DistributedLeafExec:
+              │     t0: DataSourceExec: file_groups={3 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>]]}, projection=[id], limit=50, file_type=parquet
+              │     t1: DataSourceExec: file_groups={3 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>]]}, projection=[id], limit=50, file_type=parquet
+              │     t2: DataSourceExec: file_groups={3 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>]]}, projection=[id], limit=50, file_type=parquet
+              │     t3: DataSourceExec: file_groups={3 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet:<int>..<int>, /target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>, /target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>]]}, projection=[id], limit=50, file_type=parquet
+              └──────────────────────────────────────────────────
+        ")
     }
 
     fn data_dir() -> PathBuf {

--- a/tests/multi_task_collect_join_repros.rs
+++ b/tests/multi_task_collect_join_repros.rs
@@ -344,8 +344,10 @@ mod tests {
     }
 
     /// A build-side `LIMIT` is carried by the `CoalescePartitionsExec` that a
-    /// broadcast rewrite replaces. The replacement must preserve that fetch or
-    /// the join observes every build row instead of the requested 50.
+    /// broadcast rewrite replaces. It must run before broadcasting so the same
+    /// 50 rows reach every consumer, rather than being applied independently after fan-out.
+    /// Every build id has 50 probe matches, so the count is 2500 regardless of which
+    /// unordered 50 ids survive.
     #[tokio::test]
     async fn build_side_fetch_is_preserved_by_broadcast() {
         assert_distributed_matches_single_node(

--- a/tests/multi_task_collect_join_repros.rs
+++ b/tests/multi_task_collect_join_repros.rs
@@ -370,63 +370,48 @@ mod tests {
     /// task applies `fetch=50` locally and the broadcast receives 50 * tasks
     /// rows. Every build id has 50 probe matches, so `count(*)` is 2500 for any
     /// unordered 50 ids.
-    ///
-    /// The product-sum query is only used to assert the stage topology. File
-    /// parts selected by unordered `LIMIT` are not stable across platforms, so
-    /// this is not a full plan snapshot.
     #[tokio::test]
     async fn build_side_fetch_is_preserved_by_broadcast() {
-        assert_distributed_matches_single_node(
+        let plan = assert_distributed_matches_single_node(
             "SELECT count(*) FROM (SELECT id FROM build_side LIMIT 50) b \
              JOIN probe_side p ON b.id = p.id",
             true,
         )
         .await
         .unwrap();
-
-        ensure_data().await;
-        let d_ctx = make_distributed_ctx(true).await.unwrap();
-        let (plan, _) = run(
-            &d_ctx,
-            "SELECT sum(b.id * b.id * p.id * p.id) FROM (SELECT id FROM build_side LIMIT 50) b \
-             CROSS JOIN probe_side p",
-        )
-        .await
-        .unwrap();
-        let plan = display_plan_ascii(plan.as_ref(), false);
-        assert!(
-            plan.lines()
-                .any(|line| line.contains("Stage 2") && line.contains("tasks=1")),
-            "expected Stage 2 with tasks=1:\n{plan}"
-        );
-        assert!(
-            plan.contains("BroadcastExec"),
-            "expected BroadcastExec:\n{plan}"
-        );
-        assert!(
-            plan.contains("CoalescePartitionsExec: fetch=50"),
-            "expected CoalescePartitionsExec: fetch=50:\n{plan}"
-        );
-        let after_fetch = plan
-            .split_once("CoalescePartitionsExec: fetch=50")
-            .map(|(_, rest)| rest)
-            .unwrap_or("");
-        assert!(
-            after_fetch.lines().any(|line| {
-                line.contains("NetworkCoalesceExec") && line.contains("input_tasks=4")
-            }),
-            "expected NetworkCoalesceExec with input_tasks=4 under fetch:\n{plan}"
-        );
-        assert!(
-            plan.contains("LocalLimitExec: fetch=50"),
-            "expected LocalLimitExec: fetch=50:\n{plan}"
-        );
-        assert!(
-            plan.lines().any(|line| {
-                line.contains("NetworkBroadcastExec") && line.contains("input_tasks=1")
-            }),
-            "expected NetworkBroadcastExec with input_tasks=1:\n{plan}"
-        );
+        assert_snapshot!(display_plan_ascii(plan.as_ref(), false), @"
+        ┌───── DistributedExec
+        │ ProjectionExec: expr=[count(Int64(1))@0 as count(*)]
+        │   AggregateExec: mode=Final, gby=[], aggr=[count(Int64(1))]
+        │     CoalescePartitionsExec
+        │       [Stage 3] => NetworkCoalesceExec: output_partitions=12, input_tasks=4
+        └──────────────────────────────────────────────────
+          ┌───── Stage 3 ── tasks=4, partitions=12
+          │ AggregateExec: mode=Partial, gby=[], aggr=[count(Int64(1))]
+          │   RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+          │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)], projection=[]
+          │       CoalescePartitionsExec
+          │         [Stage 2] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=4, input_tasks=1
+          │       DistributedLeafExec:
+          │         t0: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/probe_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/probe_side/part-2.parquet:<int>..<int>]]}, projection=[id], file_type=parquet, predicate=DynamicFilter [ empty ]
+          │         t1: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/probe_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/probe_side/part-2.parquet:<int>..<int>]]}, projection=[id], file_type=parquet, predicate=DynamicFilter [ empty ]
+          │         t2: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/probe_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/probe_side/part-3.parquet:<int>..<int>]]}, projection=[id], file_type=parquet, predicate=DynamicFilter [ empty ]
+          │         t3: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/probe_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/probe_side/part-3.parquet:<int>..<int>]]}, projection=[id], file_type=parquet, predicate=DynamicFilter [ empty ]
+          └──────────────────────────────────────────────────
+            ┌───── Stage 2 ── tasks=1, partitions=4
+            │ BroadcastExec: input_partitions=1, consumer_tasks=4, output_partitions=4
+            │   CoalescePartitionsExec: fetch=50
+            │     [Stage 1] => NetworkCoalesceExec: output_partitions=12, input_tasks=4
+            └──────────────────────────────────────────────────
+              ┌───── Stage 1 ── tasks=4, partitions=12
+              │ LocalLimitExec: fetch=50
+              │   DistributedLeafExec:
+              │     t0: DataSourceExec: file_groups={3 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>]]}, projection=[id], limit=50, file_type=parquet
+              │     t1: DataSourceExec: file_groups={3 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>]]}, projection=[id], limit=50, file_type=parquet
+              │     t2: DataSourceExec: file_groups={3 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>]]}, projection=[id], limit=50, file_type=parquet
+              │     t3: DataSourceExec: file_groups={3 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet:<int>..<int>, /target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>, /target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>]]}, projection=[id], limit=50, file_type=parquet
+              └──────────────────────────────────────────────────
+        ")
     }
 
     fn data_dir() -> PathBuf {

--- a/tests/multi_task_collect_join_repros.rs
+++ b/tests/multi_task_collect_join_repros.rs
@@ -369,9 +369,11 @@ mod tests {
     /// single coalesced producer task before fan-out; otherwise each producer
     /// task applies `fetch=50` locally and the broadcast receives 50 * tasks
     /// rows. Every build id has 50 probe matches, so `count(*)` is 2500 for any
-    /// unordered 50 ids. The product-sum query below is only used to snapshot
-    /// the stage shape; its value is not compared because `LIMIT` without
-    /// `ORDER BY` may pick different ids on each engine.
+    /// unordered 50 ids.
+    ///
+    /// The product-sum query is only used to assert the stage topology. File
+    /// parts selected by unordered `LIMIT` are not stable across platforms, so
+    /// this is not a full plan snapshot.
     #[tokio::test]
     async fn build_side_fetch_is_preserved_by_broadcast() {
         assert_distributed_matches_single_node(
@@ -391,38 +393,40 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_snapshot!(display_plan_ascii(plan.as_ref(), false), @r"
-        ┌───── DistributedExec
-        │ AggregateExec: mode=Final, gby=[], aggr=[sum(b.id * b.id * p.id * p.id)]
-        │   CoalescePartitionsExec
-        │     [Stage 3] => NetworkCoalesceExec: output_partitions=12, input_tasks=4
-        └──────────────────────────────────────────────────
-          ┌───── Stage 3 ── tasks=4, partitions=12
-          │ AggregateExec: mode=Partial, gby=[], aggr=[sum(b.id * b.id * p.id * p.id)]
-          │   RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
-          │     CrossJoinExec
-          │       CoalescePartitionsExec
-          │         [Stage 2] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=4, input_tasks=1
-          │       DistributedLeafExec:
-          │         t0: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/probe_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/probe_side/part-2.parquet:<int>..<int>]]}, projection=[id], file_type=parquet
-          │         t1: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/probe_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/probe_side/part-2.parquet:<int>..<int>]]}, projection=[id], file_type=parquet
-          │         t2: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/probe_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/probe_side/part-3.parquet:<int>..<int>]]}, projection=[id], file_type=parquet
-          │         t3: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/probe_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/probe_side/part-3.parquet:<int>..<int>]]}, projection=[id], file_type=parquet
-          └──────────────────────────────────────────────────
-            ┌───── Stage 2 ── tasks=1, partitions=4
-            │ BroadcastExec: input_partitions=1, consumer_tasks=4, output_partitions=4
-            │   CoalescePartitionsExec: fetch=50
-            │     [Stage 1] => NetworkCoalesceExec: output_partitions=12, input_tasks=4
-            └──────────────────────────────────────────────────
-              ┌───── Stage 1 ── tasks=4, partitions=12
-              │ LocalLimitExec: fetch=50
-              │   DistributedLeafExec:
-              │     t0: DataSourceExec: file_groups={3 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>]]}, projection=[id], limit=50, file_type=parquet
-              │     t1: DataSourceExec: file_groups={3 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>]]}, projection=[id], limit=50, file_type=parquet
-              │     t2: DataSourceExec: file_groups={3 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>]]}, projection=[id], limit=50, file_type=parquet
-              │     t3: DataSourceExec: file_groups={3 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet:<int>..<int>, /target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>, /target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>]]}, projection=[id], limit=50, file_type=parquet
-              └──────────────────────────────────────────────────
-        ")
+        let plan = display_plan_ascii(plan.as_ref(), false);
+        assert!(
+            plan.lines()
+                .any(|line| line.contains("Stage 2") && line.contains("tasks=1")),
+            "expected Stage 2 with tasks=1:\n{plan}"
+        );
+        assert!(
+            plan.contains("BroadcastExec"),
+            "expected BroadcastExec:\n{plan}"
+        );
+        assert!(
+            plan.contains("CoalescePartitionsExec: fetch=50"),
+            "expected CoalescePartitionsExec: fetch=50:\n{plan}"
+        );
+        let after_fetch = plan
+            .split_once("CoalescePartitionsExec: fetch=50")
+            .map(|(_, rest)| rest)
+            .unwrap_or("");
+        assert!(
+            after_fetch.lines().any(|line| {
+                line.contains("NetworkCoalesceExec") && line.contains("input_tasks=4")
+            }),
+            "expected NetworkCoalesceExec with input_tasks=4 under fetch:\n{plan}"
+        );
+        assert!(
+            plan.contains("LocalLimitExec: fetch=50"),
+            "expected LocalLimitExec: fetch=50:\n{plan}"
+        );
+        assert!(
+            plan.lines().any(|line| {
+                line.contains("NetworkBroadcastExec") && line.contains("input_tasks=1")
+            }),
+            "expected NetworkBroadcastExec with input_tasks=1:\n{plan}"
+        );
     }
 
     fn data_dir() -> PathBuf {

--- a/tests/multi_task_collect_join_repros.rs
+++ b/tests/multi_task_collect_join_repros.rs
@@ -365,8 +365,10 @@ mod tests {
     }
 
     /// A build-side `LIMIT` is carried by the `CoalescePartitionsExec` that a
-    /// broadcast rewrite replaces. The replacement must preserve that fetch or
-    /// the join observes every build row instead of the requested 50.
+    /// broadcast rewrite replaces. It must run before broadcasting so the same
+    /// 50 rows reach every consumer, rather than being applied independently after fan-out.
+    /// Every build id has 50 probe matches, so the count is 2500 regardless of which
+    /// unordered 50 ids survive.
     #[tokio::test]
     async fn build_side_fetch_is_preserved_by_broadcast() {
         assert_distributed_matches_single_node(

--- a/tests/multi_task_collect_join_repros.rs
+++ b/tests/multi_task_collect_join_repros.rs
@@ -370,6 +370,10 @@ mod tests {
     /// task applies `fetch=50` locally and the broadcast receives 50 * tasks
     /// rows. Every build id has 50 probe matches, so `count(*)` is 2500 for any
     /// unordered 50 ids.
+    ///
+    /// File-group assignment under LIMIT is not stable (same reason the
+    /// normalize sibling does not snapshot the plan). Assert the fetch-bearing
+    /// coalesce stays below the broadcast instead.
     #[tokio::test]
     async fn build_side_fetch_is_preserved_by_broadcast() {
         let plan = assert_distributed_matches_single_node(
@@ -379,39 +383,20 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_snapshot!(display_plan_ascii(plan.as_ref(), false), @"
-        ┌───── DistributedExec
-        │ ProjectionExec: expr=[count(Int64(1))@0 as count(*)]
-        │   AggregateExec: mode=Final, gby=[], aggr=[count(Int64(1))]
-        │     CoalescePartitionsExec
-        │       [Stage 3] => NetworkCoalesceExec: output_partitions=12, input_tasks=4
-        └──────────────────────────────────────────────────
-          ┌───── Stage 3 ── tasks=4, partitions=12
-          │ AggregateExec: mode=Partial, gby=[], aggr=[count(Int64(1))]
-          │   RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
-          │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)], projection=[]
-          │       CoalescePartitionsExec
-          │         [Stage 2] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=4, input_tasks=1
-          │       DistributedLeafExec:
-          │         t0: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/probe_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/probe_side/part-2.parquet:<int>..<int>]]}, projection=[id], file_type=parquet, predicate=DynamicFilter [ empty ]
-          │         t1: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/probe_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/probe_side/part-2.parquet:<int>..<int>]]}, projection=[id], file_type=parquet, predicate=DynamicFilter [ empty ]
-          │         t2: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/probe_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/probe_side/part-3.parquet:<int>..<int>]]}, projection=[id], file_type=parquet, predicate=DynamicFilter [ empty ]
-          │         t3: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/probe_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/probe_side/part-3.parquet:<int>..<int>]]}, projection=[id], file_type=parquet, predicate=DynamicFilter [ empty ]
-          └──────────────────────────────────────────────────
-            ┌───── Stage 2 ── tasks=1, partitions=4
-            │ BroadcastExec: input_partitions=1, consumer_tasks=4, output_partitions=4
-            │   CoalescePartitionsExec: fetch=50
-            │     [Stage 1] => NetworkCoalesceExec: output_partitions=12, input_tasks=4
-            └──────────────────────────────────────────────────
-              ┌───── Stage 1 ── tasks=4, partitions=12
-              │ LocalLimitExec: fetch=50
-              │   DistributedLeafExec:
-              │     t0: DataSourceExec: file_groups={3 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>]]}, projection=[id], limit=50, file_type=parquet
-              │     t1: DataSourceExec: file_groups={3 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>]]}, projection=[id], limit=50, file_type=parquet
-              │     t2: DataSourceExec: file_groups={3 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>]]}, projection=[id], limit=50, file_type=parquet
-              │     t3: DataSourceExec: file_groups={3 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet:<int>..<int>, /target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>, /target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>]]}, projection=[id], limit=50, file_type=parquet
-              └──────────────────────────────────────────────────
-        ")
+        let display = display_plan_ascii(plan.as_ref(), false);
+        assert!(
+            display.contains("BroadcastExec:")
+                && display.contains("CoalescePartitionsExec: fetch=50"),
+            "expected fetch-bearing coalesce below BroadcastExec, got:\n{display}"
+        );
+        let broadcast_at = display.find("BroadcastExec:").expect("BroadcastExec");
+        let fetch_at = display
+            .find("CoalescePartitionsExec: fetch=50")
+            .expect("fetch");
+        assert!(
+            fetch_at > broadcast_at,
+            "fetch-bearing coalesce must be nested under BroadcastExec:\n{display}"
+        );
     }
 
     fn data_dir() -> PathBuf {


### PR DESCRIPTION
## What

- keep a fetch-bearing `CoalescePartitionsExec` inside `BroadcastExec`
- continue stripping fetch-less coalesces before broadcast
- document why the regression count is invariant to unordered `LIMIT` row selection

## Why

This follows up on #618. Moving the fetch to the coalesce above `BroadcastExec` changes a global build-side limit into a per-consumer limit after fan-out. The post-merge unit run demonstrated the resulting correctness failure: single-node and distributed `count(*)` returned `2500` and `3750` even though every possible set of 50 build IDs has exactly 2,500 probe matches.

Keeping the fetch-bearing coalesce as the broadcast input applies the limit once before replication. The resulting distributed plan has `BroadcastExec` over `CoalescePartitionsExec: fetch=50`.

Failure evidence: https://github.com/datafusion-contrib/datafusion-distributed/actions/runs/31358856004/job/93363560852

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --features integration --test multi_task_collect_join_repros build_side_fetch_is_preserved_by_broadcast` (passed, then passed 5 repeated runs)