### PR TITLE
feat: implement replace_children for custom ExecutionPlan nodes

### DIFF
--- a/benchmarks/benches/broadcast_cache_scenarios.rs
+++ b/benchmarks/benches/broadcast_cache_scenarios.rs
@@ -1,3 +1,4 @@
+use datafusion::physical_plan::ReplaceChildrenOptions;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use datafusion::arrow::array::UInt8Array;
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
@@ -146,6 +147,14 @@ impl ExecutionPlan for SyntheticExec {
         _children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         unimplemented!()
+    }
+
+    fn replace_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.with_new_children(children)
     }
 
     fn execute(

--- a/benchmarks/benches/broadcast_cache_scenarios.rs
+++ b/benchmarks/benches/broadcast_cache_scenarios.rs
@@ -142,19 +142,12 @@ impl ExecutionPlan for SyntheticExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
-    fn with_new_children(
-        self: Arc<Self>,
-        _children: Vec<Arc<dyn ExecutionPlan>>,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        unimplemented!()
-    }
-
     fn replace_children(
         self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
         _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        self.with_new_children(children)
+        unimplemented!()
     }
 
     fn execute(

--- a/examples/custom_execution_plan.rs
+++ b/examples/custom_execution_plan.rs
@@ -1,3 +1,4 @@
+use datafusion::physical_plan::ReplaceChildrenOptions;
 //! This example demonstrates how to create a custom execution plan that works with
 //! Distributed DataFusion. It implements a `numbers(start, end)` table function that
 //! generates a sequence of numbers and can be distributed across multiple workers.
@@ -185,6 +186,14 @@ impl ExecutionPlan for NumbersExec {
         _: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(self)
+    }
+
+    fn replace_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.with_new_children(children)
     }
 
     fn execute(

--- a/examples/custom_execution_plan.rs
+++ b/examples/custom_execution_plan.rs
@@ -181,19 +181,12 @@ impl ExecutionPlan for NumbersExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
-    fn with_new_children(
-        self: Arc<Self>,
-        _: Vec<Arc<dyn ExecutionPlan>>,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        Ok(self)
-    }
-
     fn replace_children(
         self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
+        _: Vec<Arc<dyn ExecutionPlan>>,
         _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        self.with_new_children(children)
+        Ok(self)
     }
 
     fn execute(

--- a/examples/custom_worker_url_routing.rs
+++ b/examples/custom_worker_url_routing.rs
@@ -1,3 +1,4 @@
+use datafusion::physical_plan::ReplaceChildrenOptions;
 //! Demonstrates **custom task routing** for **cache affinity**: consistently routing each parquet
 //! file to the *same* worker so that worker can serve it from an in-memory cache on repeat queries.
 //!
@@ -106,6 +107,14 @@ impl ExecutionPlan for CacheExec {
         mut children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(CacheExec::new(children.remove(0)))
+    }
+
+    fn replace_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.with_new_children(children)
     }
 
     fn execute(

--- a/examples/custom_worker_url_routing.rs
+++ b/examples/custom_worker_url_routing.rs
@@ -102,19 +102,12 @@ impl ExecutionPlan for CacheExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
-    fn with_new_children(
-        self: Arc<Self>,
-        mut children: Vec<Arc<dyn ExecutionPlan>>,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        Ok(CacheExec::new(children.remove(0)))
-    }
-
     fn replace_children(
         self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
         _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        self.with_new_children(children)
+        Ok(CacheExec::new(children.remove(0)))
     }
 
     fn execute(

--- a/examples/work_unit_feed.rs
+++ b/examples/work_unit_feed.rs
@@ -1,3 +1,4 @@
+use datafusion::physical_plan::ReplaceChildrenOptions;
 //! Demonstrates **work unit feeds**: a distributed leaf node whose work is discovered on the
 //! coordinator *at runtime* and streamed to the workers while the query runs, instead of being
 //! known at planning time (think a paginated API, a queue, or a catalog handing out keys).
@@ -161,6 +162,14 @@ impl ExecutionPlan for RemoteScanExec {
         _: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(self)
+    }
+
+    fn replace_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.with_new_children(children)
     }
 
     fn execute(

--- a/examples/work_unit_feed.rs
+++ b/examples/work_unit_feed.rs
@@ -157,19 +157,12 @@ impl ExecutionPlan for RemoteScanExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
-    fn with_new_children(
-        self: Arc<Self>,
-        _: Vec<Arc<dyn ExecutionPlan>>,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        Ok(self)
-    }
-
     fn replace_children(
         self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
+        _: Vec<Arc<dyn ExecutionPlan>>,
         _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        self.with_new_children(children)
+        Ok(self)
     }
 
     fn execute(

--- a/src/coordinator/distributed.rs
+++ b/src/coordinator/distributed.rs
@@ -180,9 +180,10 @@ impl ExecutionPlan for DistributedExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let child = require_one_child(&children)?;
         // Replacing the public child is independent from replacing the visualization plan. A
@@ -199,15 +200,6 @@ impl ExecutionPlan for DistributedExec {
             metrics_store: self.metrics_store.clone(),
             completed_dynamic_filter_store: self.completed_dynamic_filter_store.clone(),
         }))
-    }
-
-    fn replace_children(
-        self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
-        _options: ReplaceChildrenOptions,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        // Prefer replace_children over deprecated with_new_children (#657).
-        self.with_new_children(children)
     }
 
     fn execute(

--- a/src/coordinator/distributed.rs
+++ b/src/coordinator/distributed.rs
@@ -13,7 +13,7 @@ use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_expr_common::metrics::MetricsSet;
 use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
 use datafusion::physical_plan::stream::RecordBatchReceiverStreamBuilder;
-use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, ReplaceChildrenOptions};
 use futures::StreamExt;
 use std::fmt::Formatter;
 use std::sync::{Arc, OnceLock};
@@ -199,6 +199,15 @@ impl ExecutionPlan for DistributedExec {
             metrics_store: self.metrics_store.clone(),
             completed_dynamic_filter_store: self.completed_dynamic_filter_store.clone(),
         }))
+    }
+
+    fn replace_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // Prefer replace_children over deprecated with_new_children (#657).
+        self.with_new_children(children)
     }
 
     fn execute(

--- a/src/dynamic_filtering/discovery.rs
+++ b/src/dynamic_filtering/discovery.rs
@@ -256,9 +256,10 @@ mod tests {
             apply_expression_roots([&self.expression], f)
         }
 
-        fn with_new_children(
+        fn replace_children(
             self: Arc<Self>,
             mut children: Vec<Arc<dyn ExecutionPlan>>,
+            _options: datafusion::physical_plan::ReplaceChildrenOptions,
         ) -> Result<Arc<dyn ExecutionPlan>> {
             Ok(Arc::new(Self::new(
                 children.remove(0),

--- a/src/execution_plans/broadcast.rs
+++ b/src/execution_plans/broadcast.rs
@@ -9,8 +9,7 @@ use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, internal_err,
-};
+    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, internal_err, ReplaceChildrenOptions};
 use futures::{Stream, StreamExt};
 use std::fmt::Formatter;
 use std::pin::Pin;
@@ -153,6 +152,15 @@ impl ExecutionPlan for BroadcastExec {
             require_one_child(children)?,
             self.consumer_task_count,
         )))
+    }
+
+    fn replace_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // Prefer replace_children over deprecated with_new_children (#657).
+        self.with_new_children(children)
     }
 
     fn execute(

--- a/src/execution_plans/broadcast.rs
+++ b/src/execution_plans/broadcast.rs
@@ -144,23 +144,15 @@ impl ExecutionPlan for BroadcastExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
-    fn with_new_children(
-        self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(Self::new(
-            require_one_child(children)?,
-            self.consumer_task_count,
-        )))
-    }
-
     fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
         _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        // Prefer replace_children over deprecated with_new_children (#657).
-        self.with_new_children(children)
+        Ok(Arc::new(Self::new(
+            require_one_child(children)?,
+            self.consumer_task_count,
+        )))
     }
 
     fn execute(

--- a/src/execution_plans/children_isolator_union.rs
+++ b/src/execution_plans/children_isolator_union.rs
@@ -12,8 +12,7 @@ use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSe
 use datafusion::physical_plan::union::UnionExec;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, EmptyRecordBatchStream, ExecutionPlan, ExecutionPlanProperties,
-    Partitioning, PlanProperties,
-};
+    Partitioning, PlanProperties, ReplaceChildrenOptions};
 use futures::{Stream, StreamExt};
 use itertools::Itertools;
 use std::fmt::Formatter;
@@ -293,6 +292,15 @@ impl ExecutionPlan for ChildrenIsolatorUnionExec {
             self.child_weights.clone(),
             self.task_idx_map.len(),
         )?))
+    }
+
+    fn replace_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // Prefer replace_children over deprecated with_new_children (#657).
+        self.with_new_children(children)
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {

--- a/src/execution_plans/children_isolator_union.rs
+++ b/src/execution_plans/children_isolator_union.rs
@@ -88,7 +88,7 @@ pub struct ChildrenIsolatorUnionExec {
     pub(crate) metrics: ExecutionPlanMetricsSet,
     pub(crate) children: Vec<Arc<dyn ExecutionPlan>>,
     /// The original per-child weights (and their optional hard caps) used to build the
-    /// `task_idx_map`. Stored so `with_new_children` can re-run the allocator with the same
+    /// `task_idx_map`. Stored so `replace_children` can re-run the allocator with the same
     /// inputs and preserve `Maximum(N)` caps across plan rewrites.
     pub(crate) child_weights: Vec<ChildWeight>,
     pub(crate) task_idx_map: Vec<
@@ -276,9 +276,10 @@ impl ExecutionPlan for ChildrenIsolatorUnionExec {
         &self.properties
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
     ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
         if children.len() != self.children.len() {
             return plan_err!(
@@ -292,15 +293,6 @@ impl ExecutionPlan for ChildrenIsolatorUnionExec {
             self.child_weights.clone(),
             self.task_idx_map.len(),
         )?))
-    }
-
-    fn replace_children(
-        self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
-        _options: ReplaceChildrenOptions,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        // Prefer replace_children over deprecated with_new_children (#657).
-        self.with_new_children(children)
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {

--- a/src/execution_plans/distributed_leaf.rs
+++ b/src/execution_plans/distributed_leaf.rs
@@ -5,8 +5,7 @@ use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_expr_common::metrics::MetricsSet;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, StatisticsArgs,
-};
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, StatisticsArgs, ReplaceChildrenOptions};
 use std::fmt::Formatter;
 use std::sync::Arc;
 
@@ -175,6 +174,15 @@ impl ExecutionPlan for DistributedLeafExec {
             return not_impl_err!("DistributedLeafExec does not accept children");
         }
         Ok(self)
+    }
+
+    fn replace_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // Prefer replace_children over deprecated with_new_children (#657).
+        self.with_new_children(children)
     }
 
     fn execute(

--- a/src/execution_plans/distributed_leaf.rs
+++ b/src/execution_plans/distributed_leaf.rs
@@ -166,23 +166,15 @@ impl ExecutionPlan for DistributedLeafExec {
         self.original.apply_expressions(f)
     }
 
-    fn with_new_children(
-        self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        if !children.is_empty() {
-            return not_impl_err!("DistributedLeafExec does not accept children");
-        }
-        Ok(self)
-    }
-
     fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
         _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        // Prefer replace_children over deprecated with_new_children (#657).
-        self.with_new_children(children)
+        if !children.is_empty() {
+            return not_impl_err!("DistributedLeafExec does not accept children");
+        }
+        Ok(self)
     }
 
     fn execute(

--- a/src/execution_plans/metrics.rs
+++ b/src/execution_plans/metrics.rs
@@ -77,6 +77,15 @@ impl ExecutionPlan for MetricsWrapperExec {
         }))
     }
 
+    fn replace_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // Prefer replace_children over deprecated with_new_children (#657).
+        self.with_new_children(children)
+    }
+
     fn execute(
         &self,
         _partition: usize,

--- a/src/execution_plans/metrics.rs
+++ b/src/execution_plans/metrics.rs
@@ -6,8 +6,7 @@ use datafusion::error::Result;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_plan::{
-    ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties,
-    ReplaceChildrenOptions,
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, ReplaceChildrenOptions,
 };
 use delegate::delegate;
 use std::fmt::{Debug, Formatter};
@@ -64,26 +63,15 @@ impl ExecutionPlan for MetricsWrapperExec {
         self.inner.apply_expressions(f)
     }
 
-    fn with_new_children(
-        self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(MetricsWrapperExec {
-            inner: Arc::clone(&self.inner).replace_children(
-                children.clone(),
-                ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
-            )?,
-            metrics: self.metrics.clone(),
-        }))
-    }
-
     fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
-        _options: ReplaceChildrenOptions,
+        options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        // Prefer replace_children over deprecated with_new_children (#657).
-        self.with_new_children(children)
+        Ok(Arc::new(MetricsWrapperExec {
+            inner: Arc::clone(&self.inner).replace_children(children, options)?,
+            metrics: self.metrics.clone(),
+        }))
     }
 
     fn execute(

--- a/src/execution_plans/network_broadcast.rs
+++ b/src/execution_plans/network_broadcast.rs
@@ -12,8 +12,7 @@ use datafusion::physical_expr_common::metrics::MetricsSet;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, Statistics,
-    StatisticsArgs,
-};
+    StatisticsArgs, ReplaceChildrenOptions};
 use std::fmt::Formatter;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -240,6 +239,15 @@ impl ExecutionPlan for NetworkBroadcastExec {
             }
         }
         Ok(Arc::new(self_clone))
+    }
+
+    fn replace_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // Prefer replace_children over deprecated with_new_children (#657).
+        self.with_new_children(children)
     }
 
     fn execute(

--- a/src/execution_plans/network_broadcast.rs
+++ b/src/execution_plans/network_broadcast.rs
@@ -223,9 +223,10 @@ impl ExecutionPlan for NetworkBroadcastExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
         let mut self_clone = self.as_ref().clone();
         match &mut self_clone.input_stage {
@@ -239,15 +240,6 @@ impl ExecutionPlan for NetworkBroadcastExec {
             }
         }
         Ok(Arc::new(self_clone))
-    }
-
-    fn replace_children(
-        self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
-        _options: ReplaceChildrenOptions,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        // Prefer replace_children over deprecated with_new_children (#657).
-        self.with_new_children(children)
     }
 
     fn execute(

--- a/src/execution_plans/network_coalesce.rs
+++ b/src/execution_plans/network_coalesce.rs
@@ -264,6 +264,15 @@ impl ExecutionPlan for NetworkCoalesceExec {
         Ok(Arc::new(self_clone))
     }
 
+    fn replace_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // Prefer replace_children over deprecated with_new_children (#657).
+        self.with_new_children(children)
+    }
+
     fn execute(
         &self,
         partition: usize,

--- a/src/execution_plans/network_coalesce.rs
+++ b/src/execution_plans/network_coalesce.rs
@@ -246,9 +246,10 @@ impl ExecutionPlan for NetworkCoalesceExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let mut self_clone = self.as_ref().clone();
         match &mut self_clone.input_stage {
@@ -262,15 +263,6 @@ impl ExecutionPlan for NetworkCoalesceExec {
             }
         }
         Ok(Arc::new(self_clone))
-    }
-
-    fn replace_children(
-        self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
-        _options: ReplaceChildrenOptions,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        // Prefer replace_children over deprecated with_new_children (#657).
-        self.with_new_children(children)
     }
 
     fn execute(

--- a/src/execution_plans/network_shuffle.rs
+++ b/src/execution_plans/network_shuffle.rs
@@ -13,8 +13,7 @@ use datafusion::physical_expr_common::metrics::MetricsSet;
 use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, Statistics, StatisticsArgs,
-};
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, Statistics, StatisticsArgs, ReplaceChildrenOptions};
 use std::fmt::Formatter;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -216,6 +215,15 @@ impl ExecutionPlan for NetworkShuffleExec {
             }
         }
         Ok(Arc::new(self_clone))
+    }
+
+    fn replace_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // Prefer replace_children over deprecated with_new_children (#657).
+        self.with_new_children(children)
     }
 
     fn execute(

--- a/src/execution_plans/network_shuffle.rs
+++ b/src/execution_plans/network_shuffle.rs
@@ -199,9 +199,10 @@ impl ExecutionPlan for NetworkShuffleExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
         let mut self_clone = self.as_ref().clone();
         match &mut self_clone.input_stage {
@@ -215,15 +216,6 @@ impl ExecutionPlan for NetworkShuffleExec {
             }
         }
         Ok(Arc::new(self_clone))
-    }
-
-    fn replace_children(
-        self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
-        _options: ReplaceChildrenOptions,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        // Prefer replace_children over deprecated with_new_children (#657).
-        self.with_new_children(children)
     }
 
     fn execute(

--- a/src/execution_plans/sampler.rs
+++ b/src/execution_plans/sampler.rs
@@ -17,8 +17,7 @@ use datafusion::physical_expr_common::metrics::{Gauge, MetricValue, MetricsSet};
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricBuilder, Time};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
-};
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties, ReplaceChildrenOptions};
 use futures::stream::FusedStream;
 use futures::{Stream, StreamExt, TryFutureExt};
 use std::collections::VecDeque;
@@ -549,6 +548,15 @@ impl ExecutionPlan for SamplerExec {
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(Self::new(require_one_child(children)?)))
+    }
+
+    fn replace_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // Prefer replace_children over deprecated with_new_children (#657).
+        self.with_new_children(children)
     }
 
     fn execute(

--- a/src/execution_plans/sampler.rs
+++ b/src/execution_plans/sampler.rs
@@ -543,20 +543,12 @@ impl ExecutionPlan for SamplerExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
-    fn with_new_children(
-        self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(Self::new(require_one_child(children)?)))
-    }
-
     fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
         _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        // Prefer replace_children over deprecated with_new_children (#657).
-        self.with_new_children(children)
+        Ok(Arc::new(Self::new(require_one_child(children)?)))
     }
 
     fn execute(

--- a/src/explain_analyze.rs
+++ b/src/explain_analyze.rs
@@ -12,8 +12,7 @@ use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_plan::analyze::AnalyzeExec;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, Distribution, ExecutionPlan, PlanProperties,
-};
+    DisplayAs, DisplayFormatType, Distribution, ExecutionPlan, PlanProperties, ReplaceChildrenOptions};
 use futures::{StreamExt, stream};
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -78,6 +77,15 @@ impl ExecutionPlan for DistributedAnalyzeExec {
             verbose: self.verbose,
             properties: Arc::clone(&self.properties),
         }))
+    }
+
+    fn replace_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // Prefer replace_children over deprecated with_new_children (#657).
+        self.with_new_children(children)
     }
 
     fn execute(

--- a/src/explain_analyze.rs
+++ b/src/explain_analyze.rs
@@ -68,24 +68,16 @@ impl ExecutionPlan for DistributedAnalyzeExec {
         vec![Distribution::UnspecifiedDistribution]
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(Self {
             input: require_one_child(&children)?,
             verbose: self.verbose,
             properties: Arc::clone(&self.properties),
         }))
-    }
-
-    fn replace_children(
-        self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
-        _options: ReplaceChildrenOptions,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        // Prefer replace_children over deprecated with_new_children (#657).
-        self.with_new_children(children)
     }
 
     fn execute(

--- a/src/test_utils/mock_exec.rs
+++ b/src/test_utils/mock_exec.rs
@@ -7,7 +7,7 @@ use datafusion::physical_expr::{EquivalenceProperties, Partitioning, PhysicalExp
 use datafusion::physical_plan::common::compute_record_batch_statistics;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::stream::{RecordBatchReceiverStream, RecordBatchStreamAdapter};
-use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, ReplaceChildrenOptions};
 use futures::{Stream, stream};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -164,6 +164,15 @@ impl ExecutionPlan for MockExec {
         _: Vec<Arc<dyn ExecutionPlan>>,
     ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
         unimplemented!()
+    }
+
+    fn replace_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // Prefer replace_children over deprecated with_new_children (#657).
+        self.with_new_children(children)
     }
 
     /// Returns a stream which yields data

--- a/src/test_utils/mock_exec.rs
+++ b/src/test_utils/mock_exec.rs
@@ -159,20 +159,12 @@ impl ExecutionPlan for MockExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
-    fn with_new_children(
-        self: Arc<Self>,
-        _: Vec<Arc<dyn ExecutionPlan>>,
-    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
-        unimplemented!()
-    }
-
     fn replace_children(
         self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
+        _: Vec<Arc<dyn ExecutionPlan>>,
         _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        // Prefer replace_children over deprecated with_new_children (#657).
-        self.with_new_children(children)
+        unimplemented!()
     }
 
     /// Returns a stream which yields data

--- a/src/test_utils/routing.rs
+++ b/src/test_utils/routing.rs
@@ -1,3 +1,4 @@
+use datafusion::physical_plan::ReplaceChildrenOptions;
 use arrow::{
     array::{Int64Array, RecordBatch, StringArray},
     datatypes::{DataType, Field, Schema, SchemaRef},
@@ -195,6 +196,15 @@ impl ExecutionPlan for URLEmitterExec {
         _: Vec<Arc<dyn ExecutionPlan>>,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(self.as_ref().clone()))
+    }
+
+    fn replace_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // Prefer replace_children over deprecated with_new_children (#657).
+        self.with_new_children(children)
     }
 
     fn execute(

--- a/src/test_utils/routing.rs
+++ b/src/test_utils/routing.rs
@@ -191,20 +191,12 @@ impl ExecutionPlan for URLEmitterExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
-    fn with_new_children(
-        self: Arc<Self>,
-        _: Vec<Arc<dyn ExecutionPlan>>,
-    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(self.as_ref().clone()))
-    }
-
     fn replace_children(
         self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
+        _: Vec<Arc<dyn ExecutionPlan>>,
         _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        // Prefer replace_children over deprecated with_new_children (#657).
-        self.with_new_children(children)
+        Ok(Arc::new(self.as_ref().clone()))
     }
 
     fn execute(

--- a/src/test_utils/test_work_unit_feed.rs
+++ b/src/test_utils/test_work_unit_feed.rs
@@ -20,7 +20,7 @@ use datafusion::physical_expr_common::metrics::MetricsSet;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::metrics::{Count, ExecutionPlanMetricsSet, MetricBuilder};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
-use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, ReplaceChildrenOptions};
 use datafusion_proto::physical_plan::{PhysicalExtensionCodec, PhysicalProtoConverterExtension};
 use datafusion_proto::protobuf::proto_error;
 use futures::StreamExt;
@@ -401,6 +401,15 @@ impl ExecutionPlan for RowGeneratorExec {
         _: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(self.as_ref().clone()))
+    }
+
+    fn replace_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // Prefer replace_children over deprecated with_new_children (#657).
+        self.with_new_children(children)
     }
 
     fn execute(

--- a/src/test_utils/test_work_unit_feed.rs
+++ b/src/test_utils/test_work_unit_feed.rs
@@ -396,20 +396,12 @@ impl ExecutionPlan for RowGeneratorExec {
         Ok(TreeNodeRecursion::Continue)
     }
 
-    fn with_new_children(
-        self: Arc<Self>,
-        _: Vec<Arc<dyn ExecutionPlan>>,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(self.as_ref().clone()))
-    }
-
     fn replace_children(
         self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
+        _: Vec<Arc<dyn ExecutionPlan>>,
         _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        // Prefer replace_children over deprecated with_new_children (#657).
-        self.with_new_children(children)
+        Ok(Arc::new(self.as_ref().clone()))
     }
 
     fn execute(

--- a/tests/custom_config_extension.rs
+++ b/tests/custom_config_extension.rs
@@ -1,3 +1,4 @@
+use datafusion::physical_plan::ReplaceChildrenOptions;
 #[cfg(all(feature = "integration", test))]
 mod tests {
     use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
@@ -177,6 +178,14 @@ mod tests {
             Ok(Arc::new(CustomConfigExtensionRequiredExec::new(
                 children[0].clone(),
             )))
+        }
+
+        fn replace_children(
+            self: Arc<Self>,
+            children: Vec<Arc<dyn ExecutionPlan>>,
+            _options: ReplaceChildrenOptions,
+        ) -> Result<Arc<dyn ExecutionPlan>> {
+            self.with_new_children(children)
         }
 
         fn execute(

--- a/tests/custom_config_extension.rs
+++ b/tests/custom_config_extension.rs
@@ -171,21 +171,14 @@ mod tests {
             Ok(TreeNodeRecursion::Continue)
         }
 
-        fn with_new_children(
-            self: Arc<Self>,
-            children: Vec<Arc<dyn ExecutionPlan>>,
-        ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
-            Ok(Arc::new(CustomConfigExtensionRequiredExec::new(
-                children[0].clone(),
-            )))
-        }
-
         fn replace_children(
             self: Arc<Self>,
             children: Vec<Arc<dyn ExecutionPlan>>,
             _options: ReplaceChildrenOptions,
-        ) -> Result<Arc<dyn ExecutionPlan>> {
-            self.with_new_children(children)
+        ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+            Ok(Arc::new(CustomConfigExtensionRequiredExec::new(
+                children[0].clone(),
+            )))
         }
 
         fn execute(

--- a/tests/custom_extension_codec.rs
+++ b/tests/custom_extension_codec.rs
@@ -1,3 +1,4 @@
+use datafusion::physical_plan::ReplaceChildrenOptions;
 #[cfg(all(feature = "integration", test))]
 mod tests {
     use datafusion::arrow::util::pretty::pretty_format_batches;
@@ -124,6 +125,14 @@ mod tests {
             children: Vec<Arc<dyn ExecutionPlan>>,
         ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
             Ok(Arc::new(CustomPassThroughExec::new(children[0].clone())))
+        }
+
+        fn replace_children(
+            self: Arc<Self>,
+            children: Vec<Arc<dyn ExecutionPlan>>,
+            _options: ReplaceChildrenOptions,
+        ) -> Result<Arc<dyn ExecutionPlan>> {
+            self.with_new_children(children)
         }
 
         fn execute(

--- a/tests/custom_extension_codec.rs
+++ b/tests/custom_extension_codec.rs
@@ -120,19 +120,12 @@ mod tests {
             Ok(TreeNodeRecursion::Continue)
         }
 
-        fn with_new_children(
-            self: Arc<Self>,
-            children: Vec<Arc<dyn ExecutionPlan>>,
-        ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
-            Ok(Arc::new(CustomPassThroughExec::new(children[0].clone())))
-        }
-
         fn replace_children(
             self: Arc<Self>,
             children: Vec<Arc<dyn ExecutionPlan>>,
             _options: ReplaceChildrenOptions,
-        ) -> Result<Arc<dyn ExecutionPlan>> {
-            self.with_new_children(children)
+        ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+            Ok(Arc::new(CustomPassThroughExec::new(children[0].clone())))
         }
 
         fn execute(

--- a/tests/error_propagation.rs
+++ b/tests/error_propagation.rs
@@ -1,3 +1,4 @@
+use datafusion::physical_plan::ReplaceChildrenOptions;
 #[cfg(all(feature = "integration", test))]
 mod tests {
     use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
@@ -127,6 +128,14 @@ mod tests {
                 children[0].clone(),
                 &self.msg,
             )))
+        }
+
+        fn replace_children(
+            self: Arc<Self>,
+            children: Vec<Arc<dyn ExecutionPlan>>,
+            _options: ReplaceChildrenOptions,
+        ) -> Result<Arc<dyn ExecutionPlan>> {
+            self.with_new_children(children)
         }
 
         fn execute(

--- a/tests/error_propagation.rs
+++ b/tests/error_propagation.rs
@@ -120,22 +120,15 @@ mod tests {
             Ok(TreeNodeRecursion::Continue)
         }
 
-        fn with_new_children(
-            self: Arc<Self>,
-            children: Vec<Arc<dyn ExecutionPlan>>,
-        ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
-            Ok(Arc::new(ErrorThrowingExec::new(
-                children[0].clone(),
-                &self.msg,
-            )))
-        }
-
         fn replace_children(
             self: Arc<Self>,
             children: Vec<Arc<dyn ExecutionPlan>>,
             _options: ReplaceChildrenOptions,
         ) -> Result<Arc<dyn ExecutionPlan>> {
-            self.with_new_children(children)
+            Ok(Arc::new(ErrorThrowingExec::new(
+                children[0].clone(),
+                &self.msg,
+            )))
         }
 
         fn execute(

--- a/tests/stateful_execution_plan.rs
+++ b/tests/stateful_execution_plan.rs
@@ -1,3 +1,4 @@
+use datafusion::physical_plan::ReplaceChildrenOptions;
 #[cfg(all(feature = "integration", test))]
 mod tests {
     use datafusion::arrow::util::pretty::pretty_format_batches;
@@ -153,6 +154,14 @@ mod tests {
             children: Vec<Arc<dyn ExecutionPlan>>,
         ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
             Ok(Arc::new(StatefulPassThroughExec::new(children[0].clone())))
+        }
+
+        fn replace_children(
+            self: Arc<Self>,
+            children: Vec<Arc<dyn ExecutionPlan>>,
+            _options: ReplaceChildrenOptions,
+        ) -> Result<Arc<dyn ExecutionPlan>> {
+            self.with_new_children(children)
         }
 
         fn execute(

--- a/tests/stateful_execution_plan.rs
+++ b/tests/stateful_execution_plan.rs
@@ -149,19 +149,12 @@ mod tests {
             Ok(TreeNodeRecursion::Continue)
         }
 
-        fn with_new_children(
-            self: Arc<Self>,
-            children: Vec<Arc<dyn ExecutionPlan>>,
-        ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
-            Ok(Arc::new(StatefulPassThroughExec::new(children[0].clone())))
-        }
-
         fn replace_children(
             self: Arc<Self>,
             children: Vec<Arc<dyn ExecutionPlan>>,
             _options: ReplaceChildrenOptions,
-        ) -> Result<Arc<dyn ExecutionPlan>> {
-            self.with_new_children(children)
+        ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+            Ok(Arc::new(StatefulPassThroughExec::new(children[0].clone())))
         }
 
         fn execute(


### PR DESCRIPTION
## Summary

feat: implement replace_children for custom ExecutionPlan nodes

## Changes

- src/coordinator/distributed.rs: replace_children -> with_new_children
- src/execution_plans/broadcast.rs: replace_children -> with_new_children
- src/execution_plans/children_isolator_union.rs: replace_children -> with_new_children
- src/execution_plans/distributed_leaf.rs: replace_children -> with_new_children
- src/execution_plans/metrics.rs: replace_children -> with_new_children
- src/execution_plans/network_broadcast.rs: replace_children -> with_new_children
- src/execution_plans/network_coalesce.rs: replace_children -> with_new_children
- src/execution_plans/network_shuffle.rs: replace_children -> with_new_children
- src/execution_plans/sampler.rs: replace_children -> with_new_children
- src/explain_analyze.rs: replace_children -> with_new_children
- src/test_utils/mock_exec.rs: replace_children -> with_new_children
- src/test_utils/routing.rs: replace_children -> with_new_children
- src/test_utils/test_work_unit_feed.rs: replace_children -> with_new_children
- examples/custom_execution_plan.rs: replace_children
- examples/custom_worker_url_routing.rs: replace_children
- examples/work_unit_feed.rs: replace_children
- tests/custom_config_extension.rs: replace_children
- tests/custom_extension_codec.rs: replace_children
- tests/error_propagation.rs: replace_children
- tests/stateful_execution_plan.rs: replace_children
- benchmarks/benches/broadcast_cache_scenarios.rs: replace_children

Fixes #657
