### PR TITLE
feat: forward remote dynamic filter updates to coordinator

### DIFF
--- a/src/coordinator/dynamic_filter_registry.rs
+++ b/src/coordinator/dynamic_filter_registry.rs
@@ -3,7 +3,9 @@ use crate::dynamic_filtering::{
     discover_dynamic_filter_consumers, discover_dynamic_filter_producers,
 };
 use datafusion::common::{HashMap, HashSet, Result};
+use datafusion::physical_expr_common::metrics::{ExecutionPlanMetricsSet, MetricBuilder};
 use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::metrics::Count;
 use std::sync::{Arc, Mutex};
 
 #[derive(Default)]
@@ -28,14 +30,22 @@ pub(super) struct DynamicFilterRegistryState {
 /// - where dynamic filter updates are coming from
 /// - how/if dynamic filter updates should be merged
 /// - where dynamic filter updates should be forwarded
-#[derive(Default)]
 pub(crate) struct DynamicFilterRegistry {
     pub(super) state: Mutex<DynamicFilterRegistryState>,
+    dynamic_filter_updates_received: Count,
 }
 
 impl DynamicFilterRegistry {
-    pub(crate) fn new() -> Self {
-        Self::default()
+    pub(crate) fn new(metrics: &ExecutionPlanMetricsSet) -> Self {
+        Self {
+            state: Mutex::new(DynamicFilterRegistryState::default()),
+            dynamic_filter_updates_received: MetricBuilder::new(metrics)
+                .global_counter("dynamic_filter_updates_received"),
+        }
+    }
+
+    pub(crate) fn record_update_received(&self) {
+        self.dynamic_filter_updates_received.add(1);
     }
 
     /// Adds any dynamic filter producers and consumers found in `plan` to the registry.

--- a/src/coordinator/query_coordinator.rs
+++ b/src/coordinator/query_coordinator.rs
@@ -497,11 +497,13 @@ impl<'a> StageCoordinator<'a> {
     }
 }
 
-/// Returns producer IDs whose consumers cross a network boundary in this task plan.
+/// Returns producer IDs with at least one remote consumer.
 ///
-/// Consumers in the same task share their dynamic-filter expression with the producer and are
-/// updated directly by DataFusion. Network-boundary expressions are metadata anchors installed by
-/// distributed planning; their IDs identify the producers whose updates must cross the coordinator.
+/// If a producer ID is present in the dynamic-filter anchors of any [`NetworkBoundary`], the plan
+/// contains at least one remote consumer and the producer's updates must be forwarded to the
+/// coordinator.
+///
+/// [`NetworkBoundary`]: crate::NetworkBoundary
 fn dynamic_filter_remote_producer_ids(plan: &Arc<dyn ExecutionPlan>) -> Result<Vec<u64>> {
     let producer_ids: HashSet<_> = discover_dynamic_filter_producers(plan)?
         .into_iter()

--- a/src/coordinator/query_coordinator.rs
+++ b/src/coordinator/query_coordinator.rs
@@ -1,11 +1,11 @@
-use crate::codec::roundtrip_pb;
+use crate::codec::{encode_execution_plan, roundtrip_pb};
 use crate::common::{TreeNodeExt, now_ns, task_ctx_with_extension};
 use crate::config_extension_ext::get_config_extension_propagation_headers;
 use crate::coordinator::DynamicFilterRegistry;
 use crate::coordinator::Store;
 use crate::coordinator::latency_metric::LatencyMetric;
 use crate::dynamic_filtering::{
-    is_dynamic_filtering_enabled,
+    discover_dynamic_filter_producers, is_dynamic_filtering_enabled,
     maybe_roundtrip_plan_to_sever_in_memory_dynamic_filter_relationships,
 };
 use crate::events::{
@@ -19,15 +19,16 @@ use crate::work_unit_feed::{build_work_unit_batch_msg, set_work_unit_send_time};
 use crate::{
     CoordinatorToWorkerMsg, DISTRIBUTED_DATAFUSION_TASK_ID_LABEL, DistributedGetterExt,
     DistributedTaskContext, DistributedWorkUnitFeedContext, LoadInfo, LocalWorkerContext,
-    MaybeEncoded, SetPlanRequest, TaskCompletedDynamicFilters, TaskKey, TaskMetrics,
-    WorkUnitFeedDeclaration, WorkerToCoordinatorMsg, get_distributed_channel_resolver,
+    MaybeEncoded, NetworkBoundaryExt, SetPlanRequest, TaskCompletedDynamicFilters, TaskKey,
+    TaskMetrics, WorkUnitFeedDeclaration, WorkerToCoordinatorMsg, get_distributed_channel_resolver,
 };
 use datafusion::common::Result;
 use datafusion::common::instant::Instant;
 use datafusion::common::runtime::JoinSet;
-use datafusion::common::tree_node::{Transformed, TreeNodeRecursion};
-use datafusion::common::{DataFusionError, internal_err};
+use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
+use datafusion::common::{DataFusionError, HashSet, internal_err};
 use datafusion::execution::TaskContext;
+use datafusion::physical_expr::expressions::DynamicFilterPhysicalExpr;
 use datafusion::physical_expr_common::metrics::{ExecutionPlanMetricsSet, Label, MetricBuilder};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::metrics::Count;
@@ -131,6 +132,12 @@ impl QueryCoordinator {
 /// - Building tasks that communicate a serialized plan to multiple workers for further execution.
 /// - Building tasks that stream partition feeds from local [WorkUnitFeedExec] nodes to their
 ///   remote counterparts.
+struct SpecializedTaskPlan {
+    plan: Arc<dyn ExecutionPlan>,
+    work_unit_feed_declarations: Vec<WorkUnitFeedDeclaration>,
+    dynamic_filter_remote_producer_ids: Vec<u64>,
+}
+
 pub(super) struct StageCoordinator<'a> {
     plan: &'a Arc<dyn ExecutionPlan>,
     query_id: Uuid,
@@ -163,7 +170,11 @@ impl<'a> StageCoordinator<'a> {
     )> {
         let session_config = self.task_ctx.session_config();
 
-        let (specialized, work_unit_feed_declarations) = self.task_specialized_plan(task_i)?;
+        let SpecializedTaskPlan {
+            plan,
+            work_unit_feed_declarations,
+            dynamic_filter_remote_producer_ids,
+        } = self.task_specialized_plan(task_i)?;
 
         let task_key = TaskKey {
             query_id: self.query_id,
@@ -172,7 +183,7 @@ impl<'a> StageCoordinator<'a> {
         };
 
         self.dynamic_filter_registry
-            .register_task(&specialized, task_key)?;
+            .register_task(&plan, task_key)?;
 
         let mut headers = get_config_extension_propagation_headers(session_config)?;
         headers.extend(get_passthrough_headers(session_config));
@@ -211,7 +222,8 @@ impl<'a> StageCoordinator<'a> {
             let set_plan_request = SetPlanRequest {
                 task_key,
                 task_count: self.task_count,
-                plan: MaybeEncoded::Decoded(Arc::clone(&specialized)),
+                plan: MaybeEncoded::Decoded(Arc::clone(&plan)),
+                dynamic_filter_remote_producer_ids: dynamic_filter_remote_producer_ids.clone(),
                 work_unit_feed_declarations: work_unit_feed_declarations.clone(),
                 target_worker_url: url.clone(),
                 query_start_time_ns: self.metrics.instantiation_time,
@@ -256,7 +268,7 @@ impl<'a> StageCoordinator<'a> {
             task_ctx: self.task_ctx,
             metrics: self.metrics_set,
             worker_resolver: worker_resolver.as_ref(),
-            task_specialized_plan: &specialized,
+            task_specialized_plan: &plan,
             task_key,
             task_count: self.task_count,
             dialer: &dialer,
@@ -335,6 +347,9 @@ impl<'a> StageCoordinator<'a> {
                             store.insert(task_key, filters);
                         }
                     }
+                    // Runtime dynamic-filter reports are accepted by this transport change. A
+                    // later change in the stack will retain and merge them.
+                    WorkerToCoordinatorMsg::ProducedDynamicFilter(_) => {}
                 }
             }
         });
@@ -418,10 +433,7 @@ impl<'a> StageCoordinator<'a> {
     /// trimming down any unnecessary information that the specific `task_i` task is not going to
     /// need, like unexecuted branches in [ChildrenIsolatorUnionExec], or unexecuted variants of
     /// [DistributedLeafExec].
-    fn task_specialized_plan(
-        &self,
-        task_i: usize,
-    ) -> Result<(Arc<dyn ExecutionPlan>, Vec<WorkUnitFeedDeclaration>)> {
+    fn task_specialized_plan(&self, task_i: usize) -> Result<SpecializedTaskPlan> {
         let session_config = self.task_ctx.session_config();
         let wuf_registry = session_config
             .get_extension::<WorkUnitFeedRegistry>()
@@ -472,8 +484,56 @@ impl<'a> StageCoordinator<'a> {
         } else {
             transformed.data
         };
-        Ok((plan, work_unit_feed_declarations))
+        let dynamic_filter_remote_producer_ids = if dynamic_filtering_enabled {
+            dynamic_filter_remote_producer_ids(&plan)?
+        } else {
+            vec![]
+        };
+        Ok(SpecializedTaskPlan {
+            plan,
+            work_unit_feed_declarations,
+            dynamic_filter_remote_producer_ids,
+        })
     }
+}
+
+/// Returns producer IDs whose consumers cross a network boundary in this task plan.
+///
+/// Consumers in the same task share their dynamic-filter expression with the producer and are
+/// updated directly by DataFusion. Network-boundary expressions are metadata anchors installed by
+/// distributed planning; their IDs identify the producers whose updates must cross the coordinator.
+fn dynamic_filter_remote_producer_ids(plan: &Arc<dyn ExecutionPlan>) -> Result<Vec<u64>> {
+    let producer_ids: HashSet<_> = discover_dynamic_filter_producers(plan)?
+        .into_iter()
+        .map(|producer| producer.id)
+        .collect();
+    let mut anchor_ids = HashSet::new();
+    plan.apply(|node| {
+        if !node.is_network_boundary() {
+            return Ok(TreeNodeRecursion::Continue);
+        }
+        node.apply_expressions(&mut |root| {
+            root.apply(|expression| {
+                if expression
+                    .downcast_ref::<DynamicFilterPhysicalExpr>()
+                    .is_some()
+                {
+                    let Some(id) = expression.expression_id() else {
+                        return datafusion::common::internal_err!(
+                            "DynamicFilterPhysicalExpr did not have an expression ID"
+                        );
+                    };
+                    anchor_ids.insert(id);
+                }
+                Ok(TreeNodeRecursion::Continue)
+            })
+        })?;
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+
+    let mut remote_producer_ids: Vec<_> = producer_ids.intersection(&anchor_ids).copied().collect();
+    remote_producer_ids.sort_unstable();
+    Ok(remote_producer_ids)
 }
 
 fn keep_stream_alive<T: 'static>(notify: Arc<Notify>) -> impl Stream<Item = T> + 'static {
@@ -525,6 +585,83 @@ impl CoordinatorToWorkerMetrics {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::NetworkShuffleExec;
+    use crate::stage::{RemoteStage, Stage};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::common::{JoinType, NullEquality};
+    use datafusion::physical_expr::Partitioning;
+    use datafusion::physical_expr::PhysicalExpr;
+    use datafusion::physical_expr::expressions::{Column, DynamicFilterPhysicalExpr, lit};
+    use datafusion::physical_plan::empty::EmptyExec;
+    use datafusion::physical_plan::filter::FilterExec;
+    use datafusion::physical_plan::joins::{HashJoinExec, PartitionMode};
+    use datafusion::physical_plan::repartition::RepartitionExec;
+
+    #[test]
+    fn identifies_only_producers_with_network_boundary_consumers() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+
+        let local_filter = dynamic_filter();
+        let local_probe = Arc::new(FilterExec::try_new(local_filter.clone(), empty(&schema))?)
+            as Arc<dyn ExecutionPlan>;
+        let local_join = join_with_filter(&schema, local_probe, Arc::clone(&local_filter))?;
+        assert!(dynamic_filter_remote_producer_ids(&local_join)?.is_empty());
+
+        let remote_filter = dynamic_filter();
+        let repartition = Arc::new(RepartitionExec::try_new(
+            empty(&schema),
+            Partitioning::Hash(vec![Arc::new(Column::new("a", 0))], 1),
+        )?) as Arc<dyn ExecutionPlan>;
+        let input_properties = Arc::clone(repartition.properties());
+        let remote_probe = Arc::new(NetworkShuffleExec::from_stage(
+            Stage::Remote(RemoteStage {
+                query_id: Default::default(),
+                num: 0,
+                workers: vec![],
+                runtime_stats: None,
+                dynamic_filter_anchors: vec![remote_filter.clone()],
+            }),
+            input_properties,
+        )) as Arc<dyn ExecutionPlan>;
+        let remote_join = join_with_filter(&schema, remote_probe, Arc::clone(&remote_filter))?;
+        assert_eq!(
+            dynamic_filter_remote_producer_ids(&remote_join)?,
+            vec![remote_filter.expression_id().unwrap()]
+        );
+        Ok(())
+    }
+
+    fn dynamic_filter() -> Arc<DynamicFilterPhysicalExpr> {
+        Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::new(Column::new("a", 0))],
+            lit(true),
+        ))
+    }
+
+    fn empty(schema: &Arc<Schema>) -> Arc<dyn ExecutionPlan> {
+        Arc::new(EmptyExec::new(Arc::clone(schema)))
+    }
+
+    fn join_with_filter(
+        schema: &Arc<Schema>,
+        probe: Arc<dyn ExecutionPlan>,
+        dynamic_filter: Arc<DynamicFilterPhysicalExpr>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(
+            HashJoinExec::try_new(
+                empty(schema),
+                probe,
+                vec![(Arc::new(Column::new("a", 0)), Arc::new(Column::new("a", 0)))],
+                None,
+                &JoinType::Inner,
+                None,
+                PartitionMode::Partitioned,
+                NullEquality::NullEqualsNothing,
+                false,
+            )?
+            .with_dynamic_filter_expr(dynamic_filter)?,
+        ))
+    }
 
     /// Regression test for a rustc miscompilation (present at least through
     /// 1.96, fixed in 1.98) of [`CoordinatorToWorkerMetrics::new`].

--- a/src/coordinator/query_coordinator.rs
+++ b/src/coordinator/query_coordinator.rs
@@ -131,12 +131,6 @@ impl QueryCoordinator {
 /// - Building tasks that communicate a serialized plan to multiple workers for further execution.
 /// - Building tasks that stream partition feeds from local [WorkUnitFeedExec] nodes to their
 ///   remote counterparts.
-struct SpecializedTaskPlan {
-    plan: Arc<dyn ExecutionPlan>,
-    work_unit_feed_declarations: Vec<WorkUnitFeedDeclaration>,
-    dynamic_filter_remote_producer_ids: Vec<u64>,
-}
-
 pub(super) struct StageCoordinator<'a> {
     plan: &'a Arc<dyn ExecutionPlan>,
     query_id: Uuid,
@@ -169,7 +163,7 @@ impl<'a> StageCoordinator<'a> {
     )> {
         let session_config = self.task_ctx.session_config();
 
-        let SpecializedTaskPlan {
+        let TaskSpecializedPlan {
             plan,
             work_unit_feed_declarations,
             dynamic_filter_remote_producer_ids,
@@ -433,7 +427,7 @@ impl<'a> StageCoordinator<'a> {
     /// trimming down any unnecessary information that the specific `task_i` task is not going to
     /// need, like unexecuted branches in [ChildrenIsolatorUnionExec], or unexecuted variants of
     /// [DistributedLeafExec].
-    fn task_specialized_plan(&self, task_i: usize) -> Result<SpecializedTaskPlan> {
+    fn task_specialized_plan(&self, task_i: usize) -> Result<TaskSpecializedPlan> {
         let session_config = self.task_ctx.session_config();
         let wuf_registry = session_config
             .get_extension::<WorkUnitFeedRegistry>()
@@ -489,7 +483,7 @@ impl<'a> StageCoordinator<'a> {
         } else {
             vec![]
         };
-        Ok(SpecializedTaskPlan {
+        Ok(TaskSpecializedPlan {
             plan,
             work_unit_feed_declarations,
             dynamic_filter_remote_producer_ids,
@@ -499,6 +493,12 @@ impl<'a> StageCoordinator<'a> {
 
 fn keep_stream_alive<T: 'static>(notify: Arc<Notify>) -> impl Stream<Item = T> + 'static {
     futures::stream::once(notify.notified_owned()).filter_map(|()| futures::future::ready(None))
+}
+
+struct TaskSpecializedPlan {
+    plan: Arc<dyn ExecutionPlan>,
+    work_unit_feed_declarations: Vec<WorkUnitFeedDeclaration>,
+    dynamic_filter_remote_producer_ids: Vec<u64>,
 }
 
 pub(super) struct NotifyGuard(Arc<Notify>);

--- a/src/coordinator/query_coordinator.rs
+++ b/src/coordinator/query_coordinator.rs
@@ -1,12 +1,12 @@
-use crate::codec::{encode_execution_plan, roundtrip_pb};
+use crate::codec::roundtrip_pb;
 use crate::common::{TreeNodeExt, now_ns, task_ctx_with_extension};
 use crate::config_extension_ext::get_config_extension_propagation_headers;
 use crate::coordinator::DynamicFilterRegistry;
 use crate::coordinator::Store;
 use crate::coordinator::latency_metric::LatencyMetric;
 use crate::dynamic_filtering::{
-    discover_dynamic_filter_producers, is_dynamic_filtering_enabled,
-    maybe_roundtrip_plan_to_sever_in_memory_dynamic_filter_relationships,
+    discover_dynamic_filter_consumers, discover_dynamic_filter_producers,
+    is_dynamic_filtering_enabled, maybe_roundtrip_plan_to_sever_in_memory_dynamic_filter_relationships,
 };
 use crate::events::{
     RouteTaskEvent, RouteTaskEventResponse, RouteTaskHandlers, new_coordinator_to_worker_dialer,
@@ -19,16 +19,15 @@ use crate::work_unit_feed::{build_work_unit_batch_msg, set_work_unit_send_time};
 use crate::{
     CoordinatorToWorkerMsg, DISTRIBUTED_DATAFUSION_TASK_ID_LABEL, DistributedGetterExt,
     DistributedTaskContext, DistributedWorkUnitFeedContext, LoadInfo, LocalWorkerContext,
-    MaybeEncoded, NetworkBoundaryExt, SetPlanRequest, TaskCompletedDynamicFilters, TaskKey,
-    TaskMetrics, WorkUnitFeedDeclaration, WorkerToCoordinatorMsg, get_distributed_channel_resolver,
+    MaybeEncoded, SetPlanRequest, TaskCompletedDynamicFilters, TaskKey, TaskMetrics,
+    WorkUnitFeedDeclaration, WorkerToCoordinatorMsg, get_distributed_channel_resolver,
 };
 use datafusion::common::Result;
 use datafusion::common::instant::Instant;
 use datafusion::common::runtime::JoinSet;
-use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
+use datafusion::common::tree_node::{Transformed, TreeNodeRecursion};
 use datafusion::common::{DataFusionError, HashSet, internal_err};
 use datafusion::execution::TaskContext;
-use datafusion::physical_expr::expressions::DynamicFilterPhysicalExpr;
 use datafusion::physical_expr_common::metrics::{ExecutionPlanMetricsSet, Label, MetricBuilder};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::metrics::Count;
@@ -347,8 +346,6 @@ impl<'a> StageCoordinator<'a> {
                             store.insert(task_key, filters);
                         }
                     }
-                    // Runtime dynamic-filter reports are accepted by this transport change. A
-                    // later change in the stack will retain and merge them.
                     WorkerToCoordinatorMsg::ProducedDynamicFilter(_) => {}
                 }
             }
@@ -509,29 +506,11 @@ fn dynamic_filter_remote_producer_ids(plan: &Arc<dyn ExecutionPlan>) -> Result<V
         .into_iter()
         .map(|producer| producer.id)
         .collect();
-    let mut anchor_ids = HashSet::new();
-    plan.apply(|node| {
-        if !node.is_network_boundary() {
-            return Ok(TreeNodeRecursion::Continue);
-        }
-        node.apply_expressions(&mut |root| {
-            root.apply(|expression| {
-                if expression
-                    .downcast_ref::<DynamicFilterPhysicalExpr>()
-                    .is_some()
-                {
-                    let Some(id) = expression.expression_id() else {
-                        return datafusion::common::internal_err!(
-                            "DynamicFilterPhysicalExpr did not have an expression ID"
-                        );
-                    };
-                    anchor_ids.insert(id);
-                }
-                Ok(TreeNodeRecursion::Continue)
-            })
-        })?;
-        Ok(TreeNodeRecursion::Continue)
-    })?;
+    let anchor_ids: HashSet<_> = discover_dynamic_filter_consumers(plan)?
+        .anchors
+        .into_iter()
+        .map(|anchor| anchor.id)
+        .collect();
 
     let mut remote_producer_ids: Vec<_> = producer_ids.intersection(&anchor_ids).copied().collect();
     remote_producer_ids.sort_unstable();

--- a/src/coordinator/query_coordinator.rs
+++ b/src/coordinator/query_coordinator.rs
@@ -5,8 +5,8 @@ use crate::coordinator::DynamicFilterRegistry;
 use crate::coordinator::Store;
 use crate::coordinator::latency_metric::LatencyMetric;
 use crate::dynamic_filtering::{
-    discover_dynamic_filter_consumers, discover_dynamic_filter_producers,
-    is_dynamic_filtering_enabled, maybe_roundtrip_plan_to_sever_in_memory_dynamic_filter_relationships,
+    dynamic_filter_remote_producer_ids, is_dynamic_filtering_enabled,
+    maybe_roundtrip_plan_to_sever_in_memory_dynamic_filter_relationships,
 };
 use crate::events::{
     RouteTaskEvent, RouteTaskEventResponse, RouteTaskHandlers, new_coordinator_to_worker_dialer,
@@ -26,7 +26,7 @@ use datafusion::common::Result;
 use datafusion::common::instant::Instant;
 use datafusion::common::runtime::JoinSet;
 use datafusion::common::tree_node::{Transformed, TreeNodeRecursion};
-use datafusion::common::{DataFusionError, HashSet, internal_err};
+use datafusion::common::{DataFusionError, internal_err};
 use datafusion::execution::TaskContext;
 use datafusion::physical_expr_common::metrics::{ExecutionPlanMetricsSet, Label, MetricBuilder};
 use datafusion::physical_plan::ExecutionPlan;
@@ -74,7 +74,7 @@ impl QueryCoordinator {
             metrics: metrics_set.clone(),
             metrics_store,
             completed_dynamic_filter_store,
-            dynamic_filter_registry: Arc::new(DynamicFilterRegistry::new()),
+            dynamic_filter_registry: Arc::new(DynamicFilterRegistry::new(metrics_set)),
             coordinator_to_worker_metrics: CoordinatorToWorkerMetrics::new(metrics_set),
             end_stream_notifier: Arc::new(Notify::new()),
             join_set: Mutex::new(JoinSet::new()),
@@ -319,6 +319,7 @@ impl<'a> StageCoordinator<'a> {
         };
         let task_metrics = self.metrics_store.clone();
         let completed_dynamic_filter_store = self.completed_dynamic_filter_store.clone();
+        let dynamic_filter_registry = Arc::clone(self.dynamic_filter_registry);
         let (load_info_tx, load_info_rx) = tokio::sync::mpsc::unbounded_channel();
         let mut load_info_tx_opt = Some(load_info_tx);
 
@@ -346,7 +347,9 @@ impl<'a> StageCoordinator<'a> {
                             store.insert(task_key, filters);
                         }
                     }
-                    WorkerToCoordinatorMsg::ProducedDynamicFilter(_) => {}
+                    WorkerToCoordinatorMsg::ProducedDynamicFilter(_) => {
+                        dynamic_filter_registry.record_update_received();
+                    }
                 }
             }
         });
@@ -494,29 +497,6 @@ impl<'a> StageCoordinator<'a> {
     }
 }
 
-/// Returns producer IDs with at least one remote consumer.
-///
-/// If a producer ID is present in the dynamic-filter anchors of any [`NetworkBoundary`], the plan
-/// contains at least one remote consumer and the producer's updates must be forwarded to the
-/// coordinator.
-///
-/// [`NetworkBoundary`]: crate::NetworkBoundary
-fn dynamic_filter_remote_producer_ids(plan: &Arc<dyn ExecutionPlan>) -> Result<Vec<u64>> {
-    let producer_ids: HashSet<_> = discover_dynamic_filter_producers(plan)?
-        .into_iter()
-        .map(|producer| producer.id)
-        .collect();
-    let anchor_ids: HashSet<_> = discover_dynamic_filter_consumers(plan)?
-        .anchors
-        .into_iter()
-        .map(|anchor| anchor.id)
-        .collect();
-
-    let mut remote_producer_ids: Vec<_> = producer_ids.intersection(&anchor_ids).copied().collect();
-    remote_producer_ids.sort_unstable();
-    Ok(remote_producer_ids)
-}
-
 fn keep_stream_alive<T: 'static>(notify: Arc<Notify>) -> impl Stream<Item = T> + 'static {
     futures::stream::once(notify.notified_owned()).filter_map(|()| futures::future::ready(None))
 }
@@ -566,83 +546,6 @@ impl CoordinatorToWorkerMetrics {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::NetworkShuffleExec;
-    use crate::stage::{RemoteStage, Stage};
-    use datafusion::arrow::datatypes::{DataType, Field, Schema};
-    use datafusion::common::{JoinType, NullEquality};
-    use datafusion::physical_expr::Partitioning;
-    use datafusion::physical_expr::PhysicalExpr;
-    use datafusion::physical_expr::expressions::{Column, DynamicFilterPhysicalExpr, lit};
-    use datafusion::physical_plan::empty::EmptyExec;
-    use datafusion::physical_plan::filter::FilterExec;
-    use datafusion::physical_plan::joins::{HashJoinExec, PartitionMode};
-    use datafusion::physical_plan::repartition::RepartitionExec;
-
-    #[test]
-    fn identifies_only_producers_with_network_boundary_consumers() -> Result<()> {
-        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
-
-        let local_filter = dynamic_filter();
-        let local_probe = Arc::new(FilterExec::try_new(local_filter.clone(), empty(&schema))?)
-            as Arc<dyn ExecutionPlan>;
-        let local_join = join_with_filter(&schema, local_probe, Arc::clone(&local_filter))?;
-        assert!(dynamic_filter_remote_producer_ids(&local_join)?.is_empty());
-
-        let remote_filter = dynamic_filter();
-        let repartition = Arc::new(RepartitionExec::try_new(
-            empty(&schema),
-            Partitioning::Hash(vec![Arc::new(Column::new("a", 0))], 1),
-        )?) as Arc<dyn ExecutionPlan>;
-        let input_properties = Arc::clone(repartition.properties());
-        let remote_probe = Arc::new(NetworkShuffleExec::from_stage(
-            Stage::Remote(RemoteStage {
-                query_id: Default::default(),
-                num: 0,
-                workers: vec![],
-                runtime_stats: None,
-                dynamic_filter_anchors: vec![remote_filter.clone()],
-            }),
-            input_properties,
-        )) as Arc<dyn ExecutionPlan>;
-        let remote_join = join_with_filter(&schema, remote_probe, Arc::clone(&remote_filter))?;
-        assert_eq!(
-            dynamic_filter_remote_producer_ids(&remote_join)?,
-            vec![remote_filter.expression_id().unwrap()]
-        );
-        Ok(())
-    }
-
-    fn dynamic_filter() -> Arc<DynamicFilterPhysicalExpr> {
-        Arc::new(DynamicFilterPhysicalExpr::new(
-            vec![Arc::new(Column::new("a", 0))],
-            lit(true),
-        ))
-    }
-
-    fn empty(schema: &Arc<Schema>) -> Arc<dyn ExecutionPlan> {
-        Arc::new(EmptyExec::new(Arc::clone(schema)))
-    }
-
-    fn join_with_filter(
-        schema: &Arc<Schema>,
-        probe: Arc<dyn ExecutionPlan>,
-        dynamic_filter: Arc<DynamicFilterPhysicalExpr>,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(
-            HashJoinExec::try_new(
-                empty(schema),
-                probe,
-                vec![(Arc::new(Column::new("a", 0)), Arc::new(Column::new("a", 0)))],
-                None,
-                &JoinType::Inner,
-                None,
-                PartitionMode::Partitioned,
-                NullEquality::NullEqualsNothing,
-                false,
-            )?
-            .with_dynamic_filter_expr(dynamic_filter)?,
-        ))
-    }
 
     /// Regression test for a rustc miscompilation (present at least through
     /// 1.96, fixed in 1.98) of [`CoordinatorToWorkerMetrics::new`].

--- a/src/dynamic_filtering/discovery.rs
+++ b/src/dynamic_filtering/discovery.rs
@@ -141,6 +141,29 @@ pub fn discover_dynamic_filter_producers(
     Ok(producers)
 }
 
+/// Returns producer IDs with at least one remote consumer.
+///
+/// If a producer ID is present in the dynamic-filter anchors of any [`NetworkBoundary`], the plan
+/// contains at least one remote consumer and the producer's updates must be forwarded to the
+/// coordinator.
+///
+/// [`NetworkBoundary`]: crate::NetworkBoundary
+pub fn dynamic_filter_remote_producer_ids(plan: &Arc<dyn ExecutionPlan>) -> Result<Vec<u64>> {
+    let producer_ids: HashSet<_> = discover_dynamic_filter_producers(plan)?
+        .into_iter()
+        .map(|producer| producer.id)
+        .collect();
+    let anchor_ids: HashSet<_> = discover_dynamic_filter_consumers(plan)?
+        .anchors
+        .into_iter()
+        .map(|anchor| anchor.id)
+        .collect();
+
+    let mut remote_producer_ids: Vec<_> = producer_ids.intersection(&anchor_ids).copied().collect();
+    remote_producer_ids.sort_unstable();
+    Ok(remote_producer_ids)
+}
+
 /// Finds consumers whose producer does not occur in `plan`. These consumers become orphaned
 /// from their producer when the producer is moved behind a remote network boundary. These
 /// orphans become network boundary anchors, artificially keeping the producers alive.

--- a/src/dynamic_filtering/discovery.rs
+++ b/src/dynamic_filtering/discovery.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub struct DiscoveredDynamicFilterProducer {
     pub id: u64,
+    pub expression: Arc<dyn PhysicalExpr>,
 }
 
 /// A dynamic-filter consumer discovered in an execution plan along with the schema it is evaluated
@@ -130,7 +131,7 @@ pub fn discover_dynamic_filter_producers(
             };
             producers
                 .entry(id)
-                .or_insert(DiscoveredDynamicFilterProducer { id });
+                .or_insert_with(|| DiscoveredDynamicFilterProducer { id, expression });
         }
         Ok(TreeNodeRecursion::Continue)
     })?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub use dynamic_filtering::rewrite_distributed_plan_with_dynamic_filters;
 pub use dynamic_filtering::{
     DiscoveredDynamicFilter, DiscoveredDynamicFilterAnchor, DiscoveredDynamicFilterConsumers,
     DiscoveredDynamicFilterProducer, discover_dynamic_filter_consumers,
-    discover_dynamic_filter_producers,
+    discover_dynamic_filter_producers, dynamic_filter_remote_producer_ids,
 };
 pub use events::{
     CoordinatorToWorkerDialer, DesiredTaskCountEvent, DesiredTaskCountEventResponse,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,9 +63,10 @@ pub use worker_resolver::{WorkerResolver, get_distributed_worker_resolver};
 
 pub use protocol::{
     ChannelResolver, CoordinatorToWorkerMsg, ExecuteTaskRequest, GetWorkerInfoRequest,
-    GetWorkerInfoResponse, LoadInfo, SetPlanRequest, TaskCompletedDynamicFilters,
-    TaskDynamicFilter, TaskKey, TaskMetrics, WorkUnitBatch, WorkUnitFeedDeclaration, WorkUnitMsg,
-    WorkerChannel, WorkerToCoordinatorMsg, get_distributed_channel_resolver,
+    GetWorkerInfoResponse, LoadInfo, ProducedDynamicFilter, SetPlanRequest,
+    TaskCompletedDynamicFilters, TaskDynamicFilter, TaskKey, TaskMetrics, WorkUnitBatch,
+    WorkUnitFeedDeclaration, WorkUnitMsg, WorkerChannel, WorkerToCoordinatorMsg,
+    get_distributed_channel_resolver,
 };
 pub use stage::{
     DistributedTaskContext, Stage, display_plan_ascii, display_plan_graphviz, explain_analyze,

--- a/src/protocol/grpc/generated/worker.rs
+++ b/src/protocol/grpc/generated/worker.rs
@@ -24,7 +24,7 @@ pub mod coordinator_to_worker_msg {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WorkerToCoordinatorMsg {
-    #[prost(oneof = "worker_to_coordinator_msg::Inner", tags = "1, 2, 3, 4")]
+    #[prost(oneof = "worker_to_coordinator_msg::Inner", tags = "1, 2, 3, 4, 5")]
     pub inner: ::core::option::Option<worker_to_coordinator_msg::Inner>,
 }
 /// Nested message and enum types in `WorkerToCoordinatorMsg`.
@@ -57,10 +57,21 @@ pub mod worker_to_coordinator_msg {
         /// Another task in the same stage may report a different value for expression_id=10.
         #[prost(message, tag = "4")]
         TaskCompletedDynamicFilters(super::TaskCompletedDynamicFilters),
+        /// An observed hash-join dynamic filter state produced by this task.
+        #[prost(message, tag = "5")]
+        ProducedDynamicFilter(super::ProducedDynamicFilter),
     }
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct DynamicFilter {
+    #[prost(uint64, tag = "1")]
+    pub expression_id: u64,
+    /// Serialized datafusion.proto.PhysicalExprNode.
+    #[prost(bytes = "vec", tag = "2")]
+    pub expression_proto: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ProducedDynamicFilter {
     #[prost(uint64, tag = "1")]
     pub expression_id: u64,
     /// Serialized datafusion.proto.PhysicalExprNode.
@@ -146,6 +157,9 @@ pub struct SetPlanRequest {
     /// relative to when the query was fired in the coordinator.
     #[prost(uint64, tag = "6")]
     pub query_start_time_ns: u64,
+    /// Producer IDs whose updates must be reported to the coordinator for remote consumers.
+    #[prost(uint64, repeated, tag = "8")]
+    pub dynamic_filter_remote_producer_ids: ::prost::alloc::vec::Vec<u64>,
 }
 /// Nested message and enum types in `SetPlanRequest`.
 pub mod set_plan_request {

--- a/src/protocol/grpc/generated/worker.rs
+++ b/src/protocol/grpc/generated/worker.rs
@@ -57,7 +57,7 @@ pub mod worker_to_coordinator_msg {
         /// Another task in the same stage may report a different value for expression_id=10.
         #[prost(message, tag = "4")]
         TaskCompletedDynamicFilters(super::TaskCompletedDynamicFilters),
-        /// An observed hash-join dynamic filter state produced by this task.
+        /// An observed dynamic filter state produced by this task.
         #[prost(message, tag = "5")]
         ProducedDynamicFilter(super::ProducedDynamicFilter),
     }

--- a/src/protocol/grpc/worker.proto
+++ b/src/protocol/grpc/worker.proto
@@ -53,10 +53,19 @@ message WorkerToCoordinatorMsg {
     //
     // Another task in the same stage may report a different value for expression_id=10.
     TaskCompletedDynamicFilters task_completed_dynamic_filters = 4;
+
+    // An observed dynamic filter state produced by this task.
+    ProducedDynamicFilter produced_dynamic_filter = 5;
   }
 }
 
 message DynamicFilter {
+  uint64 expression_id = 1;
+  // Serialized datafusion.proto.PhysicalExprNode.
+  bytes expression_proto = 2;
+}
+
+message ProducedDynamicFilter {
   uint64 expression_id = 1;
   // Serialized datafusion.proto.PhysicalExprNode.
   bytes expression_proto = 2;
@@ -131,6 +140,8 @@ message SetPlanRequest {
   // Unix nanos when the query started as reported by the coordinator. Used for collecting temporal metrics
   // relative to when the query was fired in the coordinator.
   uint64 query_start_time_ns = 6;
+  // Producer IDs whose updates must be reported to the coordinator for remote consumers.
+  repeated uint64 dynamic_filter_remote_producer_ids = 8;
 }
 
 message WorkUnitBatch {

--- a/src/protocol/grpc/worker_client.rs
+++ b/src/protocol/grpc/worker_client.rs
@@ -26,7 +26,6 @@ use datafusion::execution::TaskContext;
 use datafusion::execution::memory_pool::MemoryConsumer;
 use datafusion::physical_expr_common::metrics::{Count, Label, MetricBuilder, MetricValue, Time};
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, Gauge};
-use datafusion_proto::protobuf::PhysicalExprNode;
 use futures::stream::BoxStream;
 use futures::{FutureExt, Stream, StreamExt, TryStreamExt};
 use http::{Extensions, HeaderMap};
@@ -568,8 +567,7 @@ fn decode_produced_dynamic_filter(
 ) -> Result<ProducedDynamicFilter> {
     Ok(ProducedDynamicFilter {
         expression_id: filter.expression_id,
-        expression: PhysicalExprNode::decode(filter.expression_proto.as_slice())
-            .map_err(|error| DataFusionError::External(Box::new(error)))?,
+        expression: MaybeEncoded::Encoded(filter.expression_proto),
     })
 }
 
@@ -874,7 +872,10 @@ mod tests {
             panic!("expected produced dynamic filter");
         };
         assert_eq!(decoded.expression_id, 42);
-        assert_eq!(decoded.expression, expression);
+        let MaybeEncoded::Encoded(decoded_expression) = decoded.expression else {
+            panic!("expected encoded dynamic filter");
+        };
+        assert_eq!(decoded_expression, expression.encode_to_vec());
         Ok(())
     }
 }

--- a/src/protocol/grpc/worker_client.rs
+++ b/src/protocol/grpc/worker_client.rs
@@ -10,9 +10,9 @@ use crate::{
     BytesMetricExt, CoordinatorToWorkerMsg, DISTRIBUTED_DATAFUSION_TASK_ID_LABEL,
     DistributedConfig, ExecuteTaskRequest, FirstLatencyMetric, GetWorkerInfoRequest,
     GetWorkerInfoResponse, LatencyMetricExt, LoadInfo, MaxLatencyMetric, MaybeEncoded,
-    MinLatencyMetric, P50LatencyMetric, P95LatencyMetric, ProducerHead, SetPlanRequest,
-    TaskCompletedDynamicFilters, TaskDynamicFilter, TaskKey, TaskMetrics, WorkUnitBatch,
-    WorkUnitFeedDeclaration, WorkUnitMsg, WorkerChannel, WorkerToCoordinatorMsg,
+    MinLatencyMetric, P50LatencyMetric, P95LatencyMetric, ProducedDynamicFilter, ProducerHead,
+    SetPlanRequest, TaskCompletedDynamicFilters, TaskDynamicFilter, TaskKey, TaskMetrics,
+    WorkUnitBatch, WorkUnitFeedDeclaration, WorkUnitMsg, WorkerChannel, WorkerToCoordinatorMsg,
 };
 use arrow_flight::FlightData;
 use arrow_flight::decode::FlightRecordBatchStream;
@@ -26,6 +26,7 @@ use datafusion::execution::TaskContext;
 use datafusion::execution::memory_pool::MemoryConsumer;
 use datafusion::physical_expr_common::metrics::{Count, Label, MetricBuilder, MetricValue, Time};
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, Gauge};
+use datafusion_proto::protobuf::PhysicalExprNode;
 use futures::stream::BoxStream;
 use futures::{FutureExt, Stream, StreamExt, TryStreamExt};
 use http::{Extensions, HeaderMap};
@@ -489,6 +490,7 @@ fn encode_set_plan_request(
             .collect(),
         target_worker_url: request.target_worker_url.to_string(),
         query_start_time_ns: request.query_start_time_ns as u64,
+        dynamic_filter_remote_producer_ids: request.dynamic_filter_remote_producer_ids,
     })
 }
 
@@ -552,8 +554,23 @@ fn decode_worker_to_coordinator_msg(
                     decode_task_completed_dynamic_filters(filters)?,
                 )
             }
+            pb::worker_to_coordinator_msg::Inner::ProducedDynamicFilter(filter) => {
+                WorkerToCoordinatorMsg::ProducedDynamicFilter(Box::new(
+                    decode_produced_dynamic_filter(filter)?,
+                ))
+            }
         },
     )
+}
+
+fn decode_produced_dynamic_filter(
+    filter: pb::ProducedDynamicFilter,
+) -> Result<ProducedDynamicFilter> {
+    Ok(ProducedDynamicFilter {
+        expression_id: filter.expression_id,
+        expression: PhysicalExprNode::decode(filter.expression_proto.as_slice())
+            .map_err(|error| DataFusionError::External(Box::new(error)))?,
+    })
 }
 
 fn decode_task_completed_dynamic_filters(
@@ -764,6 +781,7 @@ impl<O, F: Future<Output = O>> Future for ElapsedComputeFuture<F> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion_proto::protobuf::PhysicalExprNode;
     use futures::StreamExt;
     use futures::stream::unfold;
 
@@ -838,5 +856,25 @@ mod tests {
         println!("expensive future: {}", expensive_time.value());
 
         assert!(expensive_time.value() > cheap_time.value());
+    }
+
+    #[test]
+    fn decode_produced_dynamic_filter() -> Result<()> {
+        let expression = PhysicalExprNode::default();
+        let decoded = decode_worker_to_coordinator_msg(pb::WorkerToCoordinatorMsg {
+            inner: Some(pb::worker_to_coordinator_msg::Inner::ProducedDynamicFilter(
+                pb::ProducedDynamicFilter {
+                    expression_id: 42,
+                    expression_proto: expression.encode_to_vec(),
+                },
+            )),
+        })?;
+
+        let WorkerToCoordinatorMsg::ProducedDynamicFilter(decoded) = decoded else {
+            panic!("expected produced dynamic filter");
+        };
+        assert_eq!(decoded.expression_id, 42);
+        assert_eq!(decoded.expression, expression);
+        Ok(())
     }
 }

--- a/src/protocol/grpc/worker_service.rs
+++ b/src/protocol/grpc/worker_service.rs
@@ -479,16 +479,19 @@ fn garbage_collect_arrays(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion::prelude::SessionContext;
     use datafusion_proto::protobuf::PhysicalExprNode;
 
     #[test]
     fn encode_produced_dynamic_filter() {
         let expression = PhysicalExprNode::default();
+        let task_ctx = SessionContext::new().task_ctx();
         let encoded = encode_worker_to_coordinator_msg(
             WorkerToCoordinatorMsg::ProducedDynamicFilter(Box::new(ProducedDynamicFilter {
                 expression_id: 42,
                 expression: expression.clone(),
             })),
+            &task_ctx,
         )
         .unwrap();
 

--- a/src/protocol/grpc/worker_service.rs
+++ b/src/protocol/grpc/worker_service.rs
@@ -285,18 +285,24 @@ fn encode_worker_to_coordinator_msg(
             }
             WorkerToCoordinatorMsg::ProducedDynamicFilter(filter) => {
                 pb::worker_to_coordinator_msg::Inner::ProducedDynamicFilter(
-                    encode_produced_dynamic_filter(*filter),
+                    encode_produced_dynamic_filter(*filter, task_ctx)?,
                 )
             }
         }),
     })
 }
 
-fn encode_produced_dynamic_filter(filter: ProducedDynamicFilter) -> pb::ProducedDynamicFilter {
-    pb::ProducedDynamicFilter {
+fn encode_produced_dynamic_filter(
+    filter: ProducedDynamicFilter,
+    task_ctx: &Arc<TaskContext>,
+) -> Result<pb::ProducedDynamicFilter, Status> {
+    Ok(pb::ProducedDynamicFilter {
         expression_id: filter.expression_id,
-        expression_proto: filter.expression.encode_to_vec(),
-    }
+        expression_proto: filter
+            .expression
+            .encode(task_ctx)
+            .map_err(datafusion_error_to_tonic_status)?,
+    })
 }
 
 fn encode_task_completed_dynamic_filters(
@@ -479,17 +485,20 @@ fn garbage_collect_arrays(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion::physical_expr::expressions::lit;
     use datafusion::prelude::SessionContext;
-    use datafusion_proto::protobuf::PhysicalExprNode;
 
     #[test]
     fn encode_produced_dynamic_filter() {
-        let expression = PhysicalExprNode::default();
+        let expression = lit(true);
         let task_ctx = SessionContext::new().task_ctx();
+        let expected = MaybeEncoded::Decoded(Arc::clone(&expression))
+            .encode(&task_ctx)
+            .unwrap();
         let encoded = encode_worker_to_coordinator_msg(
             WorkerToCoordinatorMsg::ProducedDynamicFilter(Box::new(ProducedDynamicFilter {
                 expression_id: 42,
-                expression: expression.clone(),
+                expression: MaybeEncoded::Decoded(expression),
             })),
             &task_ctx,
         )
@@ -501,6 +510,6 @@ mod tests {
             panic!("expected produced dynamic filter");
         };
         assert_eq!(encoded.expression_id, 42);
-        assert_eq!(encoded.expression_proto, expression.encode_to_vec());
+        assert_eq!(encoded.expression_proto, expected);
     }
 }

--- a/src/protocol/grpc/worker_service.rs
+++ b/src/protocol/grpc/worker_service.rs
@@ -7,8 +7,9 @@ use crate::common::{deserialize_uuid, now_ns};
 use crate::protocol::grpc::{ObservabilityServiceImpl, ObservabilityServiceServer};
 use crate::{
     CoordinatorToWorkerMsg, DistributedConfig, ExecuteTaskRequest, LoadInfo, MaybeEncoded,
-    ProducerHead, SetPlanRequest, TaskCompletedDynamicFilters, TaskKey, TaskMetrics, WorkUnitBatch,
-    WorkUnitFeedDeclaration, WorkUnitMsg, Worker, WorkerResolver, WorkerToCoordinatorMsg,
+    ProducedDynamicFilter, ProducerHead, SetPlanRequest, TaskCompletedDynamicFilters, TaskKey,
+    TaskMetrics, WorkUnitBatch, WorkUnitFeedDeclaration, WorkUnitMsg, Worker, WorkerResolver,
+    WorkerToCoordinatorMsg,
 };
 
 use crate::worker::CoordinatorChannelResult;
@@ -231,6 +232,7 @@ fn decode_set_plan_request(request: pb::SetPlanRequest) -> Result<SetPlanRequest
             .collect::<Result<_, _>>()?,
         target_worker_url: parse_url(&request.target_worker_url, "target_worker_url")?,
         query_start_time_ns: request.query_start_time_ns as usize,
+        dynamic_filter_remote_producer_ids: request.dynamic_filter_remote_producer_ids,
     })
 }
 
@@ -281,8 +283,20 @@ fn encode_worker_to_coordinator_msg(
                     encode_task_completed_dynamic_filters(filters, task_ctx)?,
                 )
             }
+            WorkerToCoordinatorMsg::ProducedDynamicFilter(filter) => {
+                pb::worker_to_coordinator_msg::Inner::ProducedDynamicFilter(
+                    encode_produced_dynamic_filter(*filter),
+                )
+            }
         }),
     })
+}
+
+fn encode_produced_dynamic_filter(filter: ProducedDynamicFilter) -> pb::ProducedDynamicFilter {
+    pb::ProducedDynamicFilter {
+        expression_id: filter.expression_id,
+        expression_proto: filter.expression.encode_to_vec(),
+    }
 }
 
 fn encode_task_completed_dynamic_filters(
@@ -460,4 +474,30 @@ fn garbage_collect_arrays(
         arrays,
         &RecordBatchOptions::new().with_row_count(Some(row_count)),
     )?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion_proto::protobuf::PhysicalExprNode;
+
+    #[test]
+    fn encode_produced_dynamic_filter() {
+        let expression = PhysicalExprNode::default();
+        let encoded = encode_worker_to_coordinator_msg(
+            WorkerToCoordinatorMsg::ProducedDynamicFilter(Box::new(ProducedDynamicFilter {
+                expression_id: 42,
+                expression: expression.clone(),
+            })),
+        )
+        .unwrap();
+
+        let Some(pb::worker_to_coordinator_msg::Inner::ProducedDynamicFilter(encoded)) =
+            encoded.inner
+        else {
+            panic!("expected produced dynamic filter");
+        };
+        assert_eq!(encoded.expression_id, 42);
+        assert_eq!(encoded.expression_proto, expression.encode_to_vec());
+    }
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -11,6 +11,7 @@ pub use channel_resolver::{ChannelResolver, get_distributed_channel_resolver};
 pub use in_process::LocalWorkerContext;
 pub use worker_channel::{
     CoordinatorToWorkerMsg, ExecuteTaskRequest, GetWorkerInfoRequest, GetWorkerInfoResponse,
-    LoadInfo, SetPlanRequest, TaskCompletedDynamicFilters, TaskDynamicFilter, TaskKey, TaskMetrics,
-    WorkUnitBatch, WorkUnitFeedDeclaration, WorkUnitMsg, WorkerChannel, WorkerToCoordinatorMsg,
+    LoadInfo, ProducedDynamicFilter, SetPlanRequest, TaskCompletedDynamicFilters,
+    TaskDynamicFilter, TaskKey, TaskMetrics, WorkUnitBatch, WorkUnitFeedDeclaration, WorkUnitMsg,
+    WorkerChannel, WorkerToCoordinatorMsg,
 };

--- a/src/protocol/worker_channel.rs
+++ b/src/protocol/worker_channel.rs
@@ -143,7 +143,7 @@ pub struct ProducedDynamicFilter {
     pub expression_id: u64,
     /// Note that sending an update via a live pointer could mean that the dynamic filter updates during
     /// transport. This means that observations at the coordinator may repeat or skip generations, but never
-    /// regress. Since the worker monitors updates and completion, it's guranteed that the completed
+    /// regress. Since the worker monitors updates and completion, it's guaranteed that the completed
     /// filter state will not be missed.
     pub expression: MaybeEncoded<Arc<dyn PhysicalExpr>>,
 }

--- a/src/protocol/worker_channel.rs
+++ b/src/protocol/worker_channel.rs
@@ -82,7 +82,8 @@ pub struct SetPlanRequest {
     /// The subplan the worker is expected to execute.
     pub plan: MaybeEncoded<Arc<dyn ExecutionPlan>>,
     /// Producer expression IDs whose consumers cross a network boundary. Workers observe and
-    /// report updates only for these IDs; task-local consumers are updated directly in memory.
+    /// report updates only for these IDs; task-local consumers are updated directly in memory
+    /// so they do not need to be reported.
     pub dynamic_filter_remote_producer_ids: Vec<u64>,
     /// Information about all the work unit feeds that will be streamed from coordinator to worker.
     /// This information is needed here because at the moment of setting the plan, all the appropriate

--- a/src/protocol/worker_channel.rs
+++ b/src/protocol/worker_channel.rs
@@ -6,6 +6,7 @@ use datafusion::execution::TaskContext;
 use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
+use datafusion_proto::protobuf::PhysicalExprNode;
 use futures::stream::BoxStream;
 use http::HeaderMap;
 use std::sync::Arc;
@@ -80,6 +81,9 @@ pub struct SetPlanRequest {
     pub task_count: usize,
     /// The subplan the worker is expected to execute.
     pub plan: MaybeEncoded<Arc<dyn ExecutionPlan>>,
+    /// Producer expression IDs whose consumers cross a network boundary. Workers observe and
+    /// report updates only for these IDs; task-local consumers are updated directly in memory.
+    pub dynamic_filter_remote_producer_ids: Vec<u64>,
     /// Information about all the work unit feeds that will be streamed from coordinator to worker.
     /// This information is needed here because at the moment of setting the plan, all the appropriate
     /// channels for the incoming work unit feeds need to be constructed.
@@ -125,10 +129,23 @@ pub enum WorkerToCoordinatorMsg {
     /// Sends the final dynamic filters used by dynamic filter consumers back to the coorindator
     /// for displaying.
     TaskCompletedDynamicFilters(TaskCompletedDynamicFilters),
+    /// Sends an observed producer dynamic-filter state to the coordinator. Unlike
+    /// `TaskCompletedDynamicFilters`, this message participates in runtime filtering and is not
+    /// used to render the final plan.
+    ProducedDynamicFilter(Box<ProducedDynamicFilter>),
     /// Load information reported by a task. This information is used for dynamically
     /// sizing the number of workers involved in a query.
     LoadInfo(LoadInfo),
     LoadInfoEos,
+}
+
+#[derive(Clone, Debug)]
+pub struct ProducedDynamicFilter {
+    /// DataFusion physical-expression ID. The source TaskKey is implicit from the channel.
+    pub expression_id: u64,
+    /// A potentially incomplete `DynamicFilterPhysicalExpr`, encoded only by the transport
+    /// boundary. Its serialized generation and completion state order reports from this task.
+    pub expression: PhysicalExprNode,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/src/protocol/worker_channel.rs
+++ b/src/protocol/worker_channel.rs
@@ -6,7 +6,6 @@ use datafusion::execution::TaskContext;
 use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
-use datafusion_proto::protobuf::PhysicalExprNode;
 use futures::stream::BoxStream;
 use http::HeaderMap;
 use std::sync::Arc;
@@ -138,12 +137,15 @@ pub enum WorkerToCoordinatorMsg {
     LoadInfoEos,
 }
 
-/// A dynamic filter snapshot update produced by a plan node in a task to be sent to
-/// the coordinator.
+/// A dynamic filter state update produced by a plan node in a task to be sent to the coordinator.
 #[derive(Clone, Debug)]
 pub struct ProducedDynamicFilter {
     pub expression_id: u64,
-    pub expression: PhysicalExprNode,
+    /// Note that sending an update via a live pointer could mean that the dynamic filter updates during
+    /// transport. This means that observations at the coordinator may repeat or skip generations, but never
+    /// regress. Since the worker monitors updates and completion, it's guranteed that the completed
+    /// filter state will not be missed.
+    pub expression: MaybeEncoded<Arc<dyn PhysicalExpr>>,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/src/protocol/worker_channel.rs
+++ b/src/protocol/worker_channel.rs
@@ -82,8 +82,7 @@ pub struct SetPlanRequest {
     /// The subplan the worker is expected to execute.
     pub plan: MaybeEncoded<Arc<dyn ExecutionPlan>>,
     /// Producer expression IDs whose consumers cross a network boundary. Workers observe and
-    /// report updates only for these IDs; task-local consumers are updated directly in memory
-    /// so they do not need to be reported.
+    /// report updates to the coordinator.
     pub dynamic_filter_remote_producer_ids: Vec<u64>,
     /// Information about all the work unit feeds that will be streamed from coordinator to worker.
     /// This information is needed here because at the moment of setting the plan, all the appropriate
@@ -130,9 +129,8 @@ pub enum WorkerToCoordinatorMsg {
     /// Sends the final dynamic filters used by dynamic filter consumers back to the coorindator
     /// for displaying.
     TaskCompletedDynamicFilters(TaskCompletedDynamicFilters),
-    /// Sends an observed producer dynamic-filter state to the coordinator. Unlike
-    /// `TaskCompletedDynamicFilters`, this message participates in runtime filtering and is not
-    /// used to render the final plan.
+    /// Sends an observed producer dynamic-filter state to the coordinator. This update
+    /// is to be used for runtime dynamic filtering.
     ProducedDynamicFilter(Box<ProducedDynamicFilter>),
     /// Load information reported by a task. This information is used for dynamically
     /// sizing the number of workers involved in a query.
@@ -140,12 +138,11 @@ pub enum WorkerToCoordinatorMsg {
     LoadInfoEos,
 }
 
+/// A dynamic filter snapshot update produced by a plan node in a task to be sent to
+/// the coordinator.
 #[derive(Clone, Debug)]
 pub struct ProducedDynamicFilter {
-    /// DataFusion physical-expression ID. The source TaskKey is implicit from the channel.
     pub expression_id: u64,
-    /// A potentially incomplete `DynamicFilterPhysicalExpr`, encoded only by the transport
-    /// boundary. Its serialized generation and completion state order reports from this task.
     pub expression: PhysicalExprNode,
 }
 

--- a/src/worker/impl_coordinator_channel.rs
+++ b/src/worker/impl_coordinator_channel.rs
@@ -14,7 +14,7 @@ use crate::{
     TaskDynamicFilter, TaskMetrics, Worker, WorkerQueryContext, WorkerToCoordinatorMsg,
 };
 use datafusion::common::tree_node::TreeNodeRecursion;
-use datafusion::common::{DataFusionError, HashSet, Result, exec_datafusion_err, internal_err};
+use datafusion::common::{DataFusionError, HashSet, Result, exec_datafusion_err};
 use datafusion::execution::{SessionStateBuilder, TaskContext};
 use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_expr::expressions::DynamicFilterPhysicalExpr;

--- a/src/worker/impl_coordinator_channel.rs
+++ b/src/worker/impl_coordinator_channel.rs
@@ -351,47 +351,6 @@ fn send_metrics_via_channel(
 mod tests {
     use super::*;
     use datafusion::physical_expr::expressions::{Column, lit};
-    use datafusion::prelude::SessionContext;
-    use datafusion_proto::protobuf::physical_expr_node::ExprType;
-
-    #[tokio::test]
-    async fn streams_dynamic_filter_updates_and_completion() -> Result<()> {
-        let dynamic_filter = Arc::new(DynamicFilterPhysicalExpr::new(
-            vec![Arc::new(Column::new("a", 0))],
-            lit(true),
-        ));
-        let expression_id = dynamic_filter.expression_id().unwrap();
-        let expression = Arc::clone(&dynamic_filter) as Arc<dyn PhysicalExpr>;
-        let (_cancel_tx, cancel_rx) = watch::channel(false);
-        let task_ctx = SessionContext::new().task_ctx();
-        let mut stream = produced_dynamic_filter_stream(expression_id, expression, cancel_rx);
-
-        let (update, ()) = tokio::join!(stream.next(), async {
-            tokio::task::yield_now().await;
-            dynamic_filter.update(lit(false)).unwrap();
-        });
-        let update = produced_filter(update.expect("expected update"));
-        let update = update.expression.to_proto(&task_ctx)?;
-        let ExprType::DynamicFilter(update) = update.expr_type.as_ref().unwrap() else {
-            panic!("expected dynamic filter");
-        };
-        let update_generation = update.generation;
-        assert!(!update.is_complete);
-
-        let (completion, ()) = tokio::join!(stream.next(), async {
-            tokio::task::yield_now().await;
-            dynamic_filter.mark_complete();
-        });
-        let completion = produced_filter(completion.expect("expected completion"));
-        let completion = completion.expression.to_proto(&task_ctx)?;
-        let ExprType::DynamicFilter(completion) = completion.expr_type.as_ref().unwrap() else {
-            panic!("expected dynamic filter");
-        };
-        assert_eq!(completion.generation, update_generation);
-        assert!(completion.is_complete);
-        assert!(stream.next().await.is_none());
-        Ok(())
-    }
 
     #[tokio::test]
     async fn cancellation_stops_dynamic_filter_updates() {
@@ -406,12 +365,5 @@ mod tests {
 
         cancel_tx.send(true).unwrap();
         assert!(stream.next().await.is_none());
-    }
-
-    fn produced_filter(message: WorkerToCoordinatorMsg) -> Box<ProducedDynamicFilter> {
-        let WorkerToCoordinatorMsg::ProducedDynamicFilter(filter) = message else {
-            panic!("expected produced dynamic filter");
-        };
-        filter
     }
 }

--- a/src/worker/impl_coordinator_channel.rs
+++ b/src/worker/impl_coordinator_channel.rs
@@ -192,11 +192,12 @@ impl Worker {
                 }
             }
 
+            // Cancel any dynamic filter producce streams that did not complete for any reason.
+            // It's expected that dynamic filters should complete and send their updates before
+            // task execution ends.
+            producer_cancel_tx.send_replace(true);
+
             // Send metrics and completed dynamic filters if enabled.
-            // TODO(#686): handle errors
-            // Producer completion is an optimization signal, not a condition for ending a task.
-            // Wake any filters that never completed before finalizing the task reports.
-            let _ = producer_cancel_tx.send(true);
 
             let metrics_tx = task_data.metrics_tx.lock().unwrap().take();
             let dynamic_filters_tx = task_data
@@ -266,63 +267,54 @@ impl Worker {
             task_ctx: Arc::clone(&task_data.task_ctx),
             stream: select_all([
                 produced_dynamic_filters_stream.boxed(),
-                load_info_stream.boxed(),
-                metrics_stream.boxed(),
-                dynamic_filters_stream.boxed(),
+                load_info_stream.map(Ok).boxed(),
+                metrics_stream.map(Ok).boxed(),
+                dynamic_filters_stream.map(Ok).boxed(),
             ])
-            .map(Ok)
             .boxed(),
         })
     }
 }
 
-/// Streams observable updates from one dynamic-filter producer until it completes or is cancelled.
+/// Streams updates from one dynamic-filter producer until it completes or cancellation is detected.
 fn produced_dynamic_filter_stream(
     expression_id: u64,
     expression: Arc<dyn PhysicalExpr>,
     task_ctx: Arc<TaskContext>,
     cancel_rx: watch::Receiver<bool>,
-) -> BoxStream<'static, WorkerToCoordinatorMsg> {
-    futures::stream::unfold(
+) -> BoxStream<'static, Result<WorkerToCoordinatorMsg>> {
+    futures::stream::try_unfold(
         Some((expression, task_ctx, cancel_rx)),
         move |state| async move {
-            let (expression, task_ctx, mut cancel_rx) = state?;
+            let Some((expression, task_ctx, mut cancel_rx)) = state else {
+                return Ok(None);
+            };
             let dynamic_filter = expression
                 .downcast_ref::<DynamicFilterPhysicalExpr>()
                 .expect("producer discovery returns DynamicFilterPhysicalExpr");
 
-            loop {
-                // `wait_update()` uses a Tokio watch channel, so multiple generations can
-                // naturally coalesce while this observer is busy. The stream promises the latest
-                // observed state rather than one message per generation; completion is awaited
-                // separately because it does not advance the generation.
-                let completed = tokio::select! {
-                    _ = dynamic_filter.wait_update() => false,
-                    _ = dynamic_filter.wait_complete() => true,
-                    _ = cancel_rx.wait_for(|cancelled| *cancelled) => return None,
-                };
-
-                let Ok(serialized) = encode_physical_expr(&expression, &task_ctx) else {
-                    // Dynamic filtering is an optimization. Ignore an unserializable update and
-                    // continue observing the producer in case a later state can be serialized.
-                    if completed {
-                        return None;
-                    }
-                    continue;
-                };
-                let is_complete = matches!(
-                    serialized.expr_type.as_ref(),
-                    Some(ExprType::DynamicFilter(dynamic_filter)) if dynamic_filter.is_complete
-                );
-                let message = WorkerToCoordinatorMsg::ProducedDynamicFilter(Box::new(
-                    ProducedDynamicFilter {
-                        expression_id,
-                        expression: serialized,
-                    },
-                ));
-                let next = (!is_complete).then_some((expression, task_ctx, cancel_rx));
-                return Some((message, next));
+            // `wait_update()` uses a Tokio watch channel, so multiple generations can
+            // are natively "deduped" into just one update. This helps avoid too many
+            // update messages. If this becomes an issue, we can introduce an artificial
+            // backoff.
+            tokio::select! {
+                _ = dynamic_filter.wait_update() => {}
+                _ = dynamic_filter.wait_complete() => {}
+                _ = cancel_rx.wait_for(|cancelled| *cancelled) => return Ok(None),
             }
+
+            let serialized = encode_physical_expr(&expression, &task_ctx)?;
+            let is_complete = matches!(
+                serialized.expr_type.as_ref(),
+                Some(ExprType::DynamicFilter(dynamic_filter)) if dynamic_filter.is_complete
+            );
+            let message =
+                WorkerToCoordinatorMsg::ProducedDynamicFilter(Box::new(ProducedDynamicFilter {
+                    expression_id,
+                    expression: serialized,
+                }));
+            let next = (!is_complete).then_some((expression, task_ctx, cancel_rx));
+            Ok(Some((message, next)))
         },
     )
     .boxed()
@@ -438,7 +430,8 @@ mod tests {
         assert!(stream.next().await.is_none());
     }
 
-    fn produced_filter(message: WorkerToCoordinatorMsg) -> Box<ProducedDynamicFilter> {
+    fn produced_filter(message: Result<WorkerToCoordinatorMsg>) -> Box<ProducedDynamicFilter> {
+        let message = message.unwrap();
         let WorkerToCoordinatorMsg::ProducedDynamicFilter(filter) = message else {
             panic!("expected produced dynamic filter");
         };

--- a/src/worker/impl_coordinator_channel.rs
+++ b/src/worker/impl_coordinator_channel.rs
@@ -1,4 +1,3 @@
-use crate::codec::encode_physical_expr;
 use crate::common::TreeNodeExt;
 use crate::dynamic_filtering::{
     discover_dynamic_filter_consumers, discover_dynamic_filter_producers,
@@ -20,7 +19,6 @@ use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_expr::expressions::DynamicFilterPhysicalExpr;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionConfig;
-use datafusion_proto::protobuf::physical_expr_node::ExprType;
 use futures::stream::{BoxStream, FuturesUnordered, select_all};
 use futures::{FutureExt, StreamExt, TryStreamExt};
 use http::HeaderMap;
@@ -138,7 +136,6 @@ impl Worker {
             .into_iter()
             .filter(|producer| dynamic_filter_remote_producer_ids.contains(&producer.id));
         let (producer_cancel_tx, producer_cancel_rx) = watch::channel(false);
-        let producer_task_ctx = Arc::clone(&task_data.task_ctx);
 
         // Continue reading remaining messages (work unit feed data) in the background.
         let mut work_unit_senders = Some(remote_work_unit_feed_registry.senders);
@@ -258,7 +255,6 @@ impl Worker {
                 produced_dynamic_filter_stream(
                     producer.id,
                     producer.expression,
-                    Arc::clone(&producer_task_ctx),
                     producer_cancel_rx.clone(),
                 )
             }));
@@ -267,10 +263,11 @@ impl Worker {
             task_ctx: Arc::clone(&task_data.task_ctx),
             stream: select_all([
                 produced_dynamic_filters_stream.boxed(),
-                load_info_stream.map(Ok).boxed(),
-                metrics_stream.map(Ok).boxed(),
-                dynamic_filters_stream.map(Ok).boxed(),
+                load_info_stream.boxed(),
+                metrics_stream.boxed(),
+                dynamic_filters_stream.boxed(),
             ])
+            .map(Ok)
             .boxed(),
         })
     }
@@ -280,43 +277,31 @@ impl Worker {
 fn produced_dynamic_filter_stream(
     expression_id: u64,
     expression: Arc<dyn PhysicalExpr>,
-    task_ctx: Arc<TaskContext>,
     cancel_rx: watch::Receiver<bool>,
-) -> BoxStream<'static, Result<WorkerToCoordinatorMsg>> {
-    futures::stream::try_unfold(
-        Some((expression, task_ctx, cancel_rx)),
-        move |state| async move {
-            let Some((expression, task_ctx, mut cancel_rx)) = state else {
-                return Ok(None);
-            };
-            let dynamic_filter = expression
-                .downcast_ref::<DynamicFilterPhysicalExpr>()
-                .expect("producer discovery returns DynamicFilterPhysicalExpr");
+) -> BoxStream<'static, WorkerToCoordinatorMsg> {
+    futures::stream::unfold(Some((expression, cancel_rx)), move |state| async move {
+        let (expression, mut cancel_rx) = state?;
+        let dynamic_filter = expression
+            .downcast_ref::<DynamicFilterPhysicalExpr>()
+            .expect("producer discovery returns DynamicFilterPhysicalExpr");
 
-            // `wait_update()` uses a Tokio watch channel, so multiple generations can
-            // are natively "deduped" into just one update. This helps avoid too many
-            // update messages. If this becomes an issue, we can introduce an artificial
-            // backoff.
-            tokio::select! {
-                _ = dynamic_filter.wait_update() => {}
-                _ = dynamic_filter.wait_complete() => {}
-                _ = cancel_rx.wait_for(|cancelled| *cancelled) => return Ok(None),
-            }
-
-            let serialized = encode_physical_expr(&expression, &task_ctx)?;
-            let is_complete = matches!(
-                serialized.expr_type.as_ref(),
-                Some(ExprType::DynamicFilter(dynamic_filter)) if dynamic_filter.is_complete
-            );
-            let message =
-                WorkerToCoordinatorMsg::ProducedDynamicFilter(Box::new(ProducedDynamicFilter {
-                    expression_id,
-                    expression: serialized,
-                }));
-            let next = (!is_complete).then_some((expression, task_ctx, cancel_rx));
-            Ok(Some((message, next)))
-        },
-    )
+        // `wait_update()` uses a Tokio watch channel, so multiple generations can
+        // are natively "deduped" into just one update. This helps avoid too many
+        // update messages. If this becomes an issue, we can introduce an artificial
+        // backoff.
+        let completed = tokio::select! {
+            _ = dynamic_filter.wait_update() => false,
+            _ = dynamic_filter.wait_complete() => true,
+            _ = cancel_rx.wait_for(|cancelled| *cancelled) => return None,
+        };
+        let message =
+            WorkerToCoordinatorMsg::ProducedDynamicFilter(Box::new(ProducedDynamicFilter {
+                expression_id,
+                expression: MaybeEncoded::Decoded(Arc::clone(&expression)),
+            }));
+        let next = (!completed).then_some((expression, cancel_rx));
+        Some((message, next))
+    })
     .boxed()
 }
 
@@ -367,6 +352,7 @@ mod tests {
     use super::*;
     use datafusion::physical_expr::expressions::{Column, lit};
     use datafusion::prelude::SessionContext;
+    use datafusion_proto::protobuf::physical_expr_node::ExprType;
 
     #[tokio::test]
     async fn streams_dynamic_filter_updates_and_completion() -> Result<()> {
@@ -377,19 +363,16 @@ mod tests {
         let expression_id = dynamic_filter.expression_id().unwrap();
         let expression = Arc::clone(&dynamic_filter) as Arc<dyn PhysicalExpr>;
         let (_cancel_tx, cancel_rx) = watch::channel(false);
-        let mut stream = produced_dynamic_filter_stream(
-            expression_id,
-            expression,
-            SessionContext::new().task_ctx(),
-            cancel_rx,
-        );
+        let task_ctx = SessionContext::new().task_ctx();
+        let mut stream = produced_dynamic_filter_stream(expression_id, expression, cancel_rx);
 
         let (update, ()) = tokio::join!(stream.next(), async {
             tokio::task::yield_now().await;
             dynamic_filter.update(lit(false)).unwrap();
         });
         let update = produced_filter(update.expect("expected update"));
-        let ExprType::DynamicFilter(update) = update.expression.expr_type.as_ref().unwrap() else {
+        let update = update.expression.to_proto(&task_ctx)?;
+        let ExprType::DynamicFilter(update) = update.expr_type.as_ref().unwrap() else {
             panic!("expected dynamic filter");
         };
         let update_generation = update.generation;
@@ -400,8 +383,8 @@ mod tests {
             dynamic_filter.mark_complete();
         });
         let completion = produced_filter(completion.expect("expected completion"));
-        let ExprType::DynamicFilter(completion) = completion.expression.expr_type.as_ref().unwrap()
-        else {
+        let completion = completion.expression.to_proto(&task_ctx)?;
+        let ExprType::DynamicFilter(completion) = completion.expr_type.as_ref().unwrap() else {
             panic!("expected dynamic filter");
         };
         assert_eq!(completion.generation, update_generation);
@@ -419,19 +402,13 @@ mod tests {
         let expression_id = dynamic_filter.expression_id().unwrap();
         let expression = dynamic_filter as Arc<dyn PhysicalExpr>;
         let (cancel_tx, cancel_rx) = watch::channel(false);
-        let mut stream = produced_dynamic_filter_stream(
-            expression_id,
-            expression,
-            SessionContext::new().task_ctx(),
-            cancel_rx,
-        );
+        let mut stream = produced_dynamic_filter_stream(expression_id, expression, cancel_rx);
 
         cancel_tx.send(true).unwrap();
         assert!(stream.next().await.is_none());
     }
 
-    fn produced_filter(message: Result<WorkerToCoordinatorMsg>) -> Box<ProducedDynamicFilter> {
-        let message = message.unwrap();
+    fn produced_filter(message: WorkerToCoordinatorMsg) -> Box<ProducedDynamicFilter> {
         let WorkerToCoordinatorMsg::ProducedDynamicFilter(filter) = message else {
             panic!("expected produced dynamic filter");
         };

--- a/src/worker/impl_coordinator_channel.rs
+++ b/src/worker/impl_coordinator_channel.rs
@@ -1,5 +1,8 @@
+use crate::codec::encode_physical_expr;
 use crate::common::TreeNodeExt;
-use crate::dynamic_filtering::discover_dynamic_filter_consumers;
+use crate::dynamic_filtering::{
+    discover_dynamic_filter_consumers, discover_dynamic_filter_producers,
+};
 use crate::events::{WorkerPlanRewriteEvent, WorkerPlanRewriteHandlers};
 use crate::execution_plans::SamplerExec;
 use crate::protocol::LocalWorkerContext;
@@ -7,20 +10,23 @@ use crate::work_unit_feed::{RemoteWorkUnitFeedRegistry, set_work_unit_received_t
 use crate::worker::task_data::TaskDataMetrics;
 use crate::{
     CoordinatorToWorkerMsg, DistributedConfig, DistributedExt, DistributedTaskContext,
-    MaybeEncoded, SetPlanRequest, TaskCompletedDynamicFilters, TaskData, TaskDynamicFilter,
-    TaskMetrics, Worker, WorkerQueryContext, WorkerToCoordinatorMsg,
+    MaybeEncoded, ProducedDynamicFilter, SetPlanRequest, TaskCompletedDynamicFilters, TaskData,
+    TaskDynamicFilter, TaskMetrics, Worker, WorkerQueryContext, WorkerToCoordinatorMsg,
 };
 use datafusion::common::tree_node::TreeNodeRecursion;
-use datafusion::common::{DataFusionError, Result, exec_datafusion_err};
+use datafusion::common::{DataFusionError, HashSet, Result, exec_datafusion_err, internal_err};
 use datafusion::execution::{SessionStateBuilder, TaskContext};
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr::expressions::DynamicFilterPhysicalExpr;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionConfig;
+use datafusion_proto::protobuf::physical_expr_node::ExprType;
 use futures::stream::{BoxStream, FuturesUnordered, select_all};
 use futures::{FutureExt, StreamExt, TryStreamExt};
 use http::HeaderMap;
 use std::sync::{Arc, OnceLock};
-use tokio::sync::oneshot;
 use tokio::sync::oneshot::Sender;
+use tokio::sync::{oneshot, watch};
 
 /// Return value of the [Worker::coordinator_channel] method.
 pub struct CoordinatorChannelResult {
@@ -123,6 +129,17 @@ impl Worker {
 
         let task_data = task_data_result.map_err(DataFusionError::Shared)?;
 
+        let dynamic_filter_remote_producer_ids: HashSet<_> = request
+            .dynamic_filter_remote_producer_ids
+            .iter()
+            .copied()
+            .collect();
+        let producer_filters = discover_dynamic_filter_producers(&task_data.base_plan)?
+            .into_iter()
+            .filter(|producer| dynamic_filter_remote_producer_ids.contains(&producer.id));
+        let (producer_cancel_tx, producer_cancel_rx) = watch::channel(false);
+        let producer_task_ctx = Arc::clone(&task_data.task_ctx);
+
         // Continue reading remaining messages (work unit feed data) in the background.
         let mut work_unit_senders = Some(remote_work_unit_feed_registry.senders);
         let task_data_entries = Arc::clone(&self.task_data_entries);
@@ -177,6 +194,10 @@ impl Worker {
 
             // Send metrics and completed dynamic filters if enabled.
             // TODO(#686): handle errors
+            // Producer completion is an optimization signal, not a condition for ending a task.
+            // Wake any filters that never completed before finalizing the task reports.
+            let _ = producer_cancel_tx.send(true);
+
             let metrics_tx = task_data.metrics_tx.lock().unwrap().take();
             let dynamic_filters_tx = task_data
                 .completed_dynamic_filters_tx
@@ -231,9 +252,20 @@ impl Worker {
             },
         );
 
+        let produced_dynamic_filters_stream =
+            select_all(producer_filters.into_iter().map(|producer| {
+                produced_dynamic_filter_stream(
+                    producer.id,
+                    producer.expression,
+                    Arc::clone(&producer_task_ctx),
+                    producer_cancel_rx.clone(),
+                )
+            }));
+
         Ok(CoordinatorChannelResult {
             task_ctx: Arc::clone(&task_data.task_ctx),
             stream: select_all([
+                produced_dynamic_filters_stream.boxed(),
                 load_info_stream.boxed(),
                 metrics_stream.boxed(),
                 dynamic_filters_stream.boxed(),
@@ -242,6 +274,58 @@ impl Worker {
             .boxed(),
         })
     }
+}
+
+/// Streams observable updates from one dynamic-filter producer until it completes or is cancelled.
+fn produced_dynamic_filter_stream(
+    expression_id: u64,
+    expression: Arc<dyn PhysicalExpr>,
+    task_ctx: Arc<TaskContext>,
+    cancel_rx: watch::Receiver<bool>,
+) -> BoxStream<'static, WorkerToCoordinatorMsg> {
+    futures::stream::unfold(
+        Some((expression, task_ctx, cancel_rx)),
+        move |state| async move {
+            let (expression, task_ctx, mut cancel_rx) = state?;
+            let dynamic_filter = expression
+                .downcast_ref::<DynamicFilterPhysicalExpr>()
+                .expect("producer discovery returns DynamicFilterPhysicalExpr");
+
+            loop {
+                // `wait_update()` uses a Tokio watch channel, so multiple generations can
+                // naturally coalesce while this observer is busy. The stream promises the latest
+                // observed state rather than one message per generation; completion is awaited
+                // separately because it does not advance the generation.
+                let completed = tokio::select! {
+                    _ = dynamic_filter.wait_update() => false,
+                    _ = dynamic_filter.wait_complete() => true,
+                    _ = cancel_rx.wait_for(|cancelled| *cancelled) => return None,
+                };
+
+                let Ok(serialized) = encode_physical_expr(&expression, &task_ctx) else {
+                    // Dynamic filtering is an optimization. Ignore an unserializable update and
+                    // continue observing the producer in case a later state can be serialized.
+                    if completed {
+                        return None;
+                    }
+                    continue;
+                };
+                let is_complete = matches!(
+                    serialized.expr_type.as_ref(),
+                    Some(ExprType::DynamicFilter(dynamic_filter)) if dynamic_filter.is_complete
+                );
+                let message = WorkerToCoordinatorMsg::ProducedDynamicFilter(Box::new(
+                    ProducedDynamicFilter {
+                        expression_id,
+                        expression: serialized,
+                    },
+                ));
+                let next = (!is_complete).then_some((expression, task_ctx, cancel_rx));
+                return Some((message, next));
+            }
+        },
+    )
+    .boxed()
 }
 
 /// Finds all consumed dynamic filters for the completed task report.
@@ -284,4 +368,80 @@ fn send_metrics_via_channel(
         pre_order_plan_metrics,
         task_metrics: task_data_metrics.to_metrics_set(),
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::physical_expr::expressions::{Column, lit};
+    use datafusion::prelude::SessionContext;
+
+    #[tokio::test]
+    async fn streams_dynamic_filter_updates_and_completion() -> Result<()> {
+        let dynamic_filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::new(Column::new("a", 0))],
+            lit(true),
+        ));
+        let expression_id = dynamic_filter.expression_id().unwrap();
+        let expression = Arc::clone(&dynamic_filter) as Arc<dyn PhysicalExpr>;
+        let (_cancel_tx, cancel_rx) = watch::channel(false);
+        let mut stream = produced_dynamic_filter_stream(
+            expression_id,
+            expression,
+            SessionContext::new().task_ctx(),
+            cancel_rx,
+        );
+
+        let (update, ()) = tokio::join!(stream.next(), async {
+            tokio::task::yield_now().await;
+            dynamic_filter.update(lit(false)).unwrap();
+        });
+        let update = produced_filter(update.expect("expected update"));
+        let ExprType::DynamicFilter(update) = update.expression.expr_type.as_ref().unwrap() else {
+            panic!("expected dynamic filter");
+        };
+        let update_generation = update.generation;
+        assert!(!update.is_complete);
+
+        let (completion, ()) = tokio::join!(stream.next(), async {
+            tokio::task::yield_now().await;
+            dynamic_filter.mark_complete();
+        });
+        let completion = produced_filter(completion.expect("expected completion"));
+        let ExprType::DynamicFilter(completion) = completion.expression.expr_type.as_ref().unwrap()
+        else {
+            panic!("expected dynamic filter");
+        };
+        assert_eq!(completion.generation, update_generation);
+        assert!(completion.is_complete);
+        assert!(stream.next().await.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cancellation_stops_dynamic_filter_updates() {
+        let dynamic_filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::new(Column::new("a", 0))],
+            lit(true),
+        ));
+        let expression_id = dynamic_filter.expression_id().unwrap();
+        let expression = dynamic_filter as Arc<dyn PhysicalExpr>;
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let mut stream = produced_dynamic_filter_stream(
+            expression_id,
+            expression,
+            SessionContext::new().task_ctx(),
+            cancel_rx,
+        );
+
+        cancel_tx.send(true).unwrap();
+        assert!(stream.next().await.is_none());
+    }
+
+    fn produced_filter(message: WorkerToCoordinatorMsg) -> Box<ProducedDynamicFilter> {
+        let WorkerToCoordinatorMsg::ProducedDynamicFilter(filter) = message else {
+            panic!("expected produced dynamic filter");
+        };
+        filter
+    }
 }

--- a/tests/dynamic_filtering/aggregates.rs
+++ b/tests/dynamic_filtering/aggregates.rs
@@ -45,6 +45,7 @@ mod tests {
                 )
             "#,
         )
+        .expect_dynamic_filter_updates()
         .execute()
         .await?;
         assert_snapshot!(display, @"

--- a/tests/dynamic_filtering/collect_left_join.rs
+++ b/tests/dynamic_filtering/collect_left_join.rs
@@ -69,6 +69,7 @@ mod tests {
             "#,
         )
         .with_broadcast_joins()
+        .expect_dynamic_filter_updates()
         .execute()
         .await?;
         assert_snapshot!(display, @r"

--- a/tests/dynamic_filtering/common.rs
+++ b/tests/dynamic_filtering/common.rs
@@ -24,6 +24,7 @@ pub(crate) struct TestQuery<'a> {
     broadcast_joins: bool,
     one_task_per_leaf: bool,
     collect_dynamic_filters: bool,
+    expect_dynamic_filter_updates: Option<bool>,
 }
 
 impl<'a> TestQuery<'a> {
@@ -34,6 +35,7 @@ impl<'a> TestQuery<'a> {
             broadcast_joins: false,
             one_task_per_leaf: false,
             collect_dynamic_filters: true,
+            expect_dynamic_filter_updates: None,
         }
     }
 
@@ -61,6 +63,11 @@ impl<'a> TestQuery<'a> {
         self
     }
 
+    pub(crate) fn expect_dynamic_filter_updates(mut self) -> Self {
+        self.expect_dynamic_filter_updates = Some(true);
+        self
+    }
+
     pub(crate) async fn execute(self) -> Result<String> {
         let (ctx, _guard, _) = start_localhost_context(2, DefaultSessionBuilder).await;
         let mut ctx = ctx
@@ -69,13 +76,15 @@ impl<'a> TestQuery<'a> {
         if self.one_task_per_leaf {
             ctx = ctx.with_distributed_desired_task_count_handler(1usize);
         }
-        if !self.broadcast_joins {
-            // Force partitioned hash joins.
+        {
             let state = ctx.state_ref();
             let mut state = state.write();
             let optimizer = &mut state.config_mut().options_mut().optimizer;
-            optimizer.hash_join_single_partition_threshold = 0;
-            optimizer.hash_join_single_partition_threshold_rows = 0;
+            if !self.broadcast_joins {
+                // Force partitioned hash joins.
+                optimizer.hash_join_single_partition_threshold = 0;
+                optimizer.hash_join_single_partition_threshold_rows = 0;
+            }
         }
         register_parquet_tables(&ctx).await?;
         execute_query_and_display(
@@ -83,6 +92,7 @@ impl<'a> TestQuery<'a> {
             self.sql,
             self.expected_rows,
             self.collect_dynamic_filters,
+            self.expect_dynamic_filter_updates,
         )
         .await
     }
@@ -114,7 +124,7 @@ pub(crate) async fn execute_range_partitioned_query(
     register_range_partitioned_table(&ctx, "dim", "testdata/join/parquet/dim", "d_dkey").await?;
     register_range_partitioned_table(&ctx, "fact", "testdata/join/parquet/fact", "f_dkey").await?;
 
-    execute_query_and_display(&ctx, sql, expected_rows, true).await
+    execute_query_and_display(&ctx, sql, expected_rows, true, Some(false)).await
 }
 
 async fn register_range_partitioned_table(
@@ -146,6 +156,7 @@ async fn execute_query_and_display(
     sql: &str,
     expected_rows: usize,
     collect_dynamic_filters: bool,
+    expect_dynamic_filter_updates: Option<bool>,
 ) -> Result<String> {
     let plan = ctx.sql(sql).await?.create_physical_plan().await?;
     let task_ctx = ctx.task_ctx();
@@ -164,6 +175,19 @@ async fn execute_query_and_display(
         !collect_dynamic_filters
     );
     assert_eq!(display_plan_ascii(plan.as_ref(), false), original_display);
+
+    if let Some(expected) = expect_dynamic_filter_updates {
+        let updates = plan
+            .metrics()
+            .expect("DistributedExec has metrics")
+            .sum(|metric| metric.value().name() == "dynamic_filter_updates_received")
+            .map_or(0, |metric| metric.as_usize());
+        assert_eq!(
+            updates > 0,
+            expected,
+            "expected dynamic_filter_updates_received > 0 to be {expected}, got {updates}"
+        );
+    }
 
     Ok(display_plan_ascii(
         plan_with_dynamic_filters.as_ref(),

--- a/tests/dynamic_filtering/discovery.rs
+++ b/tests/dynamic_filtering/discovery.rs
@@ -11,6 +11,7 @@ mod tests {
         DefaultSessionBuilder, DistributedExt, NetworkBoundaryExt, RouteTaskEvent,
         RouteTaskEventResponse, RouteTaskHandler, assert_snapshot,
         discover_dynamic_filter_consumers, discover_dynamic_filter_producers,
+        dynamic_filter_remote_producer_ids,
     };
     use itertools::Itertools;
     use std::collections::BTreeSet;
@@ -38,7 +39,7 @@ mod tests {
         )
         .await?;
         assert_snapshot!(display, @r"
-        Stage 5
+        Stage 5 remote_producers=[1]
           AggregateExec
             HashJoinExec producers=[1]
               NetworkShuffleExec
@@ -48,7 +49,7 @@ mod tests {
           RepartitionExec
             AggregateExec
               DataSourceExec consumers=[1]
-        Stage 3
+        Stage 3 remote_producers=[2]
           RepartitionExec
             HashJoinExec producers=[2]
               NetworkShuffleExec
@@ -88,7 +89,7 @@ mod tests {
         )
         .await?;
         assert_snapshot!(display, @r"
-        Stage 4
+        Stage 4 remote_producers=[1]
           AggregateExec
             HashJoinExec producers=[1]
               AggregateExec
@@ -258,8 +259,15 @@ mod tests {
         let mut output = String::new();
         let mut normalizer = IdNormalizer::default();
         for stage_id in plans.keys().sorted().rev() {
-            writeln!(output, "Stage {stage_id}").expect("writing to String cannot fail");
             let plan = &plans[stage_id];
+            let remote_producers = dynamic_filter_remote_producer_ids(plan)?
+                .into_iter()
+                .collect();
+            let remote_producers = normalizer
+                .annotation("remote_producers", remote_producers)
+                .map_or_else(String::new, |annotation| format!(" {annotation}"));
+            writeln!(output, "Stage {stage_id}{remote_producers}")
+                .expect("writing to String cannot fail");
             let consumers = discover_dynamic_filter_consumers(plan)?;
             let discovered = DynamicFilterIds {
                 consumers: consumers

--- a/tests/dynamic_filtering/partitioned_join.rs
+++ b/tests/dynamic_filtering/partitioned_join.rs
@@ -70,6 +70,7 @@ mod tests {
                 JOIN weather probe ON build.key = probe."RainToday"
             "#,
         )
+        .expect_dynamic_filter_updates()
         .execute()
         .await?;
         assert_snapshot!(display, @"

--- a/tests/dynamic_filtering/sorts.rs
+++ b/tests/dynamic_filtering/sorts.rs
@@ -54,6 +54,7 @@ mod tests {
             "#,
         )
         .with_expected_rows(10)
+        .expect_dynamic_filter_updates()
         .execute()
         .await?;
         assert_snapshot!(display, @"


### PR DESCRIPTION
## Stack

This stack of PRs implements distributed dynamic filtering #528 
1. https://github.com/datafusion-contrib/datafusion-distributed/pull/623
2. https://github.com/datafusion-contrib/datafusion-distributed/pull/634
3. https://github.com/datafusion-contrib/datafusion-distributed/pull/635 <- you are here
4. https://github.com/datafusion-contrib/datafusion-distributed/pull/636
5. https://github.com/datafusion-contrib/datafusion-distributed/pull/637
6. https://github.com/datafusion-contrib/datafusion-distributed/pull/639


## Problem

The `QueryCoordinator` needs to receive partial dynamic filter updates from workers.

## Solution
We introduce a new `WorkerToCoordinatorMsg` which 
```
message ProducedDynamicFilter {
  uint64 expression_id = 1;
  // Serialized datafusion.proto.PhysicalExprNode.
  bytes expression_proto = 2;
}
```

In this PR makes each worker unconditionally send updates (via `wait_update()` and `wait_complete()`) to the coordinator for any `dynamic_filter_remote_producer_ids` in the `SetPlanRequest`. The purpose of `dynamic_filter_remote_producer_ids` is to exclude any dynamic filters who only have local consumers - these don't need to be forwarded to the coordinator.