### PR TITLE
fix: preserve network boundary equivalence groups

### DIFF
--- a/src/codec/distributed_codec.rs
+++ b/src/codec/distributed_codec.rs
@@ -187,7 +187,7 @@ impl PhysicalExtensionCodec for DistributedCodec {
                 let schema = Arc::new(schema);
                 let equivalence_properties = parse_equivalence_properties(
                     equivalence_classes,
-                    schema.clone(),
+                    schema,
                     &decode_ctx,
                     proto_converter,
                 )?;

--- a/src/codec/distributed_codec.rs
+++ b/src/codec/distributed_codec.rs
@@ -154,7 +154,7 @@ impl PhysicalExtensionCodec for DistributedCodec {
                 let schema = Arc::new(schema);
                 let equivalence_properties = parse_equivalence_properties(
                     equivalence_classes,
-                    schema.clone(),
+                    schema,
                     &decode_ctx,
                     proto_converter,
                 )?;

--- a/src/codec/distributed_codec.rs
+++ b/src/codec/distributed_codec.rs
@@ -15,6 +15,7 @@ use datafusion::common::Result;
 use datafusion::error::DataFusionError;
 use datafusion::execution::TaskContext;
 use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_expr::equivalence::{EquivalenceClass, EquivalenceGroup};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::union::UnionExec;
 use datafusion::physical_plan::{ExecutionPlan, Partitioning, PlanProperties};
@@ -102,6 +103,7 @@ impl PhysicalExtensionCodec for DistributedCodec {
                 schema,
                 partitioning,
                 input_stage,
+                equivalence_classes,
             }) => {
                 let schema: Schema = schema
                     .as_ref()
@@ -116,10 +118,17 @@ impl PhysicalExtensionCodec for DistributedCodec {
                     proto_converter,
                 )?
                 .ok_or(proto_error("NetworkShuffleExec is missing partitioning"))?;
+                let schema = Arc::new(schema);
+                let equivalence_properties = parse_equivalence_properties(
+                    equivalence_classes,
+                    schema.clone(),
+                    &decode_ctx,
+                    proto_converter,
+                )?;
 
-                Ok(Arc::new(new_network_hash_shuffle_exec(
+                Ok(Arc::new(new_network_hash_shuffle_exec_with_properties(
                     partitioning,
-                    Arc::new(schema),
+                    equivalence_properties,
                     parse_stage_proto(input_stage, inputs)?,
                 )))
             }
@@ -127,6 +136,7 @@ impl PhysicalExtensionCodec for DistributedCodec {
                 schema,
                 partitioning,
                 input_stage,
+                equivalence_classes,
             }) => {
                 let schema: Schema = schema
                     .as_ref()
@@ -141,10 +151,17 @@ impl PhysicalExtensionCodec for DistributedCodec {
                     proto_converter,
                 )?
                 .ok_or(proto_error("NetworkCoalesceExec is missing partitioning"))?;
+                let schema = Arc::new(schema);
+                let equivalence_properties = parse_equivalence_properties(
+                    equivalence_classes,
+                    schema.clone(),
+                    &decode_ctx,
+                    proto_converter,
+                )?;
 
-                Ok(Arc::new(new_network_coalesce_tasks_exec(
+                Ok(Arc::new(new_network_coalesce_tasks_exec_with_properties(
                     partitioning,
-                    Arc::new(schema),
+                    equivalence_properties,
                     parse_stage_proto(input_stage, inputs)?,
                 )))
             }
@@ -152,6 +169,7 @@ impl PhysicalExtensionCodec for DistributedCodec {
                 schema,
                 partitioning,
                 input_stage,
+                equivalence_classes,
             }) => {
                 let schema: Schema = schema
                     .as_ref()
@@ -166,10 +184,17 @@ impl PhysicalExtensionCodec for DistributedCodec {
                     proto_converter,
                 )?
                 .ok_or(proto_error("NetworkBroadcastExec is missing partitioning"))?;
+                let schema = Arc::new(schema);
+                let equivalence_properties = parse_equivalence_properties(
+                    equivalence_classes,
+                    schema.clone(),
+                    &decode_ctx,
+                    proto_converter,
+                )?;
 
-                Ok(Arc::new(new_network_broadcast_exec(
+                Ok(Arc::new(new_network_broadcast_exec_with_properties(
                     partitioning,
-                    Arc::new(schema),
+                    equivalence_properties,
                     parse_stage_proto(input_stage, inputs)?,
                 )))
             }
@@ -280,6 +305,11 @@ impl PhysicalExtensionCodec for DistributedCodec {
                     proto_converter,
                 )?),
                 input_stage: Some(encode_stage_proto(node.input_stage())?),
+                equivalence_classes: serialize_equivalence_group(
+                    node.properties().equivalence_properties(),
+                    self,
+                    proto_converter,
+                )?,
             };
 
             let wrapper = DistributedExecProto {
@@ -296,6 +326,11 @@ impl PhysicalExtensionCodec for DistributedCodec {
                     proto_converter,
                 )?),
                 input_stage: Some(encode_stage_proto(node.input_stage())?),
+                equivalence_classes: serialize_equivalence_group(
+                    node.properties().equivalence_properties(),
+                    self,
+                    proto_converter,
+                )?,
             };
 
             let wrapper = DistributedExecProto {
@@ -312,6 +347,11 @@ impl PhysicalExtensionCodec for DistributedCodec {
                     proto_converter,
                 )?),
                 input_stage: Some(encode_stage_proto(node.input_stage())?),
+                equivalence_classes: serialize_equivalence_group(
+                    node.properties().equivalence_properties(),
+                    self,
+                    proto_converter,
+                )?,
             };
 
             let wrapper = DistributedExecProto {
@@ -375,6 +415,49 @@ impl PhysicalExtensionCodec for DistributedCodec {
     }
 }
 
+fn serialize_equivalence_group(
+    properties: &EquivalenceProperties,
+    codec: &dyn PhysicalExtensionCodec,
+    proto_converter: &dyn PhysicalProtoConverterExtension,
+) -> Result<Vec<EquivalenceClassProto>> {
+    properties
+        .eq_group()
+        .iter()
+        .map(|class| {
+            class
+                .iter()
+                .map(|expr| proto_converter.physical_expr_to_proto(expr, codec))
+                .collect::<Result<Vec<_>>>()
+                .map(|expressions| EquivalenceClassProto { expressions })
+        })
+        .collect()
+}
+
+fn parse_equivalence_properties(
+    equivalence_classes: Vec<EquivalenceClassProto>,
+    schema: SchemaRef,
+    decode_ctx: &PhysicalPlanDecodeContext<'_>,
+    proto_converter: &dyn PhysicalProtoConverterExtension,
+) -> Result<EquivalenceProperties> {
+    let classes = equivalence_classes
+        .into_iter()
+        .map(|class| {
+            class
+                .expressions
+                .iter()
+                .map(|expr| {
+                    proto_converter.proto_to_physical_expr(expr, schema.as_ref(), decode_ctx)
+                })
+                .collect::<Result<Vec<_>>>()
+                .map(EquivalenceClass::new)
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut properties = EquivalenceProperties::new(schema);
+    properties.add_equivalence_group(EquivalenceGroup::new(classes))?;
+    Ok(properties)
+}
+
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StageProto {
     /// Our query id
@@ -431,6 +514,16 @@ pub struct NetworkShuffleExecProto {
     partitioning: Option<protobuf::Partitioning>,
     #[prost(message, optional, tag = "3")]
     input_stage: Option<StageProto>,
+    #[prost(message, repeated, tag = "4")]
+    equivalence_classes: Vec<EquivalenceClassProto>,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EquivalenceClassProto {
+    /// Expressions known to produce equal values. Ordering properties are intentionally
+    /// excluded because they are not generally valid across a network shuffle.
+    #[prost(message, repeated, tag = "1")]
+    expressions: Vec<protobuf::PhysicalExprNode>,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -467,14 +560,27 @@ pub struct ChildIdxWithTaskContextProto {
     task_count: u64,
 }
 
+#[cfg(test)]
 fn new_network_hash_shuffle_exec(
     partitioning: Partitioning,
     schema: SchemaRef,
     input_stage: Stage,
 ) -> NetworkShuffleExec {
+    new_network_hash_shuffle_exec_with_properties(
+        partitioning,
+        EquivalenceProperties::new(schema),
+        input_stage,
+    )
+}
+
+fn new_network_hash_shuffle_exec_with_properties(
+    partitioning: Partitioning,
+    equivalence_properties: EquivalenceProperties,
+    input_stage: Stage,
+) -> NetworkShuffleExec {
     NetworkShuffleExec {
         properties: Arc::new(PlanProperties::new(
-            EquivalenceProperties::new(schema),
+            equivalence_properties,
             partitioning,
             EmissionType::Incremental,
             Boundedness::Bounded,
@@ -495,16 +601,31 @@ pub struct NetworkCoalesceExecProto {
     partitioning: Option<protobuf::Partitioning>,
     #[prost(message, optional, tag = "3")]
     input_stage: Option<StageProto>,
+    #[prost(message, repeated, tag = "4")]
+    equivalence_classes: Vec<EquivalenceClassProto>,
 }
 
+#[cfg(test)]
 fn new_network_coalesce_tasks_exec(
     partitioning: Partitioning,
     schema: SchemaRef,
     input_stage: Stage,
 ) -> NetworkCoalesceExec {
+    new_network_coalesce_tasks_exec_with_properties(
+        partitioning,
+        EquivalenceProperties::new(schema),
+        input_stage,
+    )
+}
+
+fn new_network_coalesce_tasks_exec_with_properties(
+    partitioning: Partitioning,
+    equivalence_properties: EquivalenceProperties,
+    input_stage: Stage,
+) -> NetworkCoalesceExec {
     NetworkCoalesceExec {
         properties: Arc::new(PlanProperties::new(
-            EquivalenceProperties::new(schema),
+            equivalence_properties,
             partitioning,
             EmissionType::Incremental,
             Boundedness::Bounded,
@@ -522,6 +643,8 @@ pub struct NetworkBroadcastExecProto {
     partitioning: Option<protobuf::Partitioning>,
     #[prost(message, optional, tag = "3")]
     input_stage: Option<StageProto>,
+    #[prost(message, repeated, tag = "4")]
+    equivalence_classes: Vec<EquivalenceClassProto>,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -533,14 +656,14 @@ pub struct BroadcastExecProto {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SamplerExecProto {}
 
-fn new_network_broadcast_exec(
+fn new_network_broadcast_exec_with_properties(
     partitioning: Partitioning,
-    schema: SchemaRef,
+    equivalence_properties: EquivalenceProperties,
     input_stage: Stage,
 ) -> NetworkBroadcastExec {
     NetworkBroadcastExec {
         properties: Arc::new(PlanProperties::new(
-            EquivalenceProperties::new(schema),
+            equivalence_properties,
             partitioning,
             EmissionType::Incremental,
             Boundedness::Bounded,
@@ -555,7 +678,7 @@ mod tests {
     use super::super::physical_plan::new_proto_converter as default_proto_converter;
     use super::*;
     use datafusion::arrow::datatypes::{DataType, Field};
-    use datafusion::physical_expr::LexOrdering;
+    use datafusion::physical_expr::{LexOrdering, PhysicalExpr};
     use datafusion::physical_plan::empty::EmptyExec;
     use datafusion::prelude::SessionContext;
     use datafusion::{
@@ -827,6 +950,85 @@ mod tests {
 
         let decoded = codec.try_decode(&buf, &[left, right], &ctx, &default_proto_converter())?;
         assert_eq!(repr(&plan), repr(&decoded));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_roundtrip_network_boundaries_preserves_equivalence_group()
+    -> datafusion::common::Result<()> {
+        let codec = DistributedCodec;
+        let ctx = create_context();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+        ]));
+        let a: Arc<dyn PhysicalExpr> = Arc::new(Column::new("a", 0));
+        let b: Arc<dyn PhysicalExpr> = Arc::new(Column::new("b", 1));
+
+        let mut equivalence_properties = EquivalenceProperties::new(schema.clone());
+        equivalence_properties.add_equal_conditions(a.clone(), b.clone())?;
+        equivalence_properties.add_ordering([PhysicalSortExpr::new_default(a.clone())]);
+
+        let properties = || {
+            Arc::new(PlanProperties::new(
+                equivalence_properties.clone(),
+                Partitioning::UnknownPartitioning(1),
+                EmissionType::Incremental,
+                Boundedness::Bounded,
+            ))
+        };
+        let plans: Vec<(&str, Arc<dyn ExecutionPlan>)> = vec![
+            (
+                "shuffle",
+                Arc::new(NetworkShuffleExec {
+                    properties: properties(),
+                    input_stage: dummy_stage(),
+                    worker_connections: WorkerConnectionPool::new(0),
+                }),
+            ),
+            (
+                "coalesce",
+                Arc::new(NetworkCoalesceExec {
+                    properties: properties(),
+                    input_stage: dummy_stage(),
+                    worker_connections: WorkerConnectionPool::new(0),
+                }),
+            ),
+            (
+                "broadcast",
+                Arc::new(NetworkBroadcastExec {
+                    properties: properties(),
+                    input_stage: dummy_stage(),
+                    worker_connections: WorkerConnectionPool::new(0),
+                }),
+            ),
+        ];
+
+        for (name, plan) in plans {
+            if name == "shuffle" {
+                assert!(plan.properties().output_ordering().is_some());
+            }
+
+            let mut buf = Vec::new();
+            codec.try_encode(plan, &mut buf, &default_proto_converter())?;
+            let decoded = codec.try_decode(&buf, &[], &ctx, &default_proto_converter())?;
+
+            assert!(
+                decoded
+                    .properties()
+                    .equivalence_properties()
+                    .eq_group()
+                    .exprs_equal(&a, &b),
+                "{name} lost the equivalence relationship"
+            );
+            if name == "shuffle" {
+                assert!(
+                    decoded.properties().output_ordering().is_none(),
+                    "shuffle should not preserve its input ordering"
+                );
+            }
+        }
 
         Ok(())
     }

--- a/src/codec/distributed_codec.rs
+++ b/src/codec/distributed_codec.rs
@@ -121,7 +121,7 @@ impl PhysicalExtensionCodec for DistributedCodec {
                 let schema = Arc::new(schema);
                 let equivalence_properties = parse_equivalence_properties(
                     equivalence_classes,
-                    schema.clone(),
+                    schema,
                     &decode_ctx,
                     proto_converter,
                 )?;

--- a/src/codec/distributed_codec.rs
+++ b/src/codec/distributed_codec.rs
@@ -126,7 +126,7 @@ impl PhysicalExtensionCodec for DistributedCodec {
                     proto_converter,
                 )?;
 
-                Ok(Arc::new(new_network_hash_shuffle_exec_with_properties(
+                Ok(Arc::new(new_network_hash_shuffle_exec(
                     partitioning,
                     equivalence_properties,
                     parse_stage_proto(input_stage, inputs)?,
@@ -159,7 +159,7 @@ impl PhysicalExtensionCodec for DistributedCodec {
                     proto_converter,
                 )?;
 
-                Ok(Arc::new(new_network_coalesce_tasks_exec_with_properties(
+                Ok(Arc::new(new_network_coalesce_tasks_exec(
                     partitioning,
                     equivalence_properties,
                     parse_stage_proto(input_stage, inputs)?,
@@ -192,7 +192,7 @@ impl PhysicalExtensionCodec for DistributedCodec {
                     proto_converter,
                 )?;
 
-                Ok(Arc::new(new_network_broadcast_exec_with_properties(
+                Ok(Arc::new(new_network_broadcast_exec(
                     partitioning,
                     equivalence_properties,
                     parse_stage_proto(input_stage, inputs)?,
@@ -560,20 +560,7 @@ pub struct ChildIdxWithTaskContextProto {
     task_count: u64,
 }
 
-#[cfg(test)]
 fn new_network_hash_shuffle_exec(
-    partitioning: Partitioning,
-    schema: SchemaRef,
-    input_stage: Stage,
-) -> NetworkShuffleExec {
-    new_network_hash_shuffle_exec_with_properties(
-        partitioning,
-        EquivalenceProperties::new(schema),
-        input_stage,
-    )
-}
-
-fn new_network_hash_shuffle_exec_with_properties(
     partitioning: Partitioning,
     equivalence_properties: EquivalenceProperties,
     input_stage: Stage,
@@ -605,20 +592,7 @@ pub struct NetworkCoalesceExecProto {
     equivalence_classes: Vec<EquivalenceClassProto>,
 }
 
-#[cfg(test)]
 fn new_network_coalesce_tasks_exec(
-    partitioning: Partitioning,
-    schema: SchemaRef,
-    input_stage: Stage,
-) -> NetworkCoalesceExec {
-    new_network_coalesce_tasks_exec_with_properties(
-        partitioning,
-        EquivalenceProperties::new(schema),
-        input_stage,
-    )
-}
-
-fn new_network_coalesce_tasks_exec_with_properties(
     partitioning: Partitioning,
     equivalence_properties: EquivalenceProperties,
     input_stage: Stage,
@@ -656,7 +630,7 @@ pub struct BroadcastExecProto {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SamplerExecProto {}
 
-fn new_network_broadcast_exec_with_properties(
+fn new_network_broadcast_exec(
     partitioning: Partitioning,
     equivalence_properties: EquivalenceProperties,
     input_stage: Stage,
@@ -728,8 +702,11 @@ mod tests {
 
         let schema = schema_i32("a");
         let part = Partitioning::Hash(vec![Arc::new(Column::new("a", 0))], 4);
-        let plan: Arc<dyn ExecutionPlan> =
-            Arc::new(new_network_hash_shuffle_exec(part, schema, dummy_stage()));
+        let plan: Arc<dyn ExecutionPlan> = Arc::new(new_network_hash_shuffle_exec(
+            part,
+            EquivalenceProperties::new(schema),
+            dummy_stage(),
+        ));
 
         let mut buf = Vec::new();
         codec.try_encode(plan.clone(), &mut buf, &default_proto_converter())?;
@@ -748,12 +725,12 @@ mod tests {
         let schema = schema_i32("c");
         let left = Arc::new(new_network_hash_shuffle_exec(
             Partitioning::RoundRobinBatch(2),
-            schema.clone(),
+            EquivalenceProperties::new(schema.clone()),
             dummy_stage(),
         ));
         let right = Arc::new(new_network_hash_shuffle_exec(
             Partitioning::RoundRobinBatch(2),
-            schema.clone(),
+            EquivalenceProperties::new(schema.clone()),
             dummy_stage(),
         ));
 
@@ -778,7 +755,7 @@ mod tests {
         let schema = schema_i32("d");
         let flight = Arc::new(new_network_hash_shuffle_exec(
             Partitioning::UnknownPartitioning(1),
-            schema.clone(),
+            EquivalenceProperties::new(schema.clone()),
             dummy_stage(),
         ));
 
@@ -811,7 +788,7 @@ mod tests {
         let schema = schema_i32("e");
         let plan: Arc<dyn ExecutionPlan> = Arc::new(new_network_coalesce_tasks_exec(
             Partitioning::RoundRobinBatch(3),
-            schema,
+            EquivalenceProperties::new(schema),
             dummy_stage(),
         ));
 
@@ -833,7 +810,7 @@ mod tests {
         let part = Partitioning::Hash(vec![Arc::new(Column::new("a", 0))], 4);
         let plan: Arc<dyn ExecutionPlan> = Arc::new(new_network_hash_shuffle_exec(
             part,
-            schema,
+            EquivalenceProperties::new(schema),
             dummy_stage_with_plan(),
         ));
 
@@ -854,7 +831,7 @@ mod tests {
         let schema = schema_i32("e");
         let plan: Arc<dyn ExecutionPlan> = Arc::new(new_network_coalesce_tasks_exec(
             Partitioning::RoundRobinBatch(3),
-            schema,
+            EquivalenceProperties::new(schema),
             dummy_stage_with_plan(),
         ));
 
@@ -875,7 +852,7 @@ mod tests {
         let schema = schema_i32("f");
         let flight = Arc::new(new_network_coalesce_tasks_exec(
             Partitioning::UnknownPartitioning(1),
-            schema,
+            EquivalenceProperties::new(schema),
             dummy_stage(),
         ));
 
@@ -899,12 +876,12 @@ mod tests {
         let schema = schema_i32("g");
         let left = Arc::new(new_network_coalesce_tasks_exec(
             Partitioning::RoundRobinBatch(2),
-            schema.clone(),
+            EquivalenceProperties::new(schema.clone()),
             dummy_stage(),
         ));
         let right = Arc::new(new_network_coalesce_tasks_exec(
             Partitioning::RoundRobinBatch(2),
-            schema.clone(),
+            EquivalenceProperties::new(schema.clone()),
             dummy_stage(),
         ));
 
@@ -929,12 +906,12 @@ mod tests {
         let schema = schema_i32("h");
         let left = Arc::new(new_network_hash_shuffle_exec(
             Partitioning::RoundRobinBatch(2),
-            schema.clone(),
+            EquivalenceProperties::new(schema.clone()),
             dummy_stage(),
         )) as Arc<dyn ExecutionPlan>;
         let right = Arc::new(new_network_hash_shuffle_exec(
             Partitioning::RoundRobinBatch(2),
-            schema.clone(),
+            EquivalenceProperties::new(schema.clone()),
             dummy_stage(),
         )) as Arc<dyn ExecutionPlan>;
 
@@ -970,38 +947,30 @@ mod tests {
         equivalence_properties.add_equal_conditions(a.clone(), b.clone())?;
         equivalence_properties.add_ordering([PhysicalSortExpr::new_default(a.clone())]);
 
-        let properties = || {
-            Arc::new(PlanProperties::new(
-                equivalence_properties.clone(),
-                Partitioning::UnknownPartitioning(1),
-                EmissionType::Incremental,
-                Boundedness::Bounded,
-            ))
-        };
         let plans: Vec<(&str, Arc<dyn ExecutionPlan>)> = vec![
             (
                 "shuffle",
-                Arc::new(NetworkShuffleExec {
-                    properties: properties(),
-                    input_stage: dummy_stage(),
-                    worker_connections: WorkerConnectionPool::new(0),
-                }),
+                Arc::new(new_network_hash_shuffle_exec(
+                    Partitioning::UnknownPartitioning(1),
+                    equivalence_properties.clone(),
+                    dummy_stage(),
+                )),
             ),
             (
                 "coalesce",
-                Arc::new(NetworkCoalesceExec {
-                    properties: properties(),
-                    input_stage: dummy_stage(),
-                    worker_connections: WorkerConnectionPool::new(0),
-                }),
+                Arc::new(new_network_coalesce_tasks_exec(
+                    Partitioning::UnknownPartitioning(1),
+                    equivalence_properties.clone(),
+                    dummy_stage(),
+                )),
             ),
             (
                 "broadcast",
-                Arc::new(NetworkBroadcastExec {
-                    properties: properties(),
-                    input_stage: dummy_stage(),
-                    worker_connections: WorkerConnectionPool::new(0),
-                }),
+                Arc::new(new_network_broadcast_exec(
+                    Partitioning::UnknownPartitioning(1),
+                    equivalence_properties,
+                    dummy_stage(),
+                )),
             ),
         ];
 


### PR DESCRIPTION
## Summary

- add a backward-compatible protobuf field for value-equivalence classes on distributed network boundaries
- restore equivalence groups when decoding `NetworkShuffleExec`, `NetworkCoalesceExec`, and `NetworkBroadcastExec`
- keep ordering properties out of the wire format so shuffle input ordering is not propagated unsafely
- cover all three boundary types with a focused round-trip regression test

## Testing

- `cargo fmt --all -- --check`
- `cargo test --lib` (297 passed, 1 ignored)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

Fixes #679