### PR TITLE
Update doc

### DIFF
--- a/docs/source/_static/images/img.png
+++ b/docs/source/_static/images/img.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ca45af071afb0d46fcc63cafd55c02725cc82fbf79fe642613428308799a72f9
-size 100712

--- a/docs/source/_static/images/img_1.png
+++ b/docs/source/_static/images/img_1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b878a69b0e3fba19e6901a35007e47502689ff320c7c18b2f184818da7eb944c
-size 139713

--- a/docs/source/_static/images/img_2.png
+++ b/docs/source/_static/images/img_2.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b878a69b0e3fba19e6901a35007e47502689ff320c7c18b2f184818da7eb944c
-size 139713

--- a/docs/source/_static/images/img_3.png
+++ b/docs/source/_static/images/img_3.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:74443b0130d4d583c9e899ebccd952e5fe20c10685b92894ef5ff8413981ff77
-size 181525

--- a/docs/source/_static/images/img_4.png
+++ b/docs/source/_static/images/img_4.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5e2ad1163809b7ba54258925dd10eea593f8543e1627279469942e9032babb58
-size 212238

--- a/docs/source/_static/images/img_5.png
+++ b/docs/source/_static/images/img_5.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:562371508231c0532dca522997ad1153466003c01ebe86367df818db267a72aa
-size 258118

--- a/docs/source/_static/images/img_6.png
+++ b/docs/source/_static/images/img_6.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:292388062f20615b842a08ac1e73e09ab309f8f4a340e7e9d9db8a5b5b3661dc
-size 307749

--- a/docs/source/_static/images/img_7.png
+++ b/docs/source/_static/images/img_7.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eb71ed8bcd09c75d5555a21701cd71b8f675f69a81c75a1863296ee7179b84d1
-size 359725

--- a/docs/source/_static/images/img_8.png
+++ b/docs/source/_static/images/img_8.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ad0fed45f388743d753c79746e6a0b2bd7885f5f30f26368ee3b154c525074bc
-size 403514

--- a/docs/source/learn/02-how-a-distributed-plan-is-built.md
+++ b/docs/source/learn/02-how-a-distributed-plan-is-built.md
@@ -1,153 +1,437 @@
 # How a Distributed Plan is Built
 
-This page walks through how the distributed DataFusion planner transforms a query into a distributed execution plan.
+This page walks through how the distributed DataFusion planner transforms a
+query into a distributed execution plan.
 
-The transformation runs as a DataFusion `QueryPlanner` (registered by `with_distributed_planner()`) **after**
-normal physical planning. It takes the single-node physical plan, finds the points where data would cross a
-thread boundary in vanilla DataFusion, and inserts a network boundary node there instead — splitting the plan
-into *stages* that run on different *tasks* (machines).
+The transformation runs as a DataFusion `QueryPlanner` (registered by
+`with_distributed_planner()`) **after**
+normal physical planning. It takes the single-node physical plan, finds the
+points where data needs to be repartitioned in vanilla DataFusion, and
+inserts a network boundary node there, splitting the plan into *stages*
+that run on different *tasks* (machines).
 
 ## The same plan, before and after
 
-Take `SELECT count(*), "RainToday" FROM weather GROUP BY "RainToday" ORDER BY count(*)` over a 3-file table on a
-3-worker cluster. Here is the ordinary single-node physical plan (file paths trimmed to `[...]`):
+Let's assume we have a table with weather data, something like this:
 
-```text
+| RainToday (Utf8View) | MinTemp (Float64) | MaxTemp (Float64) |
+|----------------------|-------------------|-------------------|
+| No                   | 8.0               | 24.3              |
+| Yes                  | 14.0              | 26.9              |
+| Yes                  | 13.7              | 23.4              |
+| No                   | 8.8               | 19.5              |
+| ...                  |                   |                   |
+
+And we issue the following query:
+
+```sql
+SELECT count(*), "RainToday" FROM weather GROUP BY "RainToday" ORDER BY count(*)
+```
+[DataFusion fiddle link](https://datafusion-fiddle.vercel.app?q=eyJzdGF0ZW1lbnQiOiJTRUxFQ1QgY291bnQoKiksIFwiUmFpblRvZGF5XCIgRlJPTSB3ZWF0aGVyIEdST1VQIEJZIFwiUmFpblRvZGF5XCIgT1JERVIgQlkgY291bnQoKikifQ==)
+
+The resulting physical plan will look like this:
+
+```sql
 SortPreservingMergeExec: [count(*)@0 ASC NULLS LAST]
   SortExec: expr=[count(*)@0 ASC NULLS LAST], preserve_partitioning=[true]
     ProjectionExec: expr=[count(Int64(1))@1 as count(*), RainToday@0 as RainToday]
       AggregateExec: mode=FinalPartitioned, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))]
-        RepartitionExec: partitioning=Hash([RainToday@0], 4), input_partitions=3
+        RepartitionExec: partitioning=Hash([RainToday@0], 2), input_partitions=2
           AggregateExec: mode=Partial, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))]
-            DataSourceExec: file_groups={3 groups: [...]}, projection=[RainToday], file_type=parquet
+            DataSourceExec: file_groups={2 groups: [[/api/parquet/weather/part-0.parquet, /api/parquet/weather/part-1.parquet], [/api/parquet/weather/part-2.parquet, /api/parquet/weather/part-3.parquet]]}, projection=[RainToday], file_type=parquet
 ```
 
-And the distributed plan for the same query, rendered with `display_plan_ascii`:
+If we now issue the same query with a low value for
+`file_scan_config_bytes_per_partition` in order to force distribution:
 
-```text
+```sql
+SET distributed.file_scan_config_bytes_per_partition = 50000;
+SELECT count(*), "RainToday" FROM weather GROUP BY "RainToday" ORDER BY count(*)
+```
+
+[DataFusion fiddle link](https://datafusion-fiddle.vercel.app?q=eyJzdGF0ZW1lbnQiOiJTRVQgZGlzdHJpYnV0ZWQuZmlsZV9zY2FuX2NvbmZpZ19ieXRlc19wZXJfcGFydGl0aW9uID0gNTAwMDA7XG5TRUxFQ1QgY291bnQoKiksIFwiUmFpblRvZGF5XCIgRlJPTSB3ZWF0aGVyIEdST1VQIEJZIFwiUmFpblRvZGF5XCIgT1JERVIgQlkgY291bnQoKikifQ==)
+
+We get the equivalent distributed plan:
+
+```sql
 ┌───── DistributedExec
 │ SortPreservingMergeExec: [count(*)@0 ASC NULLS LAST]
-│   [Stage 2] => NetworkCoalesceExec: output_partitions=8, input_tasks=2
+│   [Stage 2] => NetworkCoalesceExec: output_partitions=4, input_tasks=2
 └──────────────────────────────────────────────────
-  ┌───── Stage 2 ── tasks=2, partitions=4
+  ┌───── Stage 2 ── tasks=2, partitions=2
   │ SortExec: expr=[count(*)@0 ASC NULLS LAST], preserve_partitioning=[true]
   │   ProjectionExec: expr=[count(Int64(1))@1 as count(*), RainToday@0 as RainToday]
   │     AggregateExec: mode=FinalPartitioned, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))]
-  │       [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=3
+  │       [Stage 1] => NetworkShuffleExec: output_partitions=2, input_tasks=2
   └──────────────────────────────────────────────────
-    ┌───── Stage 1 ── tasks=3, partitions=8
-    │ RepartitionExec: partitioning=Hash([RainToday@0], 8), input_partitions=3
+    ┌───── Stage 1 ── tasks=2, partitions=4
+    │ RepartitionExec: partitioning=Hash([RainToday@0], 4), input_partitions=4
     │   AggregateExec: mode=Partial, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))]
-    │     DistributedLeafExec: DataSourceExec: file_groups={3 groups: [...]}, projection=[RainToday], file_type=parquet
+    │     DistributedLeafExec:
+    │       t0: DataSourceExec: file_groups={4 groups: [[/api/parquet/weather/part-0.parquet:0..21645], [/api/parquet/weather/part-0.parquet:43290..43674, /api/parquet/weather/part-1.parquet:0..21261], [/api/parquet/weather/part-1.parquet:42906..43392, /api/parquet/weather/part-2.parquet:0..21159], [/api/parquet/weather/part-2.parquet:42804..43052, /api/parquet/weather/part-3.parquet:0..21397]]}, projection=[RainToday], file_type=parquet
+    │       t1: DataSourceExec: file_groups={4 groups: [[/api/parquet/weather/part-0.parquet:21645..43290], [/api/parquet/weather/part-1.parquet:21261..42906], [/api/parquet/weather/part-2.parquet:21159..42804], [/api/parquet/weather/part-3.parquet:21397..43040]]}, projection=[RainToday], file_type=parquet
     └──────────────────────────────────────────────────
 ```
 
-Same operators, same order. The planner only:
+The key differences are:
 
-- inserted a **`NetworkShuffleExec`** above the hash `RepartitionExec` (the shuffle now fans data across tasks),
-- inserted a **`NetworkCoalesceExec`** at the top to gather all tasks into the single head task,
-- wrapped the leaf in a **`DistributedLeafExec`** so each task scans its own slice of the files, and
-- grew the shuffle's partition count (4 → 8) because it now feeds multiple tasks.
+- inserted a **`NetworkShuffleExec`** above the hash `RepartitionExec` (the
+  shuffle now fans data across machines),
+- inserted a **`NetworkCoalesceExec`** at the top to gather all tasks into the
+  single head task,
+- wrapped the leaf in a **`DistributedLeafExec`** so each task scans its own
+  slice of the files, and
+- grew the output partitions of `RepartitionExec` from 2 to 4, to account for
+  the two machines above with two partitions each.
 
 ### Reading the output
 
-- `┌───── Stage 1 ── tasks=3, partitions=8` — a stage running on **3 tasks**, each on a different worker,
-  together spanning **8 partitions**. Tasks are machines; partitions are the threads within a task.
-- `[Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=3` — a **network boundary**: this node
-  streams the output of Stage 1 over Arrow Flight instead of from a child node. `input_tasks` is how many tasks
-  produced the data; `output_partitions` is how many partitions it exposes to its parent.
-- `DistributedExec` — the root and the only node the client executes. It hosts the **head stage**, which always
-  runs on a single task (the coordinator).
-- `DistributedLeafExec` — a transparent wrapper around the original leaf; `DistributedExec` swaps in the right
-  per-task variant before sending the stage to a worker.
+- `┌───── Stage 1 ── tasks=2, partitions=4` — a stage running on **3 tasks**,
+  each on a different worker, together spanning **8 partitions**. Tasks are
+  machines; partitions are the threads within a task.
+- `[Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=3` — a
+  **network boundary**: this node streams the output of Stage 1 over Arrow
+  Flight instead of from a child node. `input_tasks` is how many tasks produced
+  the data; `output_partitions` is how many partitions it exposes to its parent.
+- `DistributedExec` — the root and the only node the client executes. It hosts
+  the **head stage**, which always runs on a single task (the coordinator).
+- `DistributedLeafExec` — a transparent wrapper around the original leaf;
+  `DistributedExec` swaps in the right per-task variant before sending the stage
+  to a worker.
 
 ## Step by step
 
-The rest of this page walks the same transformation visually, on a four-file aggregation. To better understand
-what happens with the plan in the distribution process, we will represent it graphically:
+The rest of this page walks the same transformation visually, on a four-file
+aggregation. To better understand what happens with the plan in the distribution
+process, we'll use some schematic drawings:
 
-![img.png](../_static/images/img.png)
+```
+              ▲            
+              │            
+              │            
+┌──────────┬──┴─┬─────────┐
+│  ┌───────▶ P0 ◀──────┐  │
+│  │       └────┘      │  │
+│  │SortPreservingMerge│  │
+└──┼───────────────────┼──┘
+   │                   │   
+   │                   │   
+┌┬─┴──┬─────────────┬──┴─┬┐
+││ P0 │             │ P1 ││
+│└─▲──┘             └──▲─┘│
+│  │       Sort        │  │
+└──┼───────────────────┼──┘
+   │                   │   
+   │                   │   
+┌┬─┴──┬─────────────┬──┴─┬┐
+││ P0 │             │ P1 ││
+│└─▲──┘             └──▲─┘│
+│  │    Projection     │  │
+└──┼───────────────────┼──┘
+   │                   │   
+   │                   │   
+┌┬─┴──┬─────────────┬──┴─┬┐
+││ P0 │             │ P1 ││
+│└▲─▲─┘             └─▲─▲┘│
+│ │  Aggregate(final)   │ │
+└───┼─────────────────┼───┘
+  │  ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐│  
+    ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘    
+┌┬┴┴──┬─────────────┬──┴┴┬┐
+││ P0 │             │ P1 ││
+│└─▲──┘             └──▲─┘│
+│  │  RepartitionExec  │  │
+└──┼───────────────────┼──┘
+   │                   │   
+   │                   │   
+┌┬─┴──┬─────────────┬──┴─┬┐
+││ P0 │             │ P1 ││
+│└─▲──┘             └──▲─┘│
+│  │Aggregate(partial) │  │
+└──┼───────────────────┼──┘
+   │                   │   
+   │                   │   
+┌┬─┴──┬─────────────┬──┴─┬┐
+││ P0 │             │ P1 ││
+│└────┘             └────┘│
+│     DataSourceExec      │
+└─────────────────────────┘
+```
 
-Note how the underlying `DataSourceExec` contains multiple non-overlapping pieces of data, represented with colors
-in the image. Depending on the underlying `DataSource` implementation in the `DataSourceExec` node, these can
-represent different things, such as different parquet files, or an external API from which we can gather data for different
-time ranges.
+Note how the data is distributed locally across 2 partitions, each one with
+its own data stream.
 
-The first step is to split the leaf node into different tasks:
-
-![img_2.png](../_static/images/img_2.png)
-
-Each task will handle a different non-overlapping piece of data.
+The distributed planner starts walking the plan in a bottom-up fashion, starting
+with the leaf nodes.
 
 The number of tasks that will be used for executing leaf nodes is determined by
 `DesiredTaskCountHandler` implementations. Default handlers exist for file-based
-`DataSourceExec` nodes. However, since `DataSourceExec` can be customized to represent
-any data source, users with custom implementations should also provide corresponding
-desired task-count and leaf-scale handlers.
+`DataSourceExec` nodes. However, since `DataSourceExec` can be customized to
+represent any data source, users with custom implementations should also provide
+corresponding desired task-count and leaf-scale handlers.
 
-the data across different tasks, each task will also distribute its data across partitions using the vanilla DataFusion
-partitioning mechanism. A partition is a split of data processed by a single thread on a single machine, whereas a
-In the case above, a desired task-count handler decided to use four tasks for the leaf node. Note that even if we are distributing
-the data across different tasks, each task will also distribute its data across partitions using the vanilla DataFusion
-partitioning mechanism. A partition is a split of data processed by a single thread on a single machine, whereas a
-the data across different tasks, each task will also distribute its data across partitions using the vanilla DataFusion
-partitioning mechanism. A partition is a split of data processed by a single thread on a single machine, whereas a 
-task is a split of data processed by an entire machine within a cluster.
+With this example setup, the leaf node will be scaled up to 2 tasks, each one
+running its own set of partitions.
 
-After that, we can continue reconstructing the plan:
+```
+   ▲                   ▲            ▲                   ▲   
+   │                   │            │                   │   
+   │                   │            │                   │   
+   │                   │            │                   │   
+   │                   │            │                   │   
+┌┬─┴──┬─────────────┬──┴─┬┐      ┌┬─┴──┬─────────────┬──┴─┬┐
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││
+│└────┘             └────┘│      │└────┘             └────┘│
+│     DataSourceExec      │      │     DataSourceExec      │
+└─────────────────────────┘      └─────────────────────────┘
+```
 
-![img_3.png](../_static/images/img_3.png)
+Once the leaf nodes are figured out, the planner walks up the next node,
+adhering to the established parallelism imposed by the leaf node.
 
-Nothing special to consider for now—the partial aggregation can simply be executed in parallel across different
-workers without further considerations.
+```
+   ▲                   ▲            ▲                   ▲   
+   │                   │            │                   │   
+   │                   │            │                   │   
+   │                   │            │                   │   
+   │                   │            │                   │   
+┌┬─┴──┬─────────────┬──┴─┬┐      ┌┬─┴──┬─────────────┬──┴─┬┐
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││
+│└─▲──┘             └──▲─┘│      │└─▲──┘             └──▲─┘│ <- added
+│  │Aggregate(partial) │  │      │  │Aggregate(partial) │  │
+└──┼───────────────────┼──┘      └──┼───────────────────┼──┘
+   │                   │            │                   │   
+   │                   │            │                   │   
+┌┬─┴──┬─────────────┬──┴─┬┐      ┌┬─┴──┬─────────────┬──┴─┬┐
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││
+│└────┘             └────┘│      │└────┘             └────┘│
+│     DataSourceExec      │      │     DataSourceExec      │
+└─────────────────────────┘      └─────────────────────────┘
+```
+
+Nothing special to consider for now—the partial aggregation can simply be
+executed in parallel across different workers without further considerations.
 
 Let's keep constructing the plan:
 
-![img_4.png](../_static/images/img_4.png)
+```
+  ▲▲▲▲               ▲▲▲▲          ▲▲▲▲               ▲▲▲▲  
+  ││││               ││││          ││││               ││││  
+                                                            
+  │││├ ─ ─ ─ ─ ─ ─ ─ ┤││├ ─ ─ ─ ─ ─│││├ ─ ─ ─ ─ ─ ─ ─ ┤│││  
+     ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─      
+┌┬┴┴┴┴┬─────────────┬┴┴┴┴┬┐      ┌┬┴┴┴┴┬─────────────┬┴┴┴┴┬┐
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││
+│└─▲──┘             └──▲─┘│      │└─▲──┘             └──▲─┘│ <- added
+│  │  RepartitionExec  │  │      │  │  RepartitionExec  │  │
+└──┼───────────────────┼──┘      └──┼───────────────────┼──┘
+   │                   │            │                   │   
+   │                   │            │                   │   
+┌┬─┴──┬─────────────┬──┴─┬┐      ┌┬─┴──┬─────────────┬──┴─┬┐
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││
+│└─▲──┘             └──▲─┘│      │└─▲──┘             └──▲─┘│
+│  │Aggregate(partial) │  │      │  │Aggregate(partial) │  │
+└──┼───────────────────┼──┘      └──┼───────────────────┼──┘
+   │                   │            │                   │   
+   │                   │            │                   │   
+┌┬─┴──┬─────────────┬──┴─┬┐      ┌┬─┴──┬─────────────┬──┴─┬┐
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││
+│└────┘             └────┘│      │└────┘             └────┘│
+│     DataSourceExec      │      │     DataSourceExec      │
+└─────────────────────────┘      └─────────────────────────┘
+```
 
-At this point, the plan encounters a `RepartitionExec` node, which requires repartitioning data so each partition
-handles a non-overlapping subset of grouping keys for the aggregation.
+At this point, the plan encounters a `RepartitionExec` node, which requires
+repartitioning data so each partition handles a non-overlapping subset of
+grouping keys for the aggregation.
 
-While `RepartitionExec` redistributes data across threads on a single machine in vanilla DataFusion, it redistributes
-data across threads on different machines in the distributed context—requiring a network shuffle.
+`RepartitionExec` is typically used for redistributing work across partitions
+in the same machine, so typically the number of output partitions adheres to
+the `datafusion.execution.target_partitions` setting, but in this case it needs
+to fan out to `datafusion.execution.target_partitions * task_count` partitions.
 
-As we are about to send data over the network, it's convenient to coalesce smaller batches into larger ones to avoid
-the overhead of sending many small messages, and instead send fewer but larger messages:
+After this, we are ready to perform the shuffle over the network. For that, a
+new `ExecutionPlan` implementation is provided: `NetworkShuffleExec`:
 
-![img_5.png](../_static/images/img_5.png)
+```
+   ▲                   ▲            ▲                   ▲               
+   │                   │            │                   │               
+   │                   │            │                   │               
+   │                   │            │                   │               
+   │                   │            │                   │               
+┌┬─┴──┬─────────────┬──┴─┬┐      ┌┬─┴──┬─────────────┬──┴─┬┐            
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││            
+│└▲▲▲▲┘             └▲▲▲▲┘│      │└▲▲▲▲┘             └▲▲▲▲┘│ <- added
+│ ││││NetworkShuffle ││││ │      │ ││││NetworkShuffle ││││ │            
+└─────────────────────────┘      └─────────────────────────┘            
+  │││├ ─ ─ ─ ─ ─ ─ ─ ┤││├ ─ ─ ─ ─ ─│││├ ─ ─ ─ ─ ─ ─ ─ ┤│││              
+     ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─        ■         
+┌┬┴┴┴┴┬─────────────┬┴┴┴┴┬┐      ┌┬┴┴┴┴┬─────────────┬┴┴┴┴┬┐            
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││  │         
+│└─▲──┘             └──▲─┘│      │└─▲──┘             └──▲─┘│            
+│  │  RepartitionExec  │  │      │  │  RepartitionExec  │  │  │         
+└──┼───────────────────┼──┘      └──┼───────────────────┼──┘            
+   │                   │            │                   │     │         
+   │                   │            │                   │               
+┌┬─┴──┬─────────────┬──┴─┬┐      ┌┬─┴──┬─────────────┬──┴─┬┐  │         
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││    Stage 1 
+│└─▲──┘             └──▲─┘│      │└─▲──┘             └──▲─┘│  │         
+│  │Aggregate(partial) │  │      │  │Aggregate(partial) │  │            
+└──┼───────────────────┼──┘      └──┼───────────────────┼──┘  │         
+   │                   │            │                   │               
+   │                   │            │                   │     │         
+┌┬─┴──┬─────────────┬──┴─┬┐      ┌┬─┴──┬─────────────┬──┴─┬┐            
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││  │         
+│└────┘             └────┘│      │└────┘             └────┘│            
+│     DataSourceExec      │      │     DataSourceExec      │  │         
+└─────────────────────────┘      └─────────────────────────┘  ■         
+```
 
-After this, we are ready to perform the shuffle over the network. For that, a new `ExecutionPlan` implementation is
-provided: `NetworkShuffleExec`:
+A `NetworkShuffleExec`, instead of calling `execute()` on its child node, will
+execute it remotely through the network, and each `NetworkShuffleExec` instance
+will know from which partitions and machines it should gather data.
 
-![img_6.png](../_static/images/img_6.png)
+Note how this means that we have just built the first stage, as the first
+network boundary was introduced. We are now in the process of building the
+second stage. The process above is repeated until the next network boundary
 
-A `NetworkShuffleExec`, instead of calling `execute()` on its child node, will execute it remotely through Arrow
-Flight, and each `NetworkShuffleExec` instance will know from which partitions and machines it should gather data.
+```
+   ▲                   ▲            ▲                   ▲               
+   │                   │            │                   │               
+   │                   │            │                   │               
+   │                   │            │                   │               
+   │                   │            │                   │               
+┌┬─┴──┬─────────────┬──┴─┬┐      ┌┬─┴──┬─────────────┬──┴─┬┐            
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││            
+│└─▲──┘             └──▲─┘│      │└─▲──┘             └──▲─┘│ <- added   
+│  │       Sort        │  │      │  │       Sort        │  │            
+└──┼───────────────────┼──┘      └──┼───────────────────┼──┘            
+   │                   │            │                   │               
+   │                   │            │                   │               
+┌┬─┴──┬─────────────┬──┴─┬┐      ┌┬─┴──┬─────────────┬──┴─┬┐            
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││            
+│└─▲──┘             └──▲─┘│      │└─▲──┘             └──▲─┘│ <- added   
+│  │    Projection     │  │      │  │    Projection     │  │            
+└──┼───────────────────┼──┘      └──┼───────────────────┼──┘            
+   │                   │            │                   │               
+   │                   │            │                   │               
+┌┬─┴──┬─────────────┬──┴─┬┐      ┌┬─┴──┬─────────────┬──┴─┬┐            
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││            
+│└─▲──┘             └──▲─┘│      │└─▲──┘             └──▲─┘│ <- added   
+│  │    Aggr(final)    │  │      │  │    Aggr(final)    │  │            
+└──┼───────────────────┼──┘      └──┼───────────────────┼──┘            
+   │                   │            │                   │               
+   │                   │            │                   │               
+┌┬─┴──┬─────────────┬──┴─┬┐      ┌┬─┴──┬─────────────┬──┴─┬┐            
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││            
+│└▲▲▲▲┘             └▲▲▲▲┘│      │└▲▲▲▲┘             └▲▲▲▲┘│            
+│ ││││NetworkShuffle ││││ │      │ ││││NetworkShuffle ││││ │            
+└─────────────────────────┘      └─────────────────────────┘            
+  │││├ ─ ─ ─ ─ ─ ─ ─ ┤││├ ─ ─ ─ ─ ─│││├ ─ ─ ─ ─ ─ ─ ─ ┤│││              
+     ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─        ■         
+┌┬┴┴┴┴┬─────────────┬┴┴┴┴┬┐      ┌┬┴┴┴┴┬─────────────┬┴┴┴┴┬┐            
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││  │         
+│└─▲──┘             └──▲─┘│      │└─▲──┘             └──▲─┘│            
+│  │  RepartitionExec  │  │      │  │  RepartitionExec  │  │  │         
+└──┼───────────────────┼──┘      └──┼───────────────────┼──┘            
+   │                   │            │                   │     │         
+   │                   │            │                   │               
+┌┬─┴──┬─────────────┬──┴─┬┐      ┌┬─┴──┬─────────────┬──┴─┬┐  │         
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││    Stage 1 
+│└─▲──┘             └──▲─┘│      │└─▲──┘             └──▲─┘│  │         
+│  │Aggregate(partial) │  │      │  │Aggregate(partial) │  │            
+└──┼───────────────────┼──┘      └──┼───────────────────┼──┘  │         
+   │                   │            │                   │               
+   │                   │            │                   │     │         
+┌┬─┴──┬─────────────┬──┴─┬┐      ┌┬─┴──┬─────────────┬──┴─┬┐            
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││  │         
+│└────┘             └────┘│      │└────┘             └────┘│            
+│     DataSourceExec      │      │     DataSourceExec      │  │         
+└─────────────────────────┘      └─────────────────────────┘  ■         
+```
 
-Note how this means that we have just built the first stage, as the first network boundary was introduced. We are now
-in the process of building the second stage, and note how it has just two tasks.
+One final step remains: the plan's head is currently distributed across two
+machines, but the final result must be consolidated on a single one. In the
+same way that vanilla DataFusion coalesces all partitions into one in the head
+node for the user, we also need to do that, but not only across partitions on a
+single machine, but across tasks on different machines.
 
-If the number of tasks in a leaf stage is driven by the hints given by desired task-count handlers, the number of tasks in upper
-stages is driven by the nodes in between that reduce or increase the cardinality of the data.
+For that, the `NetworkCoalesceExec` network boundary is introduced: it coalesces
+P partitions across N tasks into N*P partitions in one task. This does not imply
+repartitioning, or shuffling, or anything like that. The partitions are the same
+but joined into a single task:
 
-In this case, the leaf stage is performing a partial aggregation before sending data to the next stage, so we can
-assume that less compute will be needed, and therefore, we can reduce the width of the next stage to just two
-tasks.
+Note how at this point, what the user sees is just an `ExecutionPlan` that can
+be executed as any other normal plan, but it will happen to be distributed under
+the hood:
 
-The rest of the plan can be formed as normal:
-
-![img_7.png](../_static/images/img_7.png)
-
-One final step remains: the plan's head is currently distributed across two machines, but the final result must be
-consolidated on a single node. In the same way that vanilla DataFusion coalesces all partitions into one in the head
-node for the user, we also need to do that, but not only across partitions on a single machine, but across tasks on
-different machines.
-
-For that, the `NetworkCoalesceExec` network boundary is introduced: it coalesces P partitions across N tasks into
-N*P partitions in one task. This does not imply repartitioning, or shuffling, or anything like that. The partitions
-are the same but joined into a single task:
-
-![img_8.png](../_static/images/img_8.png)
-
-Note how at this point, what the user sees is just an `ExecutionPlan` that can be executed as any other normal plan,
-but it will happen to be distributed under the hood.
+```
+                              ▲                                         
+                              │                                         
+                              │                                         
+                 ┌─────────┬──┴─┬─────────┐                             
+                 │         │ P0 │         │                             
+                 │         └────┘         │   <- added                       
+                 │  SortPreservingMerge   │                             
+                 └──▲─────▲──────▲─────▲──┘                             
+                    │     │      │     │                                
+                    │     │      │     │                                
+                 ┌┬─┴──┬┬─┴──┬┬──┴─┬┬──┴─┬┐                             
+                 ││ P0 ││ P1 ││ P2 ││ P3 ││                             
+                 │└────┘└────┘└────┘└────┘│   <- added                  
+                 │    NetworkCoalesce     │                             
+                 └──▲─────▲─────▲──────▲──┘                             
+                    │     │     │      │                                
+   ┌────────────────┘     │     │      └────────────────┐               
+   │                   ┌──┘     └───┐                   │               
+   │                   │            │                   │               
+   │                   │            │                   │               
+   │                   │            │                   │               
+┌┬─┴──┬─────────────┬──┴─┬┐      ┌┬─┴──┬─────────────┬──┴─┬┐  ■         
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││            
+│└─▲──┘             └──▲─┘│      │└─▲──┘             └──▲─┘│  │         
+│  │       Sort        │  │      │  │       Sort        │  │            
+└──┼───────────────────┼──┘      └──┼───────────────────┼──┘  │         
+   │                   │            │                   │               
+   │                   │            │                   │     │         
+┌┬─┴──┬─────────────┬──┴─┬┐      ┌┬─┴──┬─────────────┬──┴─┬┐            
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││  │         
+│└─▲──┘             └──▲─┘│      │└─▲──┘             └──▲─┘│            
+│  │    Projection     │  │      │  │    Projection     │  │  │         
+└──┼───────────────────┼──┘      └──┼───────────────────┼──┘            
+   │                   │            │                   │     │ Stage 2 
+   │                   │            │                   │               
+┌┬─┴──┬─────────────┬──┴─┬┐      ┌┬─┴──┬─────────────┬──┴─┬┐  │         
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││            
+│└─▲──┘             └──▲─┘│      │└─▲──┘             └──▲─┘│  │         
+│  │    Aggr(final)    │  │      │  │    Aggr(final)    │  │            
+└──┼───────────────────┼──┘      └──┼───────────────────┼──┘  │         
+   │                   │            │                   │               
+   │                   │            │                   │     │         
+┌┬─┴──┬─────────────┬──┴─┬┐      ┌┬─┴──┬─────────────┬──┴─┬┐            
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││  │         
+│└▲▲▲▲┘             └▲▲▲▲┘│      │└▲▲▲▲┘             └▲▲▲▲┘│            
+│ ││││NetworkShuffle ││││ │      │ ││││NetworkShuffle ││││ │  │         
+└─────────────────────────┘      └─────────────────────────┘  ■         
+  │││├ ─ ─ ─ ─ ─ ─ ─ ┤││├ ─ ─ ─ ─ ─│││├ ─ ─ ─ ─ ─ ─ ─ ┤│││              
+     ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─        ■         
+┌┬┴┴┴┴┬─────────────┬┴┴┴┴┬┐      ┌┬┴┴┴┴┬─────────────┬┴┴┴┴┬┐            
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││  │         
+│└─▲──┘             └──▲─┘│      │└─▲──┘             └──▲─┘│            
+│  │  RepartitionExec  │  │      │  │  RepartitionExec  │  │  │         
+└──┼───────────────────┼──┘      └──┼───────────────────┼──┘            
+   │                   │            │                   │     │         
+   │                   │            │                   │               
+┌┬─┴──┬─────────────┬──┴─┬┐      ┌┬─┴──┬─────────────┬──┴─┬┐  │         
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││    Stage 1 
+│└─▲──┘             └──▲─┘│      │└─▲──┘             └──▲─┘│  │         
+│  │Aggregate(partial) │  │      │  │Aggregate(partial) │  │            
+└──┼───────────────────┼──┘      └──┼───────────────────┼──┘  │         
+   │                   │            │                   │               
+   │                   │            │                   │     │         
+┌┬─┴──┬─────────────┬──┴─┬┐      ┌┬─┴──┬─────────────┬──┴─┬┐            
+││ P0 │             │ P1 ││      ││ P2 │             │ P3 ││  │         
+│└────┘             └────┘│      │└────┘             └────┘│            
+│     DataSourceExec      │      │     DataSourceExec      │  │         
+└─────────────────────────┘      └─────────────────────────┘  ■         
+```


### PR DESCRIPTION
Closes https://github.com/datafusion-contrib/datafusion-distributed/issues/620

Updates the outdated 02-how-a-distributed-plan-is-built.md doc, moving away from scalidraw generated .png files for the explanation into plain text ascii drawnings, similar to the ones we see in the doc comments in other parts of the project.

