### PR TITLE
refactor: move remote benchmark worker upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,10 +919,13 @@ checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -930,10 +933,15 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -952,6 +960,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2145,6 +2154,8 @@ name = "datafusion-distributed-benchmarks"
 version = "0.1.0"
 dependencies = [
  "arrow",
+ "async-trait",
+ "axum",
  "built",
  "criterion",
  "datafusion",
@@ -2152,6 +2163,9 @@ dependencies = [
  "env_logger",
  "futures",
  "log",
+ "mimalloc",
+ "object_store",
+ "openssl",
  "parquet",
  "reqwest",
  "serde",
@@ -2163,6 +2177,7 @@ dependencies = [
  "tonic",
  "tpchgen",
  "tpchgen-arrow",
+ "url",
  "zip",
 ]
 
@@ -4357,6 +4372,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4364,6 +4388,7 @@ checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -5450,6 +5475,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6243,6 +6279,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -5,16 +5,19 @@ edition = "2024"
 default-run = "dfbench"
 
 [dependencies]
+async-trait = "0.1.89"
+axum = "0.8"
 datafusion = { workspace = true }
 datafusion-distributed = { path = "..", features = [
   "integration",
   "system-metrics",
 ] }
 tokio = { version = "1.48", features = ["full"] }
+url = "2.5.7"
 parquet = { version = "58" }
 structopt = { version = "0.3.26" }
 log = "0.4.27"
-serde = "1.0.219"
+serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.141"
 env_logger = "0.11.8"
 futures = "0.3.31"
@@ -25,6 +28,9 @@ tpchgen-arrow = { git = "https://github.com/clflushopt/tpchgen-rs", rev = "438e9
 reqwest = "0.12"
 zip = "6.0"
 sketches-ddsketch = "0.3"
+object_store = { version = "0.13", features = ["aws"] }
+openssl = { version = "0.10", features = ["vendored"] }
+mimalloc = "0.1"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,5 +1,9 @@
 # Local DataFusion benchmarks
 
+The crate also owns the `worker` binary deployed by the remote benchmark
+harness. Keeping that binary here makes API changes to DataFusion Distributed
+and its benchmark worker compile together from the same revision.
+
 ### Generating Benchmarking data
 
 Generate datasets alongside the integration-test fixtures under `testdata/`.

--- a/benchmarks/src/bin/worker.rs
+++ b/benchmarks/src/bin/worker.rs
@@ -1,0 +1,371 @@
+use async_trait::async_trait;
+use axum::{Json, Router, extract::Query, http::StatusCode, routing::get};
+use datafusion::catalog::memory::DataSourceExec;
+use datafusion::common::DataFusionError;
+use datafusion::common::instant::Instant;
+use datafusion::common::runtime::SpawnedTask;
+use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
+use datafusion::execution::SessionStateBuilder;
+use datafusion::execution::runtime_env::RuntimeEnv;
+use datafusion::physical_plan::execute_stream;
+use datafusion::prelude::SessionContext;
+use datafusion_distributed::test_utils::work_unit_file_scan::{
+    WorkUnitFileScanCodec, WorkUnitFileScanConfig, work_unit_file_scan_desired_task_count,
+    work_unit_file_scan_scale_up_leaf_node,
+};
+use datafusion_distributed::{
+    ChannelResolver, DistributedExt, DistributedMetricsFormat, NetworkBoundaryExt,
+    SessionStateBuilderExt, Worker, WorkerQueryContext, WorkerResolver, display_plan_ascii,
+    get_distributed_channel_resolver, get_distributed_worker_resolver,
+    rewrite_distributed_plan_with_metrics,
+};
+use datafusion_distributed_benchmarks::stats::stats_estimation_q_error;
+use futures::{StreamExt, TryFutureExt};
+use log::{error, info, warn};
+use object_store::aws::AmazonS3Builder;
+use serde::Serialize;
+use std::error::Error;
+use std::fmt::Display;
+use std::io;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+use structopt::StructOpt;
+use tonic::transport::Server;
+use url::Url;
+
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[allow(clippy::disallowed_types)]
+type QueryParameters = std::collections::HashMap<String, String>;
+
+pub(crate) mod built_info {
+    // The file has been placed there by the build script.
+    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+
+#[derive(Serialize)]
+struct QueryResult {
+    plan: String,
+    count: usize,
+    elapsed_ms: f64,
+    tasks: usize,
+    stats_q_error_p50: Option<f64>,
+    stats_q_error_p95: Option<f64>,
+}
+
+#[derive(Serialize)]
+struct WorkerInfo {
+    worker_urls: Vec<String>,
+    git_commit_hash: String,
+    build_time_utc: String,
+    errors: Vec<String>,
+}
+
+#[derive(Debug, StructOpt, Clone)]
+#[structopt(about = "worker spawn command")]
+struct Cmd {
+    /// The bucket name.
+    #[structopt(long, default_value = "datafusion-distributed-benchmarks")]
+    bucket: String,
+
+    /// The headless worker service used for worker discovery.
+    #[structopt(
+        long,
+        default_value = "datafusion-workers.benchmark-datafusion.svc.cluster.local"
+    )]
+    worker_dns_name: String,
+
+    // Turns broadcast joins on.
+    #[structopt(long)]
+    broadcast_joins: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .parse_default_env()
+        .init();
+
+    let cmd = Cmd::from_args();
+
+    const LISTENER_ADDR: &str = "0.0.0.0:9000";
+    const WORKER_ADDR: &str = "0.0.0.0:9001";
+
+    info!("Starting HTTP listener on {LISTENER_ADDR}...");
+    let listener = tokio::net::TcpListener::bind(LISTENER_ADDR).await?;
+
+    let self_url = get_self_url().await?;
+    info!("Resolved self URL as {self_url}");
+
+    // Register S3 object store
+    let s3_url = Url::parse(&format!("s3://{}", cmd.bucket))?;
+
+    info!("Building shared SessionContext for the whole lifetime of the HTTP listener...");
+    let s3 = Arc::new(
+        AmazonS3Builder::from_env()
+            .with_bucket_name(s3_url.host().unwrap().to_string())
+            .build()?,
+    );
+    let runtime_env = Arc::new(RuntimeEnv::default());
+    runtime_env.register_object_store(&s3_url, s3);
+
+    let worker = Worker::from_session_builder(|ctx: WorkerQueryContext| async move {
+        Ok(ctx
+            .builder
+            .with_distributed_user_codec(WorkUnitFileScanCodec)
+            .build())
+    })
+    .with_runtime_env(Arc::clone(&runtime_env));
+
+    let state_builder = SessionStateBuilder::new()
+        .with_default_features()
+        .with_runtime_env(runtime_env)
+        .with_distributed_local_worker_context(worker.to_local_worker_context(self_url))
+        .with_distributed_worker_resolver(DnsWorkerResolver::new(cmd.worker_dns_name.clone()))
+        .with_distributed_planner()
+        .with_distributed_broadcast_joins(cmd.broadcast_joins)?
+        // Uncomment for enabling WorkUnitFileScans.
+        // .with_physical_optimizer_rule(Arc::new(WorkUnitFileScanRule))
+        .with_distributed_user_codec(WorkUnitFileScanCodec)
+        .with_distributed_desired_task_count_handler(work_unit_file_scan_desired_task_count)
+        .with_distributed_scale_up_leaf_node_handler(work_unit_file_scan_scale_up_leaf_node)
+        .with_distributed_work_unit_feed(|dse: &DataSourceExec| {
+            dse.data_source()
+                .downcast_ref::<WorkUnitFileScanConfig>()
+                .map(|v| &v.feed)
+        });
+    let state = state_builder.build();
+    let ctx = SessionContext::from(state);
+    let ctx_clone = ctx.clone();
+
+    let http_server = axum::serve(
+        listener,
+        Router::new()
+            .route(
+                "/info",
+                get(move || async move {
+                    let ctx = ctx_clone.clone();
+
+                    let worker_resolver =
+                        get_distributed_worker_resolver(ctx.state_ref().read().config())
+                            .map_err(err)?;
+                    let channel_resolver =
+                        get_distributed_channel_resolver(ctx.task_ctx().as_ref());
+
+                    let mut worker_urls = vec![];
+                    let mut errors = vec![];
+                    for worker_url in worker_resolver.get_urls().map_err(err)? {
+                        if let Err(err) = channel_resolver
+                            .get_worker_client_for_url(&worker_url)
+                            .await
+                        {
+                            errors.push(err.to_string())
+                        } else {
+                            worker_urls.push(worker_url);
+                        };
+                    }
+                    let worker_urls = worker_urls.into_iter().map(|v| v.to_string()).collect();
+
+                    Ok::<_, (StatusCode, String)>(Json(WorkerInfo {
+                        worker_urls,
+                        git_commit_hash: built_info::GIT_COMMIT_HASH
+                            .unwrap_or_default()
+                            .to_string(),
+                        build_time_utc: built_info::BUILT_TIME_UTC.to_string(),
+                        errors,
+                    }))
+                }),
+            )
+            .route(
+                "/",
+                get(move |Query(params): Query<QueryParameters>| {
+                    let ctx = ctx.clone();
+
+                    async move {
+                        let sql = params.get("sql").ok_or(err("Missing 'sql' parameter"))?;
+
+                        let mut df_opt = None;
+                        for sql in sql.split(";") {
+                            if sql.trim().is_empty() {
+                                continue;
+                            }
+                            let df = ctx.sql(sql).await.map_err(err)?;
+                            df_opt = Some(df);
+                        }
+                        let Some(df) = df_opt else {
+                            return Err(err("Empty 'sql' parameter"));
+                        };
+
+                        let start = Instant::now();
+
+                        info!("Executing query...");
+                        let abort_notifier = AbortNotifier::new("Query aborted");
+                        let abort_notifier_clone = abort_notifier.clone();
+                        let task = SpawnedTask::spawn(async move {
+                            let _ = abort_notifier_clone;
+                            loop {
+                                tokio::time::sleep(Duration::from_secs(5)).await;
+                                info!("Query still running...");
+                            }
+                        });
+                        let physical = df.create_physical_plan().await.map_err(err)?;
+                        let mut stream =
+                            execute_stream(physical.clone(), ctx.task_ctx()).map_err(err)?;
+                        let mut count = 0;
+                        while let Some(batch) = stream.next().await {
+                            count += batch.map_err(err)?.num_rows();
+                            info!("Gathered {count} rows, query still in progress..")
+                        }
+                        let physical = rewrite_distributed_plan_with_metrics(
+                            physical,
+                            DistributedMetricsFormat::PerTask,
+                        )
+                        .await
+                        .map_err(err)?;
+                        let stats_q_error = stats_estimation_q_error(&physical);
+                        let plan = display_plan_ascii(physical.as_ref(), true);
+                        drop(task);
+
+                        let mut task_count = 0;
+                        physical
+                            .apply(|plan| {
+                                let Some(nb) = plan.as_network_boundary() else {
+                                    return Ok(TreeNodeRecursion::Continue);
+                                };
+                                task_count += nb.input_stage().task_count();
+                                Ok(TreeNodeRecursion::Continue)
+                            })
+                            .expect(".apply failed");
+
+                        let elapsed = start.elapsed();
+                        let ms = elapsed.as_secs_f64() * 1000.0;
+                        info!("Finished executing query:\n{sql}\n\n{plan}");
+                        info!("Returned {count} rows in {ms} ms");
+                        abort_notifier.finished();
+
+                        Ok::<_, (StatusCode, String)>(Json(QueryResult {
+                            count,
+                            plan,
+                            elapsed_ms: ms,
+                            tasks: task_count,
+                            stats_q_error_p50: stats_q_error.map(|q_error| q_error.p50),
+                            stats_q_error_p95: stats_q_error.map(|q_error| q_error.p95),
+                        }))
+                    }
+                    .inspect_err(|(_, msg)| {
+                        error!("Error executing query: {msg}");
+                    })
+                }),
+            ),
+    );
+    let dns_worker_resolver = Arc::new(DnsWorkerResolver::new(cmd.worker_dns_name));
+    let grpc_server = Server::builder()
+        .add_service(worker.with_observability_service(dns_worker_resolver))
+        .add_service(worker.into_worker_server())
+        .serve(WORKER_ADDR.parse()?);
+
+    info!("Started listener HTTP server in {LISTENER_ADDR}");
+    info!("Started distributed DataFusion worker in {WORKER_ADDR}");
+
+    tokio::select! {
+        result = http_server => result?,
+        result = grpc_server => result?,
+    }
+
+    Ok(())
+}
+
+struct AbortNotifier {
+    aborted: AtomicBool,
+    msg: String,
+}
+
+impl AbortNotifier {
+    fn new(msg: impl Display) -> Arc<Self> {
+        Arc::new(AbortNotifier {
+            aborted: AtomicBool::new(true),
+            msg: msg.to_string(),
+        })
+    }
+
+    fn finished(&self) {
+        self.aborted
+            .store(false, std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+impl Drop for AbortNotifier {
+    fn drop(&mut self) {
+        if self.aborted.load(std::sync::atomic::Ordering::Relaxed) {
+            warn!("{}", self.msg);
+        }
+    }
+}
+
+fn err(s: impl Display) -> (StatusCode, String) {
+    (StatusCode::INTERNAL_SERVER_ERROR, s.to_string())
+}
+
+async fn get_self_url() -> Result<Url, Box<dyn Error>> {
+    let pod_ip = std::env::var("POD_IP")
+        .map_err(|_| io::Error::new(io::ErrorKind::NotFound, "POD_IP is not set"))?;
+    Ok(Url::parse(&format!("http://{pod_ip}:9001"))?)
+}
+
+#[derive(Clone)]
+struct DnsWorkerResolver {
+    urls: Arc<RwLock<Vec<Url>>>,
+}
+
+async fn background_dns_worker_resolver(urls: Arc<RwLock<Vec<Url>>>, worker_dns_name: String) {
+    loop {
+        let addresses = match tokio::net::lookup_host((worker_dns_name.as_str(), 9001)).await {
+            Ok(addresses) => addresses,
+            Err(err) => {
+                warn!("Error resolving benchmark workers: {err}");
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                continue;
+            }
+        };
+
+        let mut workers = addresses
+            .map(|address| Url::parse(&format!("http://{address}")).unwrap())
+            .collect::<Vec<_>>();
+        workers.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+        workers.dedup();
+        if !urls.read().unwrap().eq(&workers) {
+            info!(
+                "New set of workers found: {}",
+                workers
+                    .iter()
+                    .map(|url| url.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+            *urls.write().unwrap() = workers;
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+impl DnsWorkerResolver {
+    fn new(worker_dns_name: String) -> Self {
+        let urls = Arc::new(RwLock::new(Vec::new()));
+        #[allow(clippy::disallowed_methods)]
+        tokio::spawn(background_dns_worker_resolver(
+            urls.clone(),
+            worker_dns_name,
+        ));
+        Self { urls }
+    }
+}
+
+#[async_trait]
+impl WorkerResolver for DnsWorkerResolver {
+    fn get_urls(&self) -> Result<Vec<Url>, DataFusionError> {
+        Ok(self.urls.read().unwrap().clone())
+    }
+}


### PR DESCRIPTION
## What changed

- restore the Kubernetes remote benchmark worker as `benchmarks/src/bin/worker.rs`
- build it as part of the existing `datafusion-distributed-benchmarks` crate
- reuse the benchmark crate's statistics helper and workspace dependency graph
- document why the remote worker is owned alongside the APIs it consumes

## Why

The worker imports DataFusion and DataFusion Distributed APIs directly. Keeping
a separate Rust crate and lockfile in the deployment-tools repository made it
drift whenever either upstream API changed. Owning the worker in this repository
lets API changes update the worker in the same commit and ensures it resolves
the exact DataFusion dependency selected by the checked-out revision.

A follow-up in `datafusion-distributed-dev-tools` removes its copied Rust crate
and makes the standard deployment path build this upstream target.

## Validation

- `cargo check -p datafusion-distributed-benchmarks --bin worker`
- `cargo clippy -p datafusion-distributed-benchmarks --bin worker --all-features -- -D warnings`
- `cargo test -p datafusion-distributed-benchmarks --lib stats::tests`
- `cargo fmt --all -- --check`
- `cargo zigbuild --manifest-path benchmarks/Cargo.toml --package datafusion-distributed-benchmarks --release --bin worker --target x86_64-unknown-linux-gnu`
