### PR TITLE
feat: add h2o groupby benchmark dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,8 @@ testdata/tpcds/*
 !testdata/tpcds/README.md
 testdata/clickbench/*
 !testdata/clickbench/queries
+testdata/h2o/*
+!testdata/h2o/queries
+!testdata/h2o/README.md
 codegen/target/*
 codegen/Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,6 +2167,7 @@ dependencies = [
  "object_store",
  "openssl",
  "parquet",
+ "rand 0.9.4",
  "reqwest",
  "serde",
  "serde_json",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -31,6 +31,7 @@ sketches-ddsketch = "0.3"
 object_store = { version = "0.13", features = ["aws"] }
 openssl = { version = "0.10", features = ["vendored"] }
 mimalloc = "0.1"
+rand = "0.9"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -15,6 +15,9 @@ For example, `tpch/sf1` is stored in `testdata/tpch/sf1`.
 
 # TPC-DS (only SCALE_FACTOR=1 is supported)
 ./gen-tpcds.sh
+
+# h2o groupby (default: SCALE_FACTOR=1 = 10 million rows)
+./gen-h2o.sh
 ```
 
 ### Running Benchmarks in single-node mode

--- a/benchmarks/gen-h2o.sh
+++ b/benchmarks/gen-h2o.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCALE_FACTOR=${SCALE_FACTOR:-1}
+PARTITIONS=${PARTITIONS:-16}
+
+echo "Generating h2o groupby dataset with SCALE_FACTOR=${SCALE_FACTOR} and PARTITIONS=${PARTITIONS}"
+
+# https://stackoverflow.com/questions/59895/how-do-i-get-the-directory-where-a-bash-script-is-located-from-within-the-script
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+DATA_DIR=${DATA_DIR:-${REPO_ROOT}/testdata/h2o}
+CARGO_COMMAND=${CARGO_COMMAND:-"cargo run -p datafusion-distributed-benchmarks --release"}
+H2O_DIR="${DATA_DIR}/sf${SCALE_FACTOR}"
+echo "Creating h2o dataset at Scale Factor ${SCALE_FACTOR} in ${H2O_DIR}..."
+
+FILE="${H2O_DIR}/x"
+if test -d "${FILE}"; then
+    echo " parquet files exist ($FILE exists)."
+else
+    echo " generating parquet files..."
+    $CARGO_COMMAND -- prepare-h2o --output "${H2O_DIR}" --scale-factor "${SCALE_FACTOR}" --partitions "$PARTITIONS"
+fi

--- a/benchmarks/src/datasets/h2o.rs
+++ b/benchmarks/src/datasets/h2o.rs
@@ -1,0 +1,356 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use super::common;
+use arrow::array::{Float64Builder, Int64Builder, StringBuilder};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion::error::DataFusionError;
+use parquet::arrow::arrow_writer::ArrowWriter;
+use parquet::file::properties::WriterProperties;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+/// Official h2oai/db-benchmark groupby-datagen seed.
+const SEED: u64 = 108;
+
+/// Default group cardinality (`K`) matching `G1_*_1e2_0_0`.
+const DEFAULT_GROUPS: u64 = 100;
+
+/// Rows at scale factor 1, matching the official "small" (1e7) dataset.
+const ROWS_PER_SCALE_FACTOR: f64 = 10_000_000.0;
+
+const BATCH_SIZE: usize = 8192;
+
+const TABLE_NAME: &str = "x";
+
+pub fn get_queries() -> Vec<String> {
+    common::get_queries("testdata/h2o/queries")
+}
+
+pub fn get_query(id: &str) -> Result<String, DataFusionError> {
+    common::get_query("testdata/h2o/queries", id)
+}
+
+/// Number of rows for a scale factor. SF1 is 10 million rows.
+pub fn rows_for_scale_factor(sf: f64) -> Result<u64, DataFusionError> {
+    if !(sf > 0.0) {
+        return Err(DataFusionError::Internal(format!(
+            "scale factor must be > 0, got {sf}"
+        )));
+    }
+    let rows = (sf * ROWS_PER_SCALE_FACTOR).round();
+    if rows < 1.0 || !rows.is_finite() {
+        return Err(DataFusionError::Internal(format!(
+            "scale factor {sf} produces no rows"
+        )));
+    }
+    Ok(rows as u64)
+}
+
+/// Generates the h2o groupby table `x` as parquet files under `data_dir/x/`.
+///
+/// Column distributions follow
+/// [groupby-datagen.R](https://github.com/h2oai/db-benchmark/blob/master/_data/groupby-datagen.R):
+/// `id1`/`id2`/`id4`/`id5` have `K` distinct values, `id3`/`id6` have `N/K`,
+/// `v1` is in `[1, 5]`, `v2` is in `[1, 15]`, and `v3` is `round(U(0, 100), 6)`.
+pub fn generate_h2o_data(
+    data_dir: &Path,
+    n_rows: u64,
+    partitions: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
+    generate_h2o_data_with_groups(data_dir, n_rows, DEFAULT_GROUPS, partitions)
+}
+
+pub fn generate_h2o_data_with_groups(
+    data_dir: &Path,
+    n_rows: u64,
+    n_groups: u64,
+    partitions: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if n_rows == 0 {
+        return Err("n_rows must be > 0".into());
+    }
+    if n_groups == 0 {
+        return Err("n_groups must be > 0".into());
+    }
+    if partitions == 0 {
+        return Err("partitions must be > 0".into());
+    }
+
+    let n_groups = n_groups.min(n_rows);
+    let n_small_groups = (n_rows / n_groups).max(1);
+
+    let table_dir = data_dir.join(TABLE_NAME);
+    fs::create_dir_all(&table_dir)?;
+
+    let schema = schema();
+    let id1_pool: Vec<String> = (1..=n_groups).map(|i| format!("id{i:03}")).collect();
+    let id3_pool: Vec<String> = (1..=n_small_groups).map(|i| format!("id{i:010}")).collect();
+
+    let mut rng = StdRng::seed_from_u64(SEED);
+    let mut file_idx = 1usize;
+    for part_rows in partition_row_counts(n_rows, partitions) {
+        if part_rows == 0 {
+            continue;
+        }
+        write_partition(
+            &mut rng,
+            &schema,
+            &id1_pool,
+            &id3_pool,
+            n_groups,
+            n_small_groups,
+            part_rows,
+            &table_dir.join(format!("{file_idx}.parquet")),
+        )?;
+        file_idx += 1;
+    }
+    Ok(())
+}
+
+fn schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id1", DataType::Utf8, false),
+        Field::new("id2", DataType::Utf8, false),
+        Field::new("id3", DataType::Utf8, false),
+        Field::new("id4", DataType::Int64, false),
+        Field::new("id5", DataType::Int64, false),
+        Field::new("id6", DataType::Int64, false),
+        Field::new("v1", DataType::Int64, false),
+        Field::new("v2", DataType::Int64, false),
+        Field::new("v3", DataType::Float64, false),
+    ]))
+}
+
+fn partition_row_counts(n_rows: u64, partitions: usize) -> Vec<u64> {
+    let p = partitions as u64;
+    let base = n_rows / p;
+    let rem = n_rows % p;
+    (0..p).map(|i| base + u64::from(i < rem)).collect()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_partition(
+    rng: &mut StdRng,
+    schema: &Arc<Schema>,
+    id1_pool: &[String],
+    id3_pool: &[String],
+    n_groups: u64,
+    n_small_groups: u64,
+    part_rows: u64,
+    path: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let file = fs::File::create(path)?;
+    let props = WriterProperties::builder().build();
+    let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props))?;
+
+    let mut remaining = part_rows;
+    while remaining > 0 {
+        let batch_rows = remaining.min(BATCH_SIZE as u64) as usize;
+        writer.write(&build_batch(
+            rng,
+            schema,
+            id1_pool,
+            id3_pool,
+            n_groups,
+            n_small_groups,
+            batch_rows,
+        )?)?;
+        remaining -= batch_rows as u64;
+    }
+
+    writer.close()?;
+    Ok(())
+}
+
+fn build_batch(
+    rng: &mut StdRng,
+    schema: &Arc<Schema>,
+    id1_pool: &[String],
+    id3_pool: &[String],
+    n_groups: u64,
+    n_small_groups: u64,
+    rows: usize,
+) -> Result<RecordBatch, Box<dyn std::error::Error>> {
+    let mut id1 = StringBuilder::with_capacity(rows, rows * 8);
+    let mut id2 = StringBuilder::with_capacity(rows, rows * 8);
+    let mut id3 = StringBuilder::with_capacity(rows, rows * 16);
+    let mut id4 = Int64Builder::with_capacity(rows);
+    let mut id5 = Int64Builder::with_capacity(rows);
+    let mut id6 = Int64Builder::with_capacity(rows);
+    let mut v1 = Int64Builder::with_capacity(rows);
+    let mut v2 = Int64Builder::with_capacity(rows);
+    let mut v3 = Float64Builder::with_capacity(rows);
+
+    for _ in 0..rows {
+        id1.append_value(&id1_pool[rng.random_range(0..id1_pool.len())]);
+        id2.append_value(&id1_pool[rng.random_range(0..id1_pool.len())]);
+        id3.append_value(&id3_pool[rng.random_range(0..id3_pool.len())]);
+        id4.append_value(rng.random_range(1..=n_groups) as i64);
+        id5.append_value(rng.random_range(1..=n_groups) as i64);
+        id6.append_value(rng.random_range(1..=n_small_groups) as i64);
+        v1.append_value(rng.random_range(1..=5) as i64);
+        v2.append_value(rng.random_range(1..=15) as i64);
+        v3.append_value((rng.random::<f64>() * 100.0 * 1_000_000.0).round() / 1_000_000.0);
+    }
+
+    Ok(RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(id1.finish()),
+            Arc::new(id2.finish()),
+            Arc::new(id3.finish()),
+            Arc::new(id4.finish()),
+            Arc::new(id5.finish()),
+            Arc::new(id6.finish()),
+            Arc::new(v1.finish()),
+            Arc::new(v2.finish()),
+            Arc::new(v3.finish()),
+        ],
+    )?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Float64Array, Int64Array, StringArray};
+    use datafusion::prelude::{ParquetReadOptions, SessionContext};
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir() -> std::path::PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("dfd-h2o-{nanos}"));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn query_files_are_numbered() {
+        assert_eq!(
+            get_queries(),
+            ["q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10"]
+        );
+        assert!(get_query("q1").unwrap().contains("GROUP BY id1"));
+    }
+
+    #[test]
+    fn scale_factor_maps_to_official_sizes() {
+        assert_eq!(rows_for_scale_factor(1.0).unwrap(), 10_000_000);
+        assert_eq!(rows_for_scale_factor(10.0).unwrap(), 100_000_000);
+        assert_eq!(rows_for_scale_factor(0.01).unwrap(), 100_000);
+        assert!(rows_for_scale_factor(0.0).is_err());
+        assert!(rows_for_scale_factor(-1.0).is_err());
+    }
+
+    #[test]
+    fn generate_writes_partitioned_groupby_table() {
+        let dir = temp_dir();
+        generate_h2o_data_with_groups(&dir, 2_000, 100, 2).unwrap();
+
+        let files: Vec<_> = fs::read_dir(dir.join("x"))
+            .unwrap()
+            .map(|e| e.unwrap().path())
+            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("parquet"))
+            .collect();
+        assert_eq!(files.len(), 2);
+
+        let mut rows = 0usize;
+        let mut id1 = std::collections::BTreeSet::new();
+        let mut id3 = std::collections::BTreeSet::new();
+        for path in &files {
+            let file = fs::File::open(path).unwrap();
+            let reader = ParquetRecordBatchReaderBuilder::try_new(file)
+                .unwrap()
+                .build()
+                .unwrap();
+            for batch in reader {
+                let batch = batch.unwrap();
+                rows += batch.num_rows();
+                let id1_col = batch
+                    .column_by_name("id1")
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .unwrap();
+                let id3_col = batch
+                    .column_by_name("id3")
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .unwrap();
+                let v1_col = batch
+                    .column_by_name("v1")
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .unwrap();
+                let v3_col = batch
+                    .column_by_name("v3")
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<Float64Array>()
+                    .unwrap();
+                for i in 0..batch.num_rows() {
+                    id1.insert(id1_col.value(i).to_string());
+                    id3.insert(id3_col.value(i).to_string());
+                    assert!((1..=5).contains(&v1_col.value(i)));
+                    assert!((0.0..=100.0).contains(&v3_col.value(i)));
+                }
+            }
+        }
+
+        assert_eq!(rows, 2_000);
+        assert!(id1.len() <= 100);
+        assert!(id3.len() <= 20);
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[tokio::test]
+    async fn generated_table_answers_groupby_q1() {
+        let dir = temp_dir();
+        generate_h2o_data_with_groups(&dir, 2_000, 100, 2).unwrap();
+
+        let ctx = SessionContext::new();
+        ctx.register_parquet(
+            "x",
+            dir.join("x").to_str().unwrap(),
+            ParquetReadOptions::default(),
+        )
+        .await
+        .unwrap();
+
+        let batches = ctx
+            .sql("SELECT id1, SUM(v1) AS v1 FROM x GROUP BY id1")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let out_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert!(out_rows > 0);
+        assert!(out_rows <= 100);
+        fs::remove_dir_all(dir).ok();
+    }
+}

--- a/benchmarks/src/datasets/h2o.rs
+++ b/benchmarks/src/datasets/h2o.rs
@@ -51,7 +51,7 @@ pub fn get_query(id: &str) -> Result<String, DataFusionError> {
 
 /// Number of rows for a scale factor. SF1 is 10 million rows.
 pub fn rows_for_scale_factor(sf: f64) -> Result<u64, DataFusionError> {
-    if !(sf > 0.0) {
+    if !sf.is_finite() || sf <= 0.0 {
         return Err(DataFusionError::Internal(format!(
             "scale factor must be > 0, got {sf}"
         )));

--- a/benchmarks/src/datasets/mod.rs
+++ b/benchmarks/src/datasets/mod.rs
@@ -1,5 +1,6 @@
 pub mod clickbench;
 mod common;
+pub mod h2o;
 pub mod tpcds;
 pub mod tpch;
 

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -1,6 +1,7 @@
 //! DataFusion Distributed benchmark runner
 mod compare;
 mod prepare_clickbench;
+mod prepare_h2o;
 mod prepare_tpcds;
 mod prepare_tpch;
 mod results;
@@ -19,6 +20,7 @@ enum Options {
     PrepareTpch(prepare_tpch::PrepareTpchOpt),
     PrepareTpcds(prepare_tpcds::PrepareTpcdsOpt),
     PrepareClickbench(prepare_clickbench::PrepareClickBenchOpt),
+    PrepareH2o(prepare_h2o::PrepareH2oOpt),
 }
 
 // Main benchmark runner entrypoint
@@ -37,5 +39,6 @@ pub fn main() -> Result<()> {
             let rt = tokio::runtime::Runtime::new()?;
             rt.block_on(async { opt.run().await })
         }
+        Options::PrepareH2o(opt) => opt.run(),
     }
 }

--- a/benchmarks/src/prepare_h2o.rs
+++ b/benchmarks/src/prepare_h2o.rs
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use datafusion::error::Result;
+use datafusion_distributed_benchmarks::datasets::h2o::{generate_h2o_data, rows_for_scale_factor};
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+/// Generate h2o groupby parquet files for benchmarks
+#[derive(Debug, StructOpt)]
+pub struct PrepareH2oOpt {
+    /// Output path for generated parquet files
+    #[structopt(parse(from_os_str), required = true, short = "o", long = "output")]
+    output_path: PathBuf,
+
+    /// Scale factor. SF1 is 10 million rows (official "small").
+    #[structopt(short = "s", long = "scale-factor", default_value = "1")]
+    scale_factor: f64,
+
+    /// Number of partitions (parquet files)
+    #[structopt(short = "n", long = "partitions", default_value = "16")]
+    partitions: usize,
+}
+
+impl PrepareH2oOpt {
+    pub fn run(self) -> Result<()> {
+        let n_rows = rows_for_scale_factor(self.scale_factor)?;
+        println!(
+            "Generating h2o groupby data ({} rows, {} partitions) in '{}'",
+            n_rows,
+            self.partitions,
+            self.output_path.display()
+        );
+        generate_h2o_data(&self.output_path, n_rows, self.partitions)
+            .map_err(|e| datafusion::error::DataFusionError::Internal(format!("{e:?}")))?;
+        println!("h2o data generation complete.");
+        Ok(())
+    }
+}

--- a/benchmarks/src/run.rs
+++ b/benchmarks/src/run.rs
@@ -36,7 +36,7 @@ use datafusion_distributed::{
     DistributedExt, DistributedMetricsFormat, NetworkBoundaryExt, SessionStateBuilderExt, Worker,
     display_plan_ascii, rewrite_distributed_plan_with_metrics,
 };
-use datafusion_distributed_benchmarks::datasets::{clickbench, register_tables, tpcds, tpch};
+use datafusion_distributed_benchmarks::datasets::{clickbench, h2o, register_tables, tpcds, tpch};
 use datafusion_distributed_benchmarks::stats::stats_estimation_q_error;
 use std::error::Error;
 use std::fs;
@@ -143,6 +143,10 @@ fn queries_for_dataset(dataset: &str) -> Result<Vec<(String, String)>, DataFusio
         "clickbench" => clickbench::get_queries()
             .into_iter()
             .map(|id| Ok((id.clone(), clickbench::get_query(&id)?)))
+            .collect(),
+        "h2o" => h2o::get_queries()
+            .into_iter()
+            .map(|id| Ok((id.clone(), h2o::get_query(&id)?)))
             .collect(),
         _ => not_impl_err!("Unknown benchmark dataset {dataset}"),
     }

--- a/docs/source/contributor-guide/04-benchmarks.md
+++ b/docs/source/contributor-guide/04-benchmarks.md
@@ -22,14 +22,16 @@ there are no performance regressions.
 
 ### Generating Test Data
 
-First, a TPCH dataset must be generated:
+First, a dataset must be generated:
 
 ```bash
 cd benchmarks
 SCALE_FACTOR=10 ./gen-tpch.sh
+SCALE_FACTOR=1 ./gen-h2o.sh
 ```
 
-This might take a while.
+This might take a while. h2o SF1 is 10 million rows (the official "small"
+groupby size).
 
 ### Running Benchmarks
 

--- a/testdata/h2o/README.md
+++ b/testdata/h2o/README.md
@@ -1,0 +1,25 @@
+This directory holds the [h2oai/db-benchmark](https://github.com/h2oai/db-benchmark)
+groupby queries and generated data.
+
+Generated data is written to `testdata/h2o/sf<scale-factor>/x/` and is run with
+`./benchmarks/run.sh --dataset h2o/sf<scale-factor>`.
+
+```bash
+# Default SF1 = 10 million rows, 16 parquet files
+./benchmarks/gen-h2o.sh
+
+# Tiny smoke-scale dataset (100k rows)
+SCALE_FACTOR=0.01 ./benchmarks/gen-h2o.sh
+
+# Official "medium" size (100 million rows)
+SCALE_FACTOR=10 ./benchmarks/gen-h2o.sh
+
+WORKERS=8 ./benchmarks/run.sh --threads 2 --dataset h2o/sf1
+```
+
+SF1 matches the official "small" `G1_1e7_1e2_0_0` size (N=1e7, K=100). The
+table schema and column cardinalities follow
+[groupby-datagen.R](https://github.com/h2oai/db-benchmark/blob/master/_data/groupby-datagen.R).
+Queries are the ten groupby statements from that suite.
+
+Join and window variants are not included here.

--- a/testdata/h2o/queries/q1.sql
+++ b/testdata/h2o/queries/q1.sql
@@ -1,0 +1,1 @@
+SELECT id1, SUM(v1) AS v1 FROM x GROUP BY id1;

--- a/testdata/h2o/queries/q10.sql
+++ b/testdata/h2o/queries/q10.sql
@@ -1,0 +1,1 @@
+SELECT id1, id2, id3, id4, id5, id6, SUM(v3) AS v3, COUNT(*) AS count FROM x GROUP BY id1, id2, id3, id4, id5, id6;

--- a/testdata/h2o/queries/q2.sql
+++ b/testdata/h2o/queries/q2.sql
@@ -1,0 +1,1 @@
+SELECT id1, id2, SUM(v1) AS v1 FROM x GROUP BY id1, id2;

--- a/testdata/h2o/queries/q3.sql
+++ b/testdata/h2o/queries/q3.sql
@@ -1,0 +1,1 @@
+SELECT id3, SUM(v1) AS v1, AVG(v3) AS v3 FROM x GROUP BY id3;

--- a/testdata/h2o/queries/q4.sql
+++ b/testdata/h2o/queries/q4.sql
@@ -1,0 +1,1 @@
+SELECT id4, AVG(v1) AS v1, AVG(v2) AS v2, AVG(v3) AS v3 FROM x GROUP BY id4;

--- a/testdata/h2o/queries/q5.sql
+++ b/testdata/h2o/queries/q5.sql
@@ -1,0 +1,1 @@
+SELECT id6, SUM(v1) AS v1, SUM(v2) AS v2, SUM(v3) AS v3 FROM x GROUP BY id6;

--- a/testdata/h2o/queries/q6.sql
+++ b/testdata/h2o/queries/q6.sql
@@ -1,0 +1,1 @@
+SELECT id4, id5, MEDIAN(v3) AS median_v3, STDDEV(v3) AS sd_v3 FROM x GROUP BY id4, id5;

--- a/testdata/h2o/queries/q7.sql
+++ b/testdata/h2o/queries/q7.sql
@@ -1,0 +1,1 @@
+SELECT id3, MAX(v1) - MIN(v2) AS range_v1_v2 FROM x GROUP BY id3;

--- a/testdata/h2o/queries/q8.sql
+++ b/testdata/h2o/queries/q8.sql
@@ -1,0 +1,1 @@
+SELECT id6, largest2_v3 FROM (SELECT id6, v3 AS largest2_v3, ROW_NUMBER() OVER (PARTITION BY id6 ORDER BY v3 DESC) AS order_v3 FROM x WHERE v3 IS NOT NULL) sub_query WHERE order_v3 <= 2;

--- a/testdata/h2o/queries/q9.sql
+++ b/testdata/h2o/queries/q9.sql
@@ -1,0 +1,1 @@
+SELECT id2, id4, POWER(CORR(v1, v2), 2) AS r2 FROM x GROUP BY id2, id4;


### PR DESCRIPTION
﻿## Summary

Adds the [h2oai/db-benchmark](https://github.com/h2oai/db-benchmark) groupby dataset so physical aggregation is a first-class benchmark suite alongside TPC-H, TPC-DS, and ClickBench. Part of #629.

This is the remaining dataset called out in that epic after the sorted TPC-H / sorted ClickBench / TPC-DS scale-factor issues.

## Layout

SF1 is 10 million rows, matching official `G1_1e7_1e2_0_0` (N=1e7, K=100, no NAs, unsorted). Data is written to `testdata/h2o/sf<scale-factor>/x/`.

The table schema and column distributions follow [groupby-datagen.R](https://github.com/h2oai/db-benchmark/blob/master/_data/groupby-datagen.R): `id1`/`id2`/`id4`/`id5` have K distinct values, `id3`/`id6` have N/K, `v1` is in `[1, 5]`, `v2` is in `[1, 15]`, and `v3` is `round(U(0, 100), 6)`. Generation uses the published seed `108`.

Queries are the ten official groupby statements, in `testdata/h2o/queries/`. Join and window variants are not included.

```bash
# Default SF1, 16 parquet files
./benchmarks/gen-h2o.sh

# Tiny smoke-scale dataset (100k rows)
SCALE_FACTOR=0.01 ./benchmarks/gen-h2o.sh

# Official "medium" size (100 million rows)
SCALE_FACTOR=10 ./benchmarks/gen-h2o.sh

WORKERS=8 ./benchmarks/run.sh --threads 2 --dataset h2o/sf1
```

## Implementation

- `benchmarks/src/datasets/h2o.rs`: generate the `x` table and load the query files
- `benchmarks/src/prepare_h2o.rs` + `prepare-h2o` CLI
- `benchmarks/gen-h2o.sh`
- `queries_for_dataset` treats `h2o/sf<scale-factor>` as the h2o suite
- `register_tables` is unchanged (`x/` is registered as parquet table `x`)

## Tests / verification

- Unit tests in `h2o.rs`: scale-factor mapping, partitioned write (row count + column ranges), and that generated data answers groupby q1
- `cargo fmt --all`
- Full `cargo test -p datafusion-distributed-benchmarks --lib datasets::h2o` did not complete locally: vendored `openssl-sys` fails to build on this Windows machine (Git perl is missing `Locale::Maketext::Simple`). CI on Ubuntu should run the crate tests if/when they are invoked; the new tests compile as part of the benchmarks lib

Do not generate a full SF1 in review unless needed. `SCALE_FACTOR=0.01 ./benchmarks/gen-h2o.sh` is the cheap smoke.
