### PR TITLE
fix: make broadcast insertion idempotent

### DIFF
--- a/src/distributed_planner/insert_broadcast.rs
+++ b/src/distributed_planner/insert_broadcast.rs
@@ -134,18 +134,20 @@ pub(super) fn insert_broadcast_execs(
             return Ok(Transformed::no(node));
         };
 
-        let broadcast_input = build_child
+        let new_build_child: Arc<dyn ExecutionPlan> = if let Some(coalesce) = build_child
             .downcast_ref::<CoalescePartitionsExec>()
             .filter(|coalesce| coalesce.fetch().is_none())
-            .map_or_else(
-                || Arc::clone(build_child),
-                |coalesce| Arc::clone(coalesce.input()),
-            );
-
-        // consumer_task_count=1 is a placeholder and will be corrected during optimizer rule.
-        let broadcast: Arc<dyn ExecutionPlan> = Arc::new(BroadcastExec::new(broadcast_input, 1));
-        let new_build_child: Arc<dyn ExecutionPlan> =
-            Arc::new(CoalescePartitionsExec::new(broadcast));
+        {
+            if coalesce.input().downcast_ref::<BroadcastExec>().is_some() {
+                return Ok(Transformed::no(node));
+            }
+            coalesced_broadcast(Arc::clone(coalesce.input()))
+        } else if build_child.downcast_ref::<BroadcastExec>().is_some() {
+            Arc::new(CoalescePartitionsExec::new(Arc::clone(build_child)))
+        } else {
+            // A fetch-bearing coalesce remains below the broadcast so the limit is global.
+            coalesced_broadcast(Arc::clone(build_child))
+        };
 
         let mut new_children: Vec<Arc<dyn ExecutionPlan>> = children.into_iter().cloned().collect();
         new_children[0] = new_build_child;
@@ -155,6 +157,12 @@ pub(super) fn insert_broadcast_execs(
         )?))
     })
     .map(|transformed| transformed.data)
+}
+
+fn coalesced_broadcast(input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+    // consumer_task_count=1 is a placeholder and will be corrected during optimizer rule.
+    let broadcast: Arc<dyn ExecutionPlan> = Arc::new(BroadcastExec::new(input, 1));
+    Arc::new(CoalescePartitionsExec::new(broadcast))
 }
 
 fn can_broadcast_left_input(plan: &dyn ExecutionPlan) -> bool {
@@ -329,6 +337,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_insert_broadcast_is_idempotent_for_supported_joins() {
+        let queries = [
+            r#"
+            SELECT a."MinTemp", b."MaxTemp"
+            FROM weather a INNER JOIN weather b
+            ON a."RainToday" = b."RainToday"
+            "#,
+            r#"
+            SELECT a."MinTemp", b."MaxTemp"
+            FROM weather a JOIN weather b ON a."MinTemp" > b."MaxTemp"
+            "#,
+            r#"
+            SELECT a."MinTemp", b."MaxTemp"
+            FROM weather a CROSS JOIN weather b
+            "#,
+        ];
+
+        for query in queries {
+            let once = sql_to_plan_with_broadcast_applications(query, true, 4, 1).await;
+            let twice = sql_to_plan_with_broadcast_applications(query, true, 4, 2).await;
+
+            assert_eq!(once, twice);
+            assert_eq!(once.matches("BroadcastExec").count(), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_insert_broadcast_wraps_direct_broadcast_without_nesting() {
+        let query = r#"
+        SELECT a."MinTemp", b."MaxTemp"
+        FROM weather a INNER JOIN weather b
+        ON a."RainToday" = b."RainToday"
+        "#;
+
+        let plan = sql_to_plan_with_direct_broadcast(query).await;
+
+        assert_eq!(plan.matches("BroadcastExec").count(), 1);
+        assert_snapshot!(plan, @"
+        HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(RainToday@1, RainToday@1)], projection=[MinTemp@0, MaxTemp@2]
+          CoalescePartitionsExec
+            BroadcastExec: input_partitions=1, consumer_tasks=1, output_partitions=1
+              DataSourceExec: file_groups={1 group: [[/testdata/weather/result-000000.parquet, /testdata/weather/result-000001.parquet, /testdata/weather/result-000002.parquet]]}, projection=[MinTemp, RainToday], file_type=parquet
+          DataSourceExec: file_groups={1 group: [[/testdata/weather/result-000000.parquet, /testdata/weather/result-000001.parquet, /testdata/weather/result-000002.parquet]]}, projection=[MaxTemp, RainToday], file_type=parquet, predicate=DynamicFilter [ empty ], dynamic_rg_pruning=eligible
+        ");
+    }
+
+    #[tokio::test]
     async fn test_no_broadcast_nested_loop_left_join() {
         let query = r#"
         SELECT a."MinTemp", b."MaxTemp"
@@ -348,15 +403,48 @@ mod tests {
         broadcast_enabled: bool,
         target_partitions: usize,
     ) -> String {
+        sql_to_plan_with_broadcast_applications(query, broadcast_enabled, target_partitions, 1)
+            .await
+    }
+
+    async fn sql_to_plan_with_broadcast_applications(
+        query: &str,
+        broadcast_enabled: bool,
+        target_partitions: usize,
+        applications: usize,
+    ) -> String {
         let test_plan = TestPlanBuilder::new()
             .target_partitions(target_partitions)
             .broadcast_joins(broadcast_enabled)
             .build()
             .await;
         let ctx = test_plan.get_ctx();
+        let mut plan = test_plan.physical_plan(query).await;
+        for _ in 0..applications {
+            plan = insert_broadcast_execs(plan, ctx.state_ref().read().config_options().as_ref())
+                .expect("failed to insert broadcasts");
+        }
+        format!("{}", displayable(plan.as_ref()).indent(true))
+    }
+
+    async fn sql_to_plan_with_direct_broadcast(query: &str) -> String {
+        let test_plan = TestPlanBuilder::new()
+            .target_partitions(1)
+            .broadcast_joins(true)
+            .build()
+            .await;
+        let ctx = test_plan.get_ctx();
         let plan = test_plan.physical_plan(query).await;
+        let mut children: Vec<_> = plan.children().into_iter().cloned().collect();
+        children[0] = Arc::new(BroadcastExec::new(Arc::clone(&children[0]), 1));
+        let plan = plan
+            .replace_children(
+                children,
+                ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+            )
+            .expect("failed to create a direct broadcast build");
         let plan = insert_broadcast_execs(plan, ctx.state_ref().read().config_options().as_ref())
-            .expect("failed to insert broadcasts");
+            .expect("failed to normalize a direct broadcast build");
         format!("{}", displayable(plan.as_ref()).indent(true))
     }
 }

--- a/src/distributed_planner/insert_broadcast.rs
+++ b/src/distributed_planner/insert_broadcast.rs
@@ -294,14 +294,21 @@ mod tests {
         ON a."RainToday" = b."RainToday"
         "#;
 
-        let plan = sql_to_plan_with_broadcast(query, true, 4).await;
-        assert_snapshot!(plan, @r"
-        HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(RainToday@1, RainToday@1)], projection=[MinTemp@0, MaxTemp@2]
-          CoalescePartitionsExec
-            BroadcastExec: input_partitions=1, consumer_tasks=1, output_partitions=1
-              DataSourceExec: file_groups={1 group: [[/testdata/weather/result-000001.parquet]]}, projection=[MinTemp, RainToday], limit=50, file_type=parquet
-          DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MaxTemp, RainToday], file_type=parquet, predicate=DynamicFilter [ empty ], dynamic_rg_pruning=eligible
-        ");
+        let plan = plan_with_broadcast_applications(query, true, 4, 1).await;
+        let join = plan
+            .downcast_ref::<HashJoinExec>()
+            .expect("expected hash join");
+        let coalesce = join
+            .left()
+            .downcast_ref::<CoalescePartitionsExec>()
+            .expect("expected coalesce above broadcast");
+        let broadcast = coalesce
+            .input()
+            .downcast_ref::<BroadcastExec>()
+            .expect("expected broadcast below coalesce");
+
+        assert_eq!(coalesce.fetch(), None);
+        assert_eq!(broadcast.input().fetch(), Some(50));
     }
 
     #[tokio::test]
@@ -413,6 +420,22 @@ mod tests {
         target_partitions: usize,
         applications: usize,
     ) -> String {
+        let plan = plan_with_broadcast_applications(
+            query,
+            broadcast_enabled,
+            target_partitions,
+            applications,
+        )
+        .await;
+        format!("{}", displayable(plan.as_ref()).indent(true))
+    }
+
+    async fn plan_with_broadcast_applications(
+        query: &str,
+        broadcast_enabled: bool,
+        target_partitions: usize,
+        applications: usize,
+    ) -> Arc<dyn ExecutionPlan> {
         let test_plan = TestPlanBuilder::new()
             .target_partitions(target_partitions)
             .broadcast_joins(broadcast_enabled)
@@ -424,7 +447,7 @@ mod tests {
             plan = insert_broadcast_execs(plan, ctx.state_ref().read().config_options().as_ref())
                 .expect("failed to insert broadcasts");
         }
-        format!("{}", displayable(plan.as_ref()).indent(true))
+        plan
     }
 
     async fn sql_to_plan_with_direct_broadcast(query: &str) -> String {

--- a/src/distributed_planner/insert_broadcast.rs
+++ b/src/distributed_planner/insert_broadcast.rs
@@ -414,43 +414,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_insert_broadcast_wraps_direct_broadcast_without_nesting() {
-        let query = r#"
-        SELECT a."MinTemp", b."MaxTemp"
-        FROM weather a INNER JOIN weather b
-        ON a."RainToday" = b."RainToday"
-        "#;
-
-        let test_plan = TestPlanBuilder::new()
-            .target_partitions(1)
-            .broadcast_joins(true)
-            .build()
-            .await;
-        let ctx = test_plan.get_ctx();
-        let plan = test_plan.physical_plan(query).await;
-        let mut children: Vec<_> = plan.children().into_iter().cloned().collect();
-        children[0] = Arc::new(BroadcastExec::new(Arc::clone(&children[0]), 1));
-        let plan = plan
-            .replace_children(
-                children,
-                ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
-            )
-            .expect("failed to create a direct broadcast build");
-        let plan = insert_broadcast_execs(plan, ctx.state_ref().read().config_options().as_ref())
-            .expect("failed to normalize a direct broadcast build");
-        let plan = displayable(plan.as_ref()).indent(true).to_string();
-
-        assert_eq!(plan.matches("BroadcastExec").count(), 1);
-        assert_snapshot!(plan, @"
-        HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(RainToday@1, RainToday@1)], projection=[MinTemp@0, MaxTemp@2]
-          CoalescePartitionsExec
-            BroadcastExec: input_partitions=1, consumer_tasks=1, output_partitions=1
-              DataSourceExec: file_groups={1 group: [[/testdata/weather/result-000000.parquet, /testdata/weather/result-000001.parquet, /testdata/weather/result-000002.parquet]]}, projection=[MinTemp, RainToday], file_type=parquet
-          DataSourceExec: file_groups={1 group: [[/testdata/weather/result-000000.parquet, /testdata/weather/result-000001.parquet, /testdata/weather/result-000002.parquet]]}, projection=[MaxTemp, RainToday], file_type=parquet, predicate=DynamicFilter [ empty ], dynamic_rg_pruning=eligible
-        ");
-    }
-
-    #[tokio::test]
     async fn test_no_broadcast_nested_loop_left_join() {
         let query = r#"
         SELECT a."MinTemp", b."MaxTemp"

--- a/src/distributed_planner/insert_broadcast.rs
+++ b/src/distributed_planner/insert_broadcast.rs
@@ -138,11 +138,11 @@ pub(super) fn insert_broadcast_execs(
             .downcast_ref::<CoalescePartitionsExec>()
             .filter(|coalesce| coalesce.fetch().is_none())
         {
-            if coalesce.input().downcast_ref::<BroadcastExec>().is_some() {
+            if coalesce.input().is::<BroadcastExec>() {
                 return Ok(Transformed::no(node));
             }
             coalesced_broadcast(Arc::clone(coalesce.input()))
-        } else if build_child.downcast_ref::<BroadcastExec>().is_some() {
+        } else if build_child.is::<BroadcastExec>() {
             Arc::new(CoalescePartitionsExec::new(Arc::clone(build_child)))
         } else {
             // A fetch-bearing coalesce remains below the broadcast so the limit is global.


### PR DESCRIPTION
## Summary

- preserve an existing canonical CoalescePartitionsExec wrapping BroadcastExec
- add only the missing coalesce when the build side is already a direct BroadcastExec
- keep fetch-bearing coalesces below newly inserted broadcasts so global limit semantics remain unchanged
- cover repeated insertion for hash, nested-loop, and cross joins, plus direct-broadcast normalization

## Validation

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --lib (299 passed, 1 ignored)

Fixes #675

## AI assistance disclosure

I used OpenAI Codex to help inspect the planner behavior, implement the change, and run validation. I reviewed the final diff and test results.
