### PR TITLE
Add in-process worker implementation

### DIFF
--- a/src/coordinator/query_coordinator.rs
+++ b/src/coordinator/query_coordinator.rs
@@ -9,9 +9,10 @@ use crate::stage::LocalStage;
 use crate::work_unit_feed::WorkUnitFeedRegistry;
 use crate::work_unit_feed::{build_work_unit_batch_msg, set_work_unit_send_time};
 use crate::{
-    CoordinatorToWorkerMsg, DISTRIBUTED_DATAFUSION_TASK_ID_LABEL, DistributedTaskContext,
-    DistributedWorkUnitFeedContext, LoadInfo, MaybeEncoded, SetPlanRequest, TaskKey,
-    WorkUnitFeedDeclaration, WorkerToCoordinatorMsg, get_distributed_channel_resolver,
+    CoordinatorToWorkerMsg, DISTRIBUTED_DATAFUSION_TASK_ID_LABEL, DistributedCodec,
+    DistributedTaskContext, DistributedWorkUnitFeedContext, LoadInfo, LocalWorkerContext,
+    MaybeEncoded, SetPlanRequest, TaskKey, WorkUnitFeedDeclaration, WorkerToCoordinatorMsg,
+    get_distributed_channel_resolver,
 };
 use datafusion::common::DataFusionError;
 use datafusion::common::instant::Instant;
@@ -21,7 +22,10 @@ use datafusion::common::{Result, exec_err};
 use datafusion::execution::TaskContext;
 use datafusion::physical_expr_common::metrics::{ExecutionPlanMetricsSet, Label, MetricBuilder};
 use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::metrics::Count;
 use datafusion::prelude::SessionConfig;
+use datafusion_proto::physical_plan::{AsExecutionPlan, DefaultPhysicalProtoConverter};
+use datafusion_proto::protobuf;
 use futures::{Stream, StreamExt, TryStreamExt};
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex};
@@ -163,8 +167,6 @@ impl<'a> StageCoordinator<'a> {
         let (worker_to_coordinator_tx, worker_to_coordinator_rx) =
             tokio::sync::mpsc::unbounded_channel();
 
-        let channel_resolver = get_distributed_channel_resolver(self.task_ctx.as_ref());
-
         let mut headers = get_config_extension_propagation_headers(session_config)?;
         headers.extend(get_passthrough_headers(session_config));
 
@@ -189,7 +191,18 @@ impl<'a> StageCoordinator<'a> {
 
         self.join_set.lock().unwrap().spawn(async move {
             let start = Instant::now();
-            let mut client = channel_resolver.get_worker_client_for_url(&url).await?;
+
+            let mut client = match LocalWorkerContext::from_ctx(&task_ctx) {
+                Some(lw) if lw.self_url == url => {
+                    metrics.local_coordinator_channels.add(1);
+                    Ok(lw.to_worker_channel())
+                }
+                _ => {
+                    metrics.remote_coordinator_channels.add(1);
+                    let ch_resolver = get_distributed_channel_resolver(task_ctx.as_ref());
+                    ch_resolver.get_worker_client_for_url(&url).await
+                }
+            }?;
             let mut worker_to_coordinator_stream = client
                 .coordinator_channel(
                     headers,
@@ -352,6 +365,16 @@ impl<'a> StageCoordinator<'a> {
                     id: wuf.id(),
                     partitions: plan.properties().partitioning.partition_count(),
                 });
+
+                // WorkUnitFeeds are transitioned to remote mode during proto conversion.
+                // Right now, there's no other way for a WorkUnitFeed to be transitioned to
+                // remote mode so that it can pull WorkUnits over the WorkerChannel.
+                //
+                // Doing this roundtrip here is not super clean, but it actually does the trick in
+                // very few LOC, and performance overhead is negligible, as the roundtrip does not
+                // even imply serialization.
+                let plan = roundtrip_pb(plan, self.task_ctx)?;
+                return Ok(Transformed::yes(plan));
             };
 
             if let Some(ciu) = plan.downcast_ref::<ChildrenIsolatorUnionExec>() {
@@ -395,6 +418,21 @@ impl<'a> StageCoordinator<'a> {
     }
 }
 
+/// Round-trips a plan converting it to a protobuf message and back to an [ExecutionPlan].
+fn roundtrip_pb(
+    plan: Arc<dyn ExecutionPlan>,
+    ctx: &Arc<TaskContext>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let codec = DistributedCodec::new_combined_with_user(ctx.session_config());
+
+    protobuf::PhysicalPlanNode::try_from_physical_plan_with_converter(
+        plan,
+        &codec,
+        &DefaultPhysicalProtoConverter {},
+    )?
+    .try_into_physical_plan(ctx, &codec)
+}
+
 fn keep_stream_alive<T: 'static>(notify: Arc<Notify>) -> impl Stream<Item = T> + 'static {
     futures::stream::once(notify.notified_owned()).filter_map(|()| futures::future::ready(None))
 }
@@ -410,6 +448,8 @@ impl Drop for NotifyGuard {
 /// Metrics that measure network details about communications between [DistributedExec] and a worker.
 #[derive(Clone)]
 pub(super) struct CoordinatorToWorkerMetrics {
+    pub(super) local_coordinator_channels: Count,
+    pub(super) remote_coordinator_channels: Count,
     pub(super) plan_send_latency: Arc<LatencyMetric>,
     pub(super) instantiation_time: usize,
 }
@@ -424,6 +464,10 @@ fn with_task_id_label(builder: MetricBuilder) -> MetricBuilder {
 impl CoordinatorToWorkerMetrics {
     pub(super) fn new(metrics: &ExecutionPlanMetricsSet) -> Self {
         Self {
+            local_coordinator_channels: MetricBuilder::new(metrics)
+                .global_counter("local_coordinator_channels"),
+            remote_coordinator_channels: MetricBuilder::new(metrics)
+                .global_counter("remote_coordinator_channels"),
             // Latency statistics about the network calls issued to the workers for feeding subplans.
             plan_send_latency: Arc::new(LatencyMetric::new(
                 "plan_send_latency",

--- a/src/execution_plans/metrics.rs
+++ b/src/execution_plans/metrics.rs
@@ -76,9 +76,27 @@ impl ExecutionPlan for MetricsWrapperExec {
     fn metrics(&self) -> Option<MetricsSet> {
         match self.inner.metrics() {
             None => Some(self.metrics.clone()),
-            Some(mut all_metrics) => {
-                for wrapped in self.metrics.iter() {
-                    all_metrics.push(Arc::clone(wrapped));
+            Some(local_metrics) => {
+                let mut all_metrics = self.metrics.clone();
+
+                for local_metric in local_metrics {
+                    // When a node is executed in an in-process worker, the ExecutionPlan might not
+                    // have suffered any [de]serialization. This means that execution metrics
+                    // collected at runtime in the Worker will be automatically visible in the
+                    // coordinator, as both happen to run in-process, and therefore, the pointer
+                    // that holds the ExecutionPlan MetricsSet is the same.
+                    //
+                    // This means that we need to dedupe the metrics here, otherwise, we might
+                    // double-count metrics:
+                    // 1. What was collected in the local worker
+                    // 2. What is automatically available in the coordiantor because of pointer
+                    //    equivalence.
+                    if !self.metrics.iter().any(|wrapped| {
+                        wrapped.value() == local_metric.value()
+                            && wrapped.partition() == local_metric.partition()
+                    }) {
+                        all_metrics.push(local_metric);
+                    }
                 }
                 Some(all_metrics)
             }

--- a/src/execution_plans/metrics.rs
+++ b/src/execution_plans/metrics.rs
@@ -89,7 +89,7 @@ impl ExecutionPlan for MetricsWrapperExec {
                     // This means that we need to dedupe the metrics here, otherwise, we might
                     // double-count metrics:
                     // 1. What was collected in the local worker
-                    // 2. What is automatically available in the coordiantor because of pointer
+                    // 2. What is automatically available in the coordinator because of pointer
                     //    equivalence.
                     if !self.metrics.iter().any(|wrapped| {
                         wrapped.value() == local_metric.value()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub use metrics::{
     MaxLatencyMetric, MinLatencyMetric, P50LatencyMetric, P75LatencyMetric, P95LatencyMetric,
     P99LatencyMetric, rewrite_distributed_plan_with_metrics,
 };
-pub use worker::LocalWorkerContext;
+pub use protocol::LocalWorkerContext;
 
 mod events;
 #[cfg(any(feature = "integration", test))]

--- a/src/protocol/in_process/local_worker_context.rs
+++ b/src/protocol/in_process/local_worker_context.rs
@@ -1,0 +1,28 @@
+use crate::protocol::in_process::InProcessWorkerClient;
+use crate::{Worker, WorkerChannel};
+use datafusion::execution::TaskContext;
+use std::sync::Arc;
+use url::Url;
+
+/// Context injected to the [TaskContext] extensions that provides information about the presence
+/// of a [Worker] locally.
+///
+/// This information can be used for executing tasks locally bypassing remote comms if the tasks
+/// that needs to be remotely executed happens to be owned by this same worker.
+pub struct LocalWorkerContext {
+    /// The registry of in-flight tasks the [Worker] in the current scope owns.
+    pub(crate) local_worker: Worker,
+    /// The URL of the [Worker] in scope. When trying to reach to a target URL that happens
+    /// to be the same as this one, local comms are preferred instead.
+    pub(crate) self_url: Url,
+}
+
+impl LocalWorkerContext {
+    pub(crate) fn from_ctx(ctx: &Arc<TaskContext>) -> Option<Arc<Self>> {
+        ctx.session_config().get_extension::<Self>()
+    }
+
+    pub(crate) fn to_worker_channel(&self) -> Box<dyn WorkerChannel> {
+        Box::new(InProcessWorkerClient::new(self.local_worker.clone()))
+    }
+}

--- a/src/protocol/in_process/local_worker_context.rs
+++ b/src/protocol/in_process/local_worker_context.rs
@@ -4,13 +4,14 @@ use datafusion::execution::TaskContext;
 use std::sync::Arc;
 use url::Url;
 
-/// Context injected to the [TaskContext] extensions that provides information about the presence
-/// of a [Worker] locally.
+/// Context injected to the [datafusion::prelude::SessionConfig] extensions that provides
+/// information about the presence of a [Worker] locally.
 ///
 /// This information can be used for executing tasks locally bypassing remote comms if the tasks
 /// that needs to be remotely executed happens to be owned by this same worker.
 pub struct LocalWorkerContext {
-    /// The registry of in-flight tasks the [Worker] in the current scope owns.
+    /// The [Worker] present in the current process, and ready answer to [WorkerChannel] method
+    /// invocations locally.
     pub(crate) local_worker: Worker,
     /// The URL of the [Worker] in scope. When trying to reach to a target URL that happens
     /// to be the same as this one, local comms are preferred instead.

--- a/src/protocol/in_process/mod.rs
+++ b/src/protocol/in_process/mod.rs
@@ -1,0 +1,5 @@
+mod local_worker_context;
+mod worker_client;
+
+pub use local_worker_context::LocalWorkerContext;
+pub(crate) use worker_client::InProcessWorkerClient;

--- a/src/protocol/in_process/worker_client.rs
+++ b/src/protocol/in_process/worker_client.rs
@@ -1,0 +1,62 @@
+use crate::{
+    CoordinatorToWorkerMsg, ExecuteTaskRequest, GetWorkerInfoRequest, GetWorkerInfoResponse,
+    SetPlanRequest, Worker, WorkerChannel, WorkerToCoordinatorMsg,
+};
+use async_trait::async_trait;
+use datafusion::arrow::array::RecordBatch;
+use datafusion::common::Result;
+use datafusion::execution::TaskContext;
+use datafusion::physical_expr_common::metrics::ExecutionPlanMetricsSet;
+use futures::StreamExt;
+use futures::stream::BoxStream;
+use http::HeaderMap;
+use std::sync::Arc;
+
+/// [WorkerChannel] that proxies method invocations to a local [Worker] referenced as a field.
+pub(crate) struct InProcessWorkerClient {
+    local_worker: Worker,
+}
+
+impl InProcessWorkerClient {
+    /// Builds a new [InProcessWorkerClient] that will proxy request to the provided [Worker],
+    /// avoiding any serde on the inputs or outputs.
+    pub(crate) fn new(local_worker: Worker) -> Self {
+        Self { local_worker }
+    }
+}
+
+#[async_trait]
+impl WorkerChannel for InProcessWorkerClient {
+    async fn coordinator_channel(
+        &mut self,
+        headers: HeaderMap,
+        set_plan_request: SetPlanRequest,
+        c2w_stream: BoxStream<'static, CoordinatorToWorkerMsg>,
+        _metrics: ExecutionPlanMetricsSet,
+        _task_ctx: &Arc<TaskContext>,
+    ) -> Result<BoxStream<'static, Result<WorkerToCoordinatorMsg>>> {
+        self.local_worker
+            .coordinator_channel(headers, set_plan_request, c2w_stream.map(Ok).boxed())
+            .await
+    }
+
+    async fn execute_task(
+        &mut self,
+        _headers: HeaderMap,
+        request: ExecuteTaskRequest,
+        _metrics: ExecutionPlanMetricsSet,
+        _task_ctx: &Arc<TaskContext>,
+    ) -> Result<Vec<BoxStream<'static, Result<RecordBatch>>>> {
+        let (result, _) = self.local_worker.execute_task(request).await?;
+        Ok(result.into_iter().map(|v| v.boxed()).collect())
+    }
+
+    async fn get_worker_info(
+        &mut self,
+        _request: GetWorkerInfoRequest,
+    ) -> Result<GetWorkerInfoResponse> {
+        Ok(GetWorkerInfoResponse {
+            version: self.local_worker.version().to_string(),
+        })
+    }
+}

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -2,11 +2,13 @@
 pub mod grpc;
 
 mod channel_resolver;
+mod in_process;
 mod worker_channel;
 
 pub(crate) use channel_resolver::set_distributed_channel_resolver;
-pub use channel_resolver::{ChannelResolver, get_distributed_channel_resolver};
 
+pub use channel_resolver::{ChannelResolver, get_distributed_channel_resolver};
+pub use in_process::LocalWorkerContext;
 pub use worker_channel::{
     CoordinatorToWorkerMsg, ExecuteTaskRequest, GetWorkerInfoRequest, GetWorkerInfoResponse,
     LoadInfo, SetPlanRequest, TaskKey, TaskMetrics, WorkUnitBatch, WorkUnitFeedDeclaration,

--- a/src/test_utils/localhost.rs
+++ b/src/test_utils/localhost.rs
@@ -61,7 +61,7 @@ where
         });
     }
     tokio::time::sleep(Duration::from_millis(100)).await;
-    let first_worker_url = Url::parse(&format!("http://127.0.0.1:{}", ports[0])).unwrap();
+    let first_worker_url = Url::parse(&format!("http://localhost:{}", ports[0])).unwrap();
 
     let worker_resolver = LocalHostWorkerResolver::new(ports);
     let state = SessionStateBuilder::new()

--- a/src/test_utils/routing.rs
+++ b/src/test_utils/routing.rs
@@ -20,11 +20,10 @@ use prost::Message;
 use std::{fmt::Formatter, sync::Arc};
 use tonic::async_trait;
 
-use crate::execution_plans::DistributedLeafExec;
-use crate::worker::LocalWorkerContext;
 use crate::{
-    DesiredTaskCountEvent, DesiredTaskCountEventResponse, DistributedTaskContext, RouteTasksEvent,
-    RouteTasksEventResponse, ScaleUpLeafNodeEvent, ScaleUpLeafNodeEventResponse, WorkerResolver,
+    DesiredTaskCountEvent, DesiredTaskCountEventResponse, DistributedLeafExec,
+    DistributedTaskContext, LocalWorkerContext, RouteTasksEvent, RouteTasksEventResponse,
+    ScaleUpLeafNodeEvent, ScaleUpLeafNodeEventResponse, WorkerResolver,
 };
 
 use crate::distributed_ext::DistributedGetterExt;

--- a/src/worker/impl_coordinator_channel.rs
+++ b/src/worker/impl_coordinator_channel.rs
@@ -1,8 +1,8 @@
 use crate::common::TreeNodeExt;
 use crate::events::{WorkerPlanRewriteEvent, WorkerPlanRewriteHandlers};
 use crate::execution_plans::SamplerExec;
+use crate::protocol::LocalWorkerContext;
 use crate::work_unit_feed::{RemoteWorkUnitFeedRegistry, set_work_unit_received_time};
-use crate::worker::LocalWorkerContext;
 use crate::worker::task_data::TaskDataMetrics;
 use crate::{
     CoordinatorToWorkerMsg, DistributedConfig, DistributedExt, DistributedTaskContext,
@@ -50,7 +50,7 @@ impl Worker {
                     task_count: request.task_count,
                 }))
                 .with_extension(Arc::new(LocalWorkerContext {
-                    task_data_entries: Arc::clone(&self.task_data_entries),
+                    local_worker: self.clone(),
                     self_url: request.target_worker_url,
                 }))
                 .with_distributed_option_extension_from_headers::<DistributedConfig>(&headers)?;

--- a/src/worker/impl_execute_task.rs
+++ b/src/worker/impl_execute_task.rs
@@ -1,5 +1,5 @@
 use crate::ExecuteTaskRequest;
-use crate::worker::worker_service::{TaskDataEntries, Worker};
+use crate::worker::worker_service::Worker;
 use datafusion::common::exec_datafusion_err;
 use datafusion::common::{Result, exec_err};
 use datafusion::error::DataFusionError;
@@ -20,14 +20,8 @@ impl Worker {
         &self,
         request: ExecuteTaskRequest,
     ) -> Result<(Vec<SendableRecordBatchStream>, Arc<TaskContext>)> {
-        Self::execute_task_static(Arc::clone(&self.task_data_entries), request).await
-    }
-
-    pub(crate) async fn execute_task_static(
-        task_data_entries: Arc<TaskDataEntries>,
-        request: ExecuteTaskRequest,
-    ) -> Result<(Vec<SendableRecordBatchStream>, Arc<TaskContext>)> {
-        let entry = task_data_entries
+        let entry = self
+            .task_data_entries
             .get_with(request.task_key, async { Default::default() })
             .await;
 

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -16,5 +16,4 @@ pub use session_builder::{
     WorkerQueryContext, WorkerSessionBuilder,
 };
 pub use task_data::TaskData;
-pub use worker_connection_pool::LocalWorkerContext;
 pub use worker_service::Worker;

--- a/src/worker/worker_connection_pool.rs
+++ b/src/worker/worker_connection_pool.rs
@@ -1,10 +1,7 @@
 use crate::distributed_planner::ProducerHead;
 use crate::passthrough_headers::get_passthrough_headers;
 use crate::stage::RemoteStage;
-use crate::worker::worker_service::TaskDataEntries;
-use crate::{
-    ChannelResolver, ExecuteTaskRequest, TaskKey, Worker, get_distributed_channel_resolver,
-};
+use crate::{ExecuteTaskRequest, LocalWorkerContext, TaskKey, get_distributed_channel_resolver};
 use datafusion::arrow::array::RecordBatch;
 use datafusion::common::runtime::SpawnedTask;
 use datafusion::common::{DataFusionError, Result, internal_datafusion_err, internal_err};
@@ -17,21 +14,6 @@ use futures::{FutureExt, StreamExt, TryFutureExt, TryStreamExt};
 use std::fmt::{Debug, Formatter};
 use std::ops::Range;
 use std::sync::{Arc, Mutex, OnceLock};
-use url::Url;
-
-/// Context set by [crate::Worker::coordinator_channel] in DataFusion's
-/// [datafusion::prelude::SessionConfig] that contains information about the local tasks the current
-/// [crate::Worker] owns.
-///
-/// This information can be used for executing tasks locally bypassing gRPC comms if the tasks that
-/// needs to be remotely executed happens to be owned by this same worker.
-pub struct LocalWorkerContext {
-    /// The registry of in-flight tasks the [crate::Worker] in the current scope owns.
-    pub(crate) task_data_entries: Arc<TaskDataEntries>,
-    /// The URL of the [crate::Worker] in scope. When trying to reach to a target URL that happens
-    /// to be the same as this one, local comms are preferred instead.
-    pub(crate) self_url: Url,
-}
 
 /// Manages connections to remote workers.
 /// - Handles a range of partitions at a time in other to give the chance to [crate::WorkerChannel]
@@ -70,8 +52,6 @@ impl WorkerConnectionPool {
         producer_head: ProducerHead,
         ctx: &Arc<TaskContext>,
     ) -> Result<BoxStream<'static, Result<RecordBatch>>> {
-        let ch_resolver = get_distributed_channel_resolver(ctx.as_ref());
-
         let Some(target_url) = input_stage.workers.get(target_task).cloned() else {
             internal_err!("input_stage.workers[{target_task}] out of range.")?
         };
@@ -80,25 +60,10 @@ impl WorkerConnectionPool {
             stage_id: input_stage.num,
             task_number: target_task,
         };
-        let output_bytes = MetricBuilder::new(&self.metrics).output_bytes(target_partition);
-        let output_rows = MetricBuilder::new(&self.metrics).output_rows(target_partition);
-
-        // If we are physically in the same worker, short circuit into a local connection without
-        // going through the `WorkerChannel`.
-        if let Some(result) = self.local_stream_short_circuit(
-            task_key,
-            target_partition,
-            &target_url,
-            producer_head.clone(),
-            ctx,
-        )? {
-            return Ok(result
-                .inspect_ok(move |batch| {
-                    output_bytes.add(logical_record_batch_size(batch));
-                    output_rows.add(batch.num_rows());
-                })
-                .boxed());
-        }
+        let bdr = || MetricBuilder::new(&self.metrics);
+        let output_bytes = bdr().output_bytes(target_partition);
+        let output_rows = bdr().output_rows(target_partition);
+        let local_connections_used = bdr().global_counter("local_connections_used");
 
         // Otherwise, we need to reach the remote worker through the `WorkerChannel`. Unlike local
         // connections, these remote connections span a range of partitions so that `WorkerChannel`
@@ -127,7 +92,16 @@ impl WorkerConnectionPool {
                     target_partition_end: target_partitions.end,
                     producer_head,
                 };
-                let mut client = ch_resolver.get_worker_client_for_url(&target_url).await?;
+                let mut client = match LocalWorkerContext::from_ctx(&ctx) {
+                    Some(lw) if lw.self_url == target_url => {
+                        local_connections_used.add(1);
+                        Ok(lw.to_worker_channel())
+                    }
+                    _ => {
+                        let ch_resolver = get_distributed_channel_resolver(ctx.as_ref());
+                        ch_resolver.get_worker_client_for_url(&target_url).await
+                    }
+                }?;
                 let headers = get_passthrough_headers(ctx.session_config());
                 let streams = client.execute_task(headers, request, metrics, &ctx).await?;
                 Ok(streams)
@@ -168,62 +142,6 @@ impl WorkerConnectionPool {
             output_rows.add(batch.num_rows());
         })
         .boxed())
-    }
-
-    fn local_stream_short_circuit(
-        &self,
-        task_key: TaskKey,
-        target_partition: usize,
-        target_url: &Url,
-        producer_head: ProducerHead,
-        ctx: &Arc<TaskContext>,
-    ) -> Result<Option<BoxStream<'static, Result<RecordBatch>>>> {
-        let Some(task_data_entries) = ctx
-            .session_config()
-            .get_extension::<LocalWorkerContext>()
-            .and_then(|lw_ctx| match &lw_ctx.self_url == target_url {
-                true => Some(Arc::clone(&lw_ctx.task_data_entries)),
-                false => None,
-            })
-        else {
-            return Ok(None);
-        };
-
-        MetricBuilder::new(&self.metrics)
-            .global_counter("local_connections_used")
-            .add(1);
-        let request = ExecuteTaskRequest {
-            task_key,
-            target_partition_start: target_partition,
-            target_partition_end: target_partition + 1,
-            producer_head,
-        };
-        // The relevant entry from `task_data_entries` needs to be eagerly retrieved, it cannot be
-        // left for until someone decides to start polling the returned `BoxStream`, otherwise,
-        // there's risk that the entry is evicted by Moka's TTL, and by the time the returned stream
-        // is polled, the entry might not be there.
-        //
-        // Note that this does not start polling the returned streams, it just instantiates them.
-        let stream_task = SpawnedTask::spawn(async move {
-            let (mut streams, _) = Worker::execute_task_static(task_data_entries, request).await?;
-            if streams.len() != 1 {
-                return internal_err!(
-                    "Expected exactly 1 stream out of Worker::execute_task_static, but got {}",
-                    streams.len()
-                );
-            }
-            Ok::<_, DataFusionError>(streams.swap_remove(0))
-        });
-
-        Ok(Some(
-            async move {
-                stream_task
-                    .await
-                    .map_err(|err| internal_datafusion_err!("{err}"))?
-            }
-            .try_flatten_stream()
-            .boxed(),
-        ))
     }
 }
 

--- a/src/worker/worker_service.rs
+++ b/src/worker/worker_service.rs
@@ -1,4 +1,5 @@
-use crate::worker::{LocalWorkerContext, SingleWriteMultiRead, WorkerSessionBuilder};
+use crate::protocol::LocalWorkerContext;
+use crate::worker::{SingleWriteMultiRead, WorkerSessionBuilder};
 use crate::{DefaultSessionBuilder, TaskData, TaskKey};
 use datafusion::common::DataFusionError;
 use datafusion::execution::runtime_env::RuntimeEnv;
@@ -89,7 +90,7 @@ impl Worker {
     /// unnecessary network hops.
     pub fn to_local_worker_context(&self, self_url: Url) -> LocalWorkerContext {
         LocalWorkerContext {
-            task_data_entries: Arc::clone(&self.task_data_entries),
+            local_worker: self.clone(),
             self_url,
         }
     }

--- a/tests/local_connections.rs
+++ b/tests/local_connections.rs
@@ -48,4 +48,74 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn half_coordinator_connections_are_local() -> Result<(), Box<dyn std::error::Error>> {
+        let (ctx, _guard, _) = start_localhost_context(2, DefaultSessionBuilder).await;
+        register_parquet_tables(&ctx).await?;
+
+        let query =
+            r#"SELECT count(*), "RainToday" FROM weather GROUP BY "RainToday" ORDER BY count(*)"#;
+
+        let plan = ctx.sql(query).await?.create_physical_plan().await?;
+        collect(Arc::clone(&plan), ctx.task_ctx()).await?;
+
+        let metrics = plan.metrics().expect("DistributedExec has metrics");
+        let metric_value = |name| {
+            metrics
+                .sum(|metric| metric.value().name() == name)
+                .map(|metric| metric.as_usize())
+                .unwrap_or_default()
+        };
+
+        // The plan above has two stages, with two tasks each, so 4 tasks in total. Assuming the
+        // coordinator is the worker 0, the coordinator->worker channels are the following:
+        // - coordinator worker 0 -> stage 0, worker 0 | local
+        // - coordinator worker 0 -> stage 0, worker 1 | remote
+        // - coordinator worker 0 -> stage 1, worker 0 | local
+        // - coordinator worker 0 -> stage 1, worker 1 | remote
+        assert_eq!(metric_value("local_coordinator_channels"), 2);
+        assert_eq!(metric_value("remote_coordinator_channels"), 2);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn network_boundaries_use_local_connections() -> Result<(), Box<dyn std::error::Error>> {
+        let (ctx, _guard, _) = start_localhost_context(2, DefaultSessionBuilder).await;
+        register_parquet_tables(&ctx).await?;
+
+        let query =
+            r#"SELECT count(*), "RainToday" FROM weather GROUP BY "RainToday" ORDER BY count(*)"#;
+
+        let plan = ctx.sql(query).await?.create_physical_plan().await?;
+        collect(Arc::clone(&plan), ctx.task_ctx()).await?;
+        let plan =
+            rewrite_distributed_plan_with_metrics(plan, DistributedMetricsFormat::Aggregated)
+                .await?;
+
+        let mut local_connections_used = 0;
+        plan.apply(|node| {
+            if node.is_network_boundary() {
+                local_connections_used += node
+                    .metrics()
+                    .unwrap_or_default()
+                    .sum(|metric| metric.value().name() == "local_connections_used")
+                    .map_or(0, |metric| metric.as_usize());
+            }
+            Ok(TreeNodeRecursion::Continue)
+        })?;
+
+        // The plan above has two stages, with two tasks each, so 4 tasks in total. Assuming the
+        // coordinator is the worker 0, the network boundary->worker channels are the following:
+        // - coordinator worker 0 -> stage 1, worker 0 | local
+        // - coordinator worker 0 -> stage 1, worker 1 | remote
+        // - stage 1, worker 0 -> stage 0, worker 0    | local
+        // - stage 1, worker 0 -> stage 0, worker 1    | remote
+        // - stage 1, worker 1 -> stage 0, worker 0    | remote
+        // - stage 1, worker 1 -> stage 0, worker 1    | local
+        assert_eq!(local_connections_used, 3);
+
+        Ok(())
+    }
 }

--- a/tests/metrics_collection.rs
+++ b/tests/metrics_collection.rs
@@ -84,6 +84,11 @@ mod tests {
         "#;
 
         let s_ctx = SessionContext::default();
+        // This test during local connections might prune some rows using dynamic filters
+        // differently in distributed vs single-node. Disabling dynamic filters prevents this
+        // from happening.
+        disable_dynamic_filters(&s_ctx);
+        disable_dynamic_filters(&d_ctx);
         let (s_physical, mut d_physical) = execute(&s_ctx, &d_ctx, query).await?;
         d_physical = rewrite_with_metrics(d_physical.clone(), format).await;
         println!("{}", display_plan_ascii(s_physical.as_ref(), true));
@@ -455,5 +460,18 @@ mod tests {
             "Sum of metric values is 0. Either the metric {metric_name} is not present or the test is too trivial"
         );
         summed
+    }
+
+    fn disable_dynamic_filters(ctx: &SessionContext) {
+        let session_state = ctx.state_ref();
+        let mut session_state = session_state.write();
+        let config = session_state.config_mut();
+        let options = config.options_mut();
+        options
+            .set(
+                "datafusion.optimizer.enable_dynamic_filter_pushdown",
+                "false",
+            )
+            .expect("static dynamic-filter setting should be valid");
     }
 }


### PR DESCRIPTION
Closes https://github.com/datafusion-contrib/datafusion-distributed/issues/576

Adds a `WorkerChannel` implementation that loops back invocations to a local `Worker`, avoiding any serialization if the Worker URL that needs to be contacted is the same URL where a local Worker is hosted.

This allows optimizations like avoiding unnecessary network transfers and serializations in two different cases:

1. Both ends of the coordinator->worker comms are colocated in the same machine. In this case, no data transfer is paid, and sending plan fragments, work units, etc... is done without serialization and/or network transfers.
2. Both ends of worker->worker comms are colocated. In this case, Arrow data is not serialized to IPC format, it's just transferred as normal RecordBatches in-memory.