### PR TITLE
Remove ColaescePartitionsExec special-case

### DIFF
--- a/src/distributed_planner/distributed_query_planner.rs
+++ b/src/distributed_planner/distributed_query_planner.rs
@@ -211,7 +211,18 @@ mod tests {
         let physical_plan_ascii = TestPlanBuilder::default()
             .physical_plan_as_ascii(query, false)
             .await;
-        assert_snapshot!(physical_plan_ascii, @"DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, MaxTemp, Rainfall, Evaporation, Sunshine, WindGustDir, WindGustSpeed, WindDir9am, WindDir3pm, WindSpeed9am, WindSpeed3pm, Humidity9am, Humidity3pm, Pressure9am, Pressure3pm, Cloud9am, Cloud3pm, Temp9am, Temp3pm, RainToday, RISK_MM, RainTomorrow], file_type=parquet");
+        assert_snapshot!(physical_plan_ascii, @r"
+        ┌───── DistributedExec
+        │ CoalescePartitionsExec
+        │   [Stage 1] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+        └──────────────────────────────────────────────────
+          ┌───── Stage 1 ── tasks=3, partitions=9
+          │ DistributedLeafExec:
+          │   t0: DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet:<int>..<int>], [/testdata/weather/result-000000.parquet:<int>..<int>, /testdata/weather/result-000001.parquet:<int>..<int>], [/testdata/weather/result-000002.parquet:<int>..<int>]]}, projection=[MinTemp, MaxTemp, Rainfall, Evaporation, Sunshine, WindGustDir, WindGustSpeed, WindDir9am, WindDir3pm, WindSpeed9am, WindSpeed3pm, Humidity9am, Humidity3pm, Pressure9am, Pressure3pm, Cloud9am, Cloud3pm, Temp9am, Temp3pm, RainToday, RISK_MM, RainTomorrow], file_type=parquet
+          │   t1: DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet:<int>..<int>], [/testdata/weather/result-000001.parquet:<int>..<int>], [/testdata/weather/result-000002.parquet:<int>..<int>]]}, projection=[MinTemp, MaxTemp, Rainfall, Evaporation, Sunshine, WindGustDir, WindGustSpeed, WindDir9am, WindDir3pm, WindSpeed9am, WindSpeed3pm, Humidity9am, Humidity3pm, Pressure9am, Pressure3pm, Cloud9am, Cloud3pm, Temp9am, Temp3pm, RainToday, RISK_MM, RainTomorrow], file_type=parquet
+          │   t2: DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet:<int>..<int>], [/testdata/weather/result-000001.parquet:<int>..<int>, /testdata/weather/result-000002.parquet:<int>..<int>], [/testdata/weather/result-000002.parquet:<int>..<int>]]}, projection=[MinTemp, MaxTemp, Rainfall, Evaporation, Sunshine, WindGustDir, WindGustSpeed, WindDir9am, WindDir3pm, WindSpeed9am, WindSpeed3pm, Humidity9am, Humidity3pm, Pressure9am, Pressure3pm, Cloud9am, Cloud3pm, Temp9am, Temp3pm, RainToday, RISK_MM, RainTomorrow], file_type=parquet
+          └──────────────────────────────────────────────────
+        ");
     }
 
     #[tokio::test]
@@ -876,10 +887,20 @@ mod tests {
             .physical_plan_as_ascii(query, false)
             .await;
         assert_snapshot!(physical_plan_ascii, @r"
-        HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(RainToday@1, RainToday@1)], projection=[MinTemp@0, MaxTemp@2]
-          CoalescePartitionsExec
-            DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, RainToday], file_type=parquet
-          DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MaxTemp, RainToday], file_type=parquet, predicate=DynamicFilter [ empty ]
+        ┌───── DistributedExec
+        │ CoalescePartitionsExec
+        │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(RainToday@1, RainToday@1)], projection=[MinTemp@0, MaxTemp@2]
+        │     CoalescePartitionsExec
+        │       [Stage 1] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+        │     DistributedLeafExec:
+        │       t0: DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet:<int>..<int>], [/testdata/weather/result-000000.parquet:<int>..<int>, /testdata/weather/result-000001.parquet:<int>..<int>, /testdata/weather/result-000002.parquet:<int>..<int>], [/testdata/weather/result-000002.parquet:<int>..<int>]]}, projection=[MaxTemp, RainToday], file_type=parquet, predicate=DynamicFilter [ empty ]
+        └──────────────────────────────────────────────────
+          ┌───── Stage 1 ── tasks=3, partitions=9
+          │ DistributedLeafExec:
+          │   t0: DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet:<int>..<int>], [/testdata/weather/result-000000.parquet:<int>..<int>, /testdata/weather/result-000001.parquet:<int>..<int>], [/testdata/weather/result-000002.parquet:<int>..<int>]]}, projection=[MinTemp, RainToday], file_type=parquet
+          │   t1: DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet:<int>..<int>], [/testdata/weather/result-000001.parquet:<int>..<int>], [/testdata/weather/result-000002.parquet:<int>..<int>]]}, projection=[MinTemp, RainToday], file_type=parquet
+          │   t2: DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet:<int>..<int>], [/testdata/weather/result-000001.parquet:<int>..<int>, /testdata/weather/result-000002.parquet:<int>..<int>], [/testdata/weather/result-000002.parquet:<int>..<int>]]}, projection=[MinTemp, RainToday], file_type=parquet
+          └──────────────────────────────────────────────────
         ");
 
         let physical_plan_ascii = TestPlanBuilder::default()

--- a/src/distributed_planner/inject_network_boundaries.rs
+++ b/src/distributed_planner/inject_network_boundaries.rs
@@ -232,23 +232,6 @@ async fn _inject_network_boundaries(
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let broadcast_joins_enabled = nb_ctx.d_cfg.broadcast_joins;
 
-    if plan.children().is_empty() {
-        // This is a leaf node, maybe a DataSourceExec, or maybe something else custom from the
-        // user. We need to estimate how many tasks are needed for this leaf node, and we'll take
-        // this decision into account when deciding how many tasks will be actually used.
-        let ev = DesiredTaskCountEvent {
-            plan: &plan,
-            session_config: nb_ctx.cfg,
-        };
-        return if let Some(estimate) = DesiredTaskCountHandlers::handle(ev).await.transpose()? {
-            Ok(nb_ctx.plan_with_task_count(plan, estimate.task_count.limit(nb_ctx.max_tasks()?)))
-        } else {
-            // We could not determine how many tasks this leaf node should run on, so
-            // assume it cannot be distributed and use just 1 task.
-            Ok(nb_ctx.plan_with_task_count(plan, Maximum(1)))
-        };
-    }
-
     let mut futures = Vec::with_capacity(plan.children().len());
     for child in plan.children() {
         let child = Arc::clone(child);
@@ -264,11 +247,17 @@ async fn _inject_network_boundaries(
         plan: &plan,
         session_config: nb_ctx.cfg,
     };
-    let mut task_count = DesiredTaskCountHandlers::handle(ev)
+    let desired_task_count = DesiredTaskCountHandlers::handle(ev)
         .await
         .transpose()?
-        .map_or(Desired(1), |v| v.task_count);
-    if plan.is::<ChildrenIsolatorUnionExec>() {
+        .map(|v| v.task_count);
+
+    let task_count = if plan.children().is_empty() {
+        // This is a leaf node, maybe a DataSourceExec, or maybe something else custom from the user.
+        // If we could not determine how many tasks this leaf node should run on, we need to assume
+        // it cannot be distributed and use just 1 task.
+        desired_task_count.unwrap_or(Maximum(1))
+    } else if plan.is::<ChildrenIsolatorUnionExec>() {
         // Isolating unions have the chance to decide how many tasks they should run on. If there
         // is a union with a bunch of children, the user might want to increase parallelism and the
         // task count for the stage running that.
@@ -276,7 +265,7 @@ async fn _inject_network_boundaries(
         for processed_child in processed_children.iter() {
             count += nb_ctx.task_count(processed_child)?.as_usize();
         }
-        task_count = Desired(count);
+        Desired(count)
     } else if let Some(node) = plan.downcast_ref::<HashJoinExec>()
         && node.mode == PartitionMode::CollectLeft
         && (!broadcast_joins_enabled
@@ -291,7 +280,7 @@ async fn _inject_network_boundaries(
         // by [normalize_collect_joins], so they never reach this arm. `!is_left_broadcast_safe()`
         // captures any remaining types that were not rewritten (for instance, cases where both
         // sides have one output partition).
-        task_count = Maximum(1);
+        Maximum(1)
     } else if let Some(node) = plan.downcast_ref::<NestedLoopJoinExec>()
         && (!broadcast_joins_enabled
             || node.join_type() == &JoinType::Full
@@ -304,13 +293,14 @@ async fn _inject_network_boundaries(
         // to probe-side-emitting ones by [normalize_collect_joins]. `!is_left_broadcast_safe()`
         // captures any remaining types that were not rewritten (for instance, cases where both
         // sides have one output partition).
-        task_count = Maximum(1);
+        Maximum(1)
     } else if plan.is::<CrossJoinExec>() && !broadcast_joins_enabled {
         // A CrossJoin also collects its entire left side in every task. It is always safe to
         // broadcast (it emits only pair rows), so it is only restricted to a single task when
         // broadcasts are unavailable.
-        task_count = Maximum(1);
+        Maximum(1)
     } else {
+        let mut task_count = desired_task_count.unwrap_or(Desired(1));
         // The task count for this plan is decided by the biggest task count from the children; unless
         // a child specifies a maximum task count, in that case, the maximum is respected. Some
         // nodes can only run in one task. If there is a subplan with a single node declaring that
@@ -318,11 +308,12 @@ async fn _inject_network_boundaries(
         for processed_child in processed_children.iter() {
             task_count = task_count.merge(nb_ctx.task_count(processed_child)?)
         }
-    }
+        task_count
+    };
 
     let plan = plan.with_new_children(processed_children)?;
     // Cap the reconciled task count by the configured max-per-stage budget.
-    task_count = task_count.limit(nb_ctx.max_tasks()?);
+    let task_count = task_count.limit(nb_ctx.max_tasks()?);
 
     // Upon reaching a hash repartition, we need to introduce a network shuffle right above it.
     if let Some(r_exec) = plan.downcast_ref::<RepartitionExec>()
@@ -367,11 +358,7 @@ async fn _inject_network_boundaries(
     // If the parent of the current node is either a `CoalescePartitionsExec` or a
     // `SortPreservingMergeExec`, a network boundary below it is necessary.
     else if let Some(parent) = parent
-        // If this node is a leaf node, putting a network boundary above is a bit wasteful, so
-        // we don't want to do it.
-        && !plan.children().is_empty()
-        && (parent.is::<CoalescePartitionsExec>()
-        || parent.is::<SortPreservingMergeExec>())
+        && (parent.is::<CoalescePartitionsExec>() || parent.is::<SortPreservingMergeExec>())
     {
         let input_stage = LocalStage {
             query_id: nb_ctx.query_id,
@@ -706,7 +693,7 @@ mod tests {
             .distributed_planner(false)
             .broadcast_joins(false);
         let annotated = annotate_test_plan(test_plan_builder, query).await;
-        assert_snapshot!(annotated, @"DataSourceExec: task_count=Desired(4)")
+        assert_snapshot!(annotated, @"DistributedLeafExec: task_count=Desired(4)")
     }
 
     #[tokio::test]
@@ -831,7 +818,8 @@ mod tests {
         assert_snapshot!(annotated, @r"
         HashJoinExec: task_count=Maximum(1)
           CoalescePartitionsExec: task_count=Maximum(1)
-            DistributedLeafExec: task_count=Maximum(1)
+            NetworkCoalesceExec: task_count=Maximum(1)
+              DistributedLeafExec: task_count=Desired(4)
           DistributedLeafExec: task_count=Maximum(1)
         ")
     }
@@ -1139,10 +1127,11 @@ mod tests {
             .distributed_planner(false)
             .broadcast_joins(true);
         let annotated = annotate_test_plan(test_plan_builder, query).await;
-        assert_snapshot!(annotated, @"
+        assert_snapshot!(annotated, @r"
         HashJoinExec: task_count=Maximum(1)
           CoalescePartitionsExec: task_count=Maximum(1)
-            DistributedLeafExec: task_count=Maximum(1)
+            NetworkCoalesceExec: task_count=Maximum(1)
+              DistributedLeafExec: task_count=Desired(4)
           DistributedLeafExec: task_count=Maximum(1)
         ");
     }
@@ -1190,10 +1179,11 @@ mod tests {
             .distributed_planner(false)
             .broadcast_joins(true);
         let annotated = annotate_test_plan(test_plan_builder, query).await;
-        assert_snapshot!(annotated, @"
+        assert_snapshot!(annotated, @r"
         NestedLoopJoinExec: task_count=Maximum(1)
           CoalescePartitionsExec: task_count=Maximum(1)
-            DistributedLeafExec: task_count=Maximum(1)
+            NetworkCoalesceExec: task_count=Maximum(1)
+              DistributedLeafExec: task_count=Desired(4)
           DistributedLeafExec: task_count=Maximum(1)
         ");
     }
@@ -1213,10 +1203,11 @@ mod tests {
             .distributed_planner(false)
             .broadcast_joins(false);
         let annotated = annotate_test_plan(test_plan_builder, query).await;
-        assert_snapshot!(annotated, @"
+        assert_snapshot!(annotated, @r"
         CrossJoinExec: task_count=Maximum(1)
           CoalescePartitionsExec: task_count=Maximum(1)
-            DistributedLeafExec: task_count=Maximum(1)
+            NetworkCoalesceExec: task_count=Maximum(1)
+              DistributedLeafExec: task_count=Desired(4)
           DistributedLeafExec: task_count=Maximum(1)
         ");
     }
@@ -1240,7 +1231,8 @@ mod tests {
         assert_snapshot!(annotated, @r"
         HashJoinExec: task_count=Maximum(1)
           CoalescePartitionsExec: task_count=Maximum(1)
-            DistributedLeafExec: task_count=Maximum(1)
+            NetworkCoalesceExec: task_count=Maximum(1)
+              DistributedLeafExec: task_count=Desired(4)
           DistributedLeafExec: task_count=Maximum(1)
         ")
     }

--- a/src/distributed_planner/insert_broadcast.rs
+++ b/src/distributed_planner/insert_broadcast.rs
@@ -195,10 +195,13 @@ mod tests {
             .physical_plan_as_string(query)
             .await;
         assert_snapshot!(physical_plan_string, @r"
-        HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(RainToday@1, RainToday@1)], projection=[MinTemp@0, MaxTemp@2]
+        DistributedExec
           CoalescePartitionsExec
-            DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, RainToday], file_type=parquet
-          DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MaxTemp, RainToday], file_type=parquet, predicate=DynamicFilter [ empty ]
+            HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(RainToday@1, RainToday@1)], projection=[MinTemp@0, MaxTemp@2]
+              CoalescePartitionsExec
+                [Stage 1] => NetworkCoalesceExec: output_partitions=12, input_tasks=4
+                  DistributedLeafExec: DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, RainToday], file_type=parquet
+              DistributedLeafExec: DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MaxTemp, RainToday], file_type=parquet, predicate=DynamicFilter [ empty ]
         ");
         let plan = sql_to_plan_with_broadcast(query, true, 4).await;
         assert_snapshot!(plan, @r"

--- a/tests/multi_task_collect_join_repros.rs
+++ b/tests/multi_task_collect_join_repros.rs
@@ -99,11 +99,22 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_snapshot!(display_plan_ascii(plan.as_ref(), false), @"
-        HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@0, id@0)]
-          CoalescePartitionsExec
-            DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet, /target/multi_task_collect_join_repros/build_side/part-1.parquet], [/target/multi_task_collect_join_repros/build_side/part-2.parquet, /target/multi_task_collect_join_repros/build_side/part-3.parquet]]}, projection=[id], file_type=parquet
-          DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/probe_side/part-0.parquet, /target/multi_task_collect_join_repros/probe_side/part-1.parquet], [/target/multi_task_collect_join_repros/probe_side/part-2.parquet, /target/multi_task_collect_join_repros/probe_side/part-3.parquet]]}, projection=[id], file_type=parquet, predicate=DynamicFilter [ id@0 >= 0 AND id@0 <= 99 AND id@0 IN (SET) ([<values>]) ], pruning_predicate=id_null_count@1 != row_count@2 AND id_max@0 >= 0 AND id_null_count@1 != row_count@2 AND id_min@3 <= 99, required_guarantees=[id in (0, 1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 2, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 3, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 4, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 5, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 6, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 7, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 8, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 9, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99)]
+        assert_snapshot!(display_plan_ascii(plan.as_ref(), false), @r"
+        ┌───── DistributedExec
+        │ CoalescePartitionsExec
+        │   HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@0, id@0)]
+        │     CoalescePartitionsExec
+        │       [Stage 1] => NetworkCoalesceExec: output_partitions=8, input_tasks=4
+        │     DistributedLeafExec:
+        │       t0: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/probe_side/part-0.parquet:<int>..<int>, /target/multi_task_collect_join_repros/probe_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/probe_side/part-2.parquet:<int>..<int>, /target/multi_task_collect_join_repros/probe_side/part-3.parquet:<int>..<int>]]}, projection=[id], file_type=parquet, predicate=DynamicFilter [ id@0 >= 0 AND id@0 <= 99 AND id@0 IN (SET) ([<values>]) ], pruning_predicate=id_null_count@1 != row_count@2 AND id_max@0 >= 0 AND id_null_count@1 != row_count@2 AND id_min@3 <= 99, required_guarantees=[id in (0, 1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 2, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 3, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 4, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 5, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 6, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 7, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 8, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 9, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99)]
+        └──────────────────────────────────────────────────
+          ┌───── Stage 1 ── tasks=4, partitions=8
+          │ DistributedLeafExec:
+          │   t0: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>]]}, projection=[id], file_type=parquet
+          │   t1: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet:<int>..<int>, /target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>, /target/multi_task_collect_join_repros/build_side/part-3.parquet:<int>..<int>]]}, projection=[id], file_type=parquet
+          │   t2: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-3.parquet:<int>..<int>]]}, projection=[id], file_type=parquet
+          │   t3: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>, /target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-3.parquet:<int>..<int>]]}, projection=[id], file_type=parquet
+          └──────────────────────────────────────────────────
         ")
     }
 
@@ -220,16 +231,26 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_snapshot!(display_plan_ascii(plan.as_ref(), false), @"
-        ProjectionExec: expr=[sum(b.id + p.id)@0 as pair_sum]
-          AggregateExec: mode=Final, gby=[], aggr=[sum(b.id + p.id)]
-            CoalescePartitionsExec
-              AggregateExec: mode=Partial, gby=[], aggr=[sum(b.id + p.id)]
-                RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
-                  CrossJoinExec
-                    CoalescePartitionsExec
-                      DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet, /target/multi_task_collect_join_repros/build_side/part-1.parquet], [/target/multi_task_collect_join_repros/build_side/part-2.parquet, /target/multi_task_collect_join_repros/build_side/part-3.parquet]]}, projection=[id], file_type=parquet
-                    DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/probe_side/part-0.parquet, /target/multi_task_collect_join_repros/probe_side/part-1.parquet], [/target/multi_task_collect_join_repros/probe_side/part-2.parquet, /target/multi_task_collect_join_repros/probe_side/part-3.parquet]]}, projection=[id], file_type=parquet
+        assert_snapshot!(display_plan_ascii(plan.as_ref(), false), @r"
+        ┌───── DistributedExec
+        │ ProjectionExec: expr=[sum(b.id + p.id)@0 as pair_sum]
+        │   AggregateExec: mode=Final, gby=[], aggr=[sum(b.id + p.id)]
+        │     CoalescePartitionsExec
+        │       AggregateExec: mode=Partial, gby=[], aggr=[sum(b.id + p.id)]
+        │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+        │           CrossJoinExec
+        │             CoalescePartitionsExec
+        │               [Stage 1] => NetworkCoalesceExec: output_partitions=8, input_tasks=4
+        │             DistributedLeafExec:
+        │               t0: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/probe_side/part-0.parquet:<int>..<int>, /target/multi_task_collect_join_repros/probe_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/probe_side/part-2.parquet:<int>..<int>, /target/multi_task_collect_join_repros/probe_side/part-3.parquet:<int>..<int>]]}, projection=[id], file_type=parquet
+        └──────────────────────────────────────────────────
+          ┌───── Stage 1 ── tasks=4, partitions=8
+          │ DistributedLeafExec:
+          │   t0: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>]]}, projection=[id], file_type=parquet
+          │   t1: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/build_side/part-0.parquet:<int>..<int>, /target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>, /target/multi_task_collect_join_repros/build_side/part-3.parquet:<int>..<int>]]}, projection=[id], file_type=parquet
+          │   t2: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-3.parquet:<int>..<int>]]}, projection=[id], file_type=parquet
+          │   t3: DataSourceExec: file_groups={2 groups: [[/target/multi_task_collect_join_repros/build_side/part-1.parquet:<int>..<int>, /target/multi_task_collect_join_repros/build_side/part-2.parquet:<int>..<int>], [/target/multi_task_collect_join_repros/build_side/part-3.parquet:<int>..<int>]]}, projection=[id], file_type=parquet
+          └──────────────────────────────────────────────────
         ")
     }
 


### PR DESCRIPTION
Previously, there was one special-case in the planner about the presence of `CoalescePartitionsExec`:

If there was a `CoalescePartitionExec` about a leaf node, this one is ignored, and is not elegible to accompanied into a `NetworkCoalesceExec`.

This decision was taken very early in the development of this project, where there was no good mechanism for selecting the right level of parallelism in leaf nodes, but this changed a while ago, and this special-case is no longer useful.

This special-case might actually translate into incorrect results in very specific situations, like when there's a broadcast join with a `fetch` value on the probe side: we need the `CoalescePartitionsExec` present above the node to introduce a `NetworkCoalesceExec` that collapses the broadcast to 1 task, otherwise the `fetch` will not be respected, as it'll be local to all N tasks, yielding `N * fetch` rows, and not the intended `fetch`.

This is something that can actually be seen here:
https://github.com/datafusion-contrib/datafusion-distributed/pull/624#discussion_r3782458181