### PR TITLE
fix: implement replace_children on distributed plan nodes

### DIFF
--- a/src/coordinator/distributed.rs
+++ b/src/coordinator/distributed.rs
@@ -13,7 +13,10 @@ use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_expr_common::metrics::MetricsSet;
 use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
 use datafusion::physical_plan::stream::RecordBatchReceiverStreamBuilder;
-use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use datafusion::physical_plan::{
+    ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties,
+    ReplaceChildrenOptions,
+};
 use futures::StreamExt;
 use std::fmt::Formatter;
 use std::sync::{Arc, Mutex};
@@ -163,9 +166,10 @@ impl ExecutionPlan for DistributedExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(DistributedExec {
             base_plan: require_one_child(&children)?,
@@ -174,6 +178,16 @@ impl ExecutionPlan for DistributedExec {
             metrics: self.metrics.clone(),
             metrics_store: self.metrics_store.clone(),
         }))
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
     }
 
     fn execute(

--- a/src/execution_plans/broadcast.rs
+++ b/src/execution_plans/broadcast.rs
@@ -366,8 +366,8 @@ mod tests {
         )?;
 
         assert_eq!(replaced.name(), "BroadcastExec");
-        assert!(Arc::ptr_eq(&replaced.children()[0], &replacement));
-        assert!(!Arc::ptr_eq(&replaced.children()[0], &original));
+        assert!(Arc::ptr_eq(replaced.children()[0], &replacement));
+        assert!(!Arc::ptr_eq(replaced.children()[0], &original));
         Ok(())
     }
 

--- a/src/execution_plans/broadcast.rs
+++ b/src/execution_plans/broadcast.rs
@@ -9,7 +9,8 @@ use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, internal_err,
+    ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning,
+    PlanProperties, ReplaceChildrenOptions, internal_err,
 };
 use futures::{Stream, StreamExt};
 use std::fmt::Formatter;
@@ -145,14 +146,25 @@ impl ExecutionPlan for BroadcastExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(Self::new(
             require_one_child(children)?,
             self.consumer_task_count,
         )))
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
     }
 
     fn execute(
@@ -335,6 +347,28 @@ mod tests {
         for (idx, expected_value) in expected.iter().enumerate() {
             assert_eq!(values.value(idx), *expected_value);
         }
+    }
+
+    fn mock_plan(schema: &Arc<Schema>) -> Arc<dyn ExecutionPlan> {
+        Arc::new(MockExec::new(vec![], Arc::clone(schema)))
+    }
+
+    #[test]
+    fn replace_children_swaps_input() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+        let original = mock_plan(&schema);
+        let replacement = mock_plan(&schema);
+        let exec = Arc::new(BroadcastExec::new(Arc::clone(&original), 2));
+
+        let replaced = exec.replace_children(
+            vec![Arc::clone(&replacement)],
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )?;
+
+        assert_eq!(replaced.name(), "BroadcastExec");
+        assert!(Arc::ptr_eq(&replaced.children()[0], &replacement));
+        assert!(!Arc::ptr_eq(&replaced.children()[0], &original));
+        Ok(())
     }
 
     #[tokio::test]

--- a/src/execution_plans/children_isolator_union.rs
+++ b/src/execution_plans/children_isolator_union.rs
@@ -11,8 +11,8 @@ use datafusion::physical_plan::empty::EmptyExec;
 use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::physical_plan::union::UnionExec;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, EmptyRecordBatchStream, ExecutionPlan, ExecutionPlanProperties,
-    Partitioning, PlanProperties,
+    ChildrenPropertiesMode, DisplayAs, DisplayFormatType, EmptyRecordBatchStream, ExecutionPlan,
+    ExecutionPlanProperties, Partitioning, PlanProperties, ReplaceChildrenOptions,
 };
 use futures::{Stream, StreamExt};
 use itertools::Itertools;
@@ -89,7 +89,7 @@ pub struct ChildrenIsolatorUnionExec {
     pub(crate) metrics: ExecutionPlanMetricsSet,
     pub(crate) children: Vec<Arc<dyn ExecutionPlan>>,
     /// The original per-child weights (and their optional hard caps) used to build the
-    /// `task_idx_map`. Stored so `with_new_children` can re-run the allocator with the same
+    /// `task_idx_map`. Stored so `replace_children` can re-run the allocator with the same
     /// inputs and preserve `Maximum(N)` caps across plan rewrites.
     pub(crate) child_weights: Vec<ChildWeight>,
     pub(crate) task_idx_map: Vec<
@@ -277,9 +277,10 @@ impl ExecutionPlan for ChildrenIsolatorUnionExec {
         &self.properties
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
     ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
         if children.len() != self.children.len() {
             return plan_err!(
@@ -293,6 +294,16 @@ impl ExecutionPlan for ChildrenIsolatorUnionExec {
             self.child_weights.clone(),
             self.task_idx_map.len(),
         )?))
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {

--- a/src/execution_plans/distributed_leaf.rs
+++ b/src/execution_plans/distributed_leaf.rs
@@ -5,7 +5,8 @@ use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_expr_common::metrics::MetricsSet;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, StatisticsArgs,
+    ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties,
+    ReplaceChildrenOptions, StatisticsArgs,
 };
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -167,14 +168,25 @@ impl ExecutionPlan for DistributedLeafExec {
         self.original.apply_expressions(f)
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         if !children.is_empty() {
             return not_impl_err!("DistributedLeafExec does not accept children");
         }
         Ok(self)
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
     }
 
     fn execute(

--- a/src/execution_plans/metrics.rs
+++ b/src/execution_plans/metrics.rs
@@ -64,17 +64,25 @@ impl ExecutionPlan for MetricsWrapperExec {
         self.inner.apply_expressions(f)
     }
 
+    fn replace_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+        options: ReplaceChildrenOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(MetricsWrapperExec {
+            inner: Arc::clone(&self.inner).replace_children(children, options)?,
+            metrics: self.metrics.clone(),
+        }))
+    }
+
     fn with_new_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(MetricsWrapperExec {
-            inner: Arc::clone(&self.inner).replace_children(
-                children.clone(),
-                ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
-            )?,
-            metrics: self.metrics.clone(),
-        }))
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
     }
 
     fn execute(

--- a/src/execution_plans/network_broadcast.rs
+++ b/src/execution_plans/network_broadcast.rs
@@ -11,8 +11,8 @@ use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_expr_common::metrics::MetricsSet;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, Statistics,
-    StatisticsArgs,
+    ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning,
+    PlanProperties, ReplaceChildrenOptions, Statistics, StatisticsArgs,
 };
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -224,9 +224,10 @@ impl ExecutionPlan for NetworkBroadcastExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
         let mut self_clone = self.as_ref().clone();
         match &mut self_clone.input_stage {
@@ -240,6 +241,16 @@ impl ExecutionPlan for NetworkBroadcastExec {
             }
         }
         Ok(Arc::new(self_clone))
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
     }
 
     fn execute(

--- a/src/execution_plans/network_coalesce.rs
+++ b/src/execution_plans/network_coalesce.rs
@@ -246,9 +246,10 @@ impl ExecutionPlan for NetworkCoalesceExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let mut self_clone = self.as_ref().clone();
         match &mut self_clone.input_stage {
@@ -262,6 +263,16 @@ impl ExecutionPlan for NetworkCoalesceExec {
             }
         }
         Ok(Arc::new(self_clone))
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
     }
 
     fn execute(

--- a/src/execution_plans/network_shuffle.rs
+++ b/src/execution_plans/network_shuffle.rs
@@ -13,7 +13,8 @@ use datafusion::physical_expr_common::metrics::MetricsSet;
 use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, Statistics, StatisticsArgs,
+    ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties,
+    ReplaceChildrenOptions, Statistics, StatisticsArgs,
 };
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -200,9 +201,10 @@ impl ExecutionPlan for NetworkShuffleExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
         let mut self_clone = self.as_ref().clone();
         match &mut self_clone.input_stage {
@@ -216,6 +218,16 @@ impl ExecutionPlan for NetworkShuffleExec {
             }
         }
         Ok(Arc::new(self_clone))
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
     }
 
     fn execute(

--- a/src/execution_plans/sampler.rs
+++ b/src/execution_plans/sampler.rs
@@ -17,7 +17,8 @@ use datafusion::physical_expr_common::metrics::{Gauge, MetricValue, MetricsSet};
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricBuilder, Time};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+    ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties,
+    PlanProperties, ReplaceChildrenOptions,
 };
 use futures::stream::FusedStream;
 use futures::{Stream, StreamExt, TryFutureExt};
@@ -544,11 +545,22 @@ impl ExecutionPlan for SamplerExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
+    fn replace_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(Self::new(require_one_child(children)?)))
+    }
+
     fn with_new_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(Self::new(require_one_child(children)?)))
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
     }
 
     fn execute(

--- a/src/explain_analyze.rs
+++ b/src/explain_analyze.rs
@@ -12,7 +12,8 @@ use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_plan::analyze::AnalyzeExec;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, Distribution, ExecutionPlan, PlanProperties,
+    ChildrenPropertiesMode, DisplayAs, DisplayFormatType, Distribution, ExecutionPlan,
+    PlanProperties, ReplaceChildrenOptions,
 };
 use futures::{StreamExt, stream};
 use std::fmt::Formatter;
@@ -69,15 +70,26 @@ impl ExecutionPlan for DistributedAnalyzeExec {
         vec![Distribution::UnspecifiedDistribution]
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(Self {
             input: require_one_child(&children)?,
             verbose: self.verbose,
             properties: Arc::clone(&self.properties),
         }))
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
     }
 
     fn execute(

--- a/src/test_utils/mock_exec.rs
+++ b/src/test_utils/mock_exec.rs
@@ -7,7 +7,10 @@ use datafusion::physical_expr::{EquivalenceProperties, Partitioning, PhysicalExp
 use datafusion::physical_plan::common::compute_record_batch_statistics;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::stream::{RecordBatchReceiverStream, RecordBatchStreamAdapter};
-use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use datafusion::physical_plan::{
+    ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties,
+    ReplaceChildrenOptions,
+};
 use futures::{Stream, stream};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -159,11 +162,22 @@ impl ExecutionPlan for MockExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         _: Vec<Arc<dyn ExecutionPlan>>,
+        _: ReplaceChildrenOptions,
     ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
         unimplemented!()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
     }
 
     /// Returns a stream which yields data

--- a/src/test_utils/routing.rs
+++ b/src/test_utils/routing.rs
@@ -11,8 +11,8 @@ use datafusion::{
     execution::TaskContext,
     physical_expr::{EquivalenceProperties, PhysicalExpr},
     physical_plan::{
-        DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties,
-        stream::RecordBatchStreamAdapter,
+        ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties,
+        ReplaceChildrenOptions, stream::RecordBatchStreamAdapter,
     },
     prelude::Expr,
 };
@@ -190,11 +190,22 @@ impl ExecutionPlan for URLEmitterExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         _: Vec<Arc<dyn ExecutionPlan>>,
+        _: ReplaceChildrenOptions,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(self.as_ref().clone()))
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
     }
 
     fn execute(

--- a/src/test_utils/test_work_unit_feed.rs
+++ b/src/test_utils/test_work_unit_feed.rs
@@ -20,7 +20,10 @@ use datafusion::physical_expr_common::metrics::MetricsSet;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::metrics::{Count, ExecutionPlanMetricsSet, MetricBuilder};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
-use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use datafusion::physical_plan::{
+    ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties,
+    ReplaceChildrenOptions,
+};
 use datafusion_proto::physical_plan::{PhysicalExtensionCodec, PhysicalProtoConverterExtension};
 use datafusion_proto::protobuf::proto_error;
 use futures::StreamExt;
@@ -396,11 +399,22 @@ impl ExecutionPlan for RowGeneratorExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         _: Vec<Arc<dyn ExecutionPlan>>,
+        _: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(self.as_ref().clone()))
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
     }
 
     fn execute(


### PR DESCRIPTION
Closes #657

`ExecutionPlan::replace_children` is a DataFusion 55 API. `branch-55` was merged to `main` in #540 (v4.0.0), so this targets `main`.

`with_new_children` is deprecated in favor of `replace_children`. This implements `replace_children` on our custom plan nodes. Existing `with_new_children` callers keep working; they forward `ChildrenPropertiesMode::Recompute`.

Types:

- `BroadcastExec`, `SamplerExec`, `DistributedLeafExec`, `MetricsWrapperExec`, `ChildrenIsolatorUnionExec`
- `NetworkBroadcastExec`, `NetworkCoalesceExec`, `NetworkShuffleExec`
- `DistributedExec`, `DistributedAnalyzeExec`
- test helpers: `MockExec`, `URLEmitterExec`, `RowGeneratorExec`

Replaces closed draft #658.
