### PR TITLE
Add ok_or_some_err macro

### DIFF
--- a/src/common/macros.rs
+++ b/src/common/macros.rs
@@ -1,0 +1,9 @@
+#[macro_export]
+macro_rules! ok_or_some_err {
+    ($expr: expr) => {
+        match $expr {
+            Ok(v) => v,
+            Err(err) => return Some(Err(err)),
+        }
+    };
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,4 +1,5 @@
 mod children_helpers;
+mod macros;
 mod maybe_encoded;
 mod once_lock;
 mod recursion;

--- a/src/events/defaults/file_scan_config.rs
+++ b/src/events/defaults/file_scan_config.rs
@@ -1,9 +1,9 @@
-use crate::DistributedConfig;
 use crate::events::{
     DesiredTaskCountEvent, DesiredTaskCountEventResponse, ScaleUpLeafNodeEvent,
     ScaleUpLeafNodeEventResponse,
 };
 use crate::execution_plans::DistributedLeafExec;
+use crate::{DistributedConfig, ok_or_some_err};
 use datafusion::catalog::memory::DataSourceExec;
 use datafusion::datasource::physical_plan::{FileGroup, FileGroupPartitioner, FileScanConfig};
 use datafusion::error::Result;
@@ -74,10 +74,7 @@ pub(crate) fn file_scan_config_scale_up_leaf_node(
             .into_iter()
             .map(|file_scan| DataSourceExec::from_data_source(file_scan) as _),
     );
-    let distributed_leaf = match distributed_leaf_result {
-        Ok(distributed_leaf) => distributed_leaf,
-        Err(e) => return Some(Err(e)),
-    };
+    let distributed_leaf = ok_or_some_err!(distributed_leaf_result);
 
     Some(Ok(ScaleUpLeafNodeEventResponse::new(Arc::new(
         distributed_leaf,

--- a/src/events/defaults/routing.rs
+++ b/src/events/defaults/routing.rs
@@ -1,6 +1,6 @@
 use crate::{
     DistributedGetterExt, LocalWorkerContext, NetworkBoundaryExt, RouteTasksEvent,
-    RouteTasksEventResponse, Stage, WorkerResolver,
+    RouteTasksEventResponse, Stage, WorkerResolver, ok_or_some_err,
 };
 use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion::common::{Result, exec_err};
@@ -8,20 +8,17 @@ use rand::Rng;
 
 /// Randomly chooses `ev.task_count` urls from the registered URLs.
 pub(crate) fn random_routing(ev: RouteTasksEvent) -> Option<Result<RouteTasksEventResponse>> {
-    let worker_resolver = match ev
-        .task_ctx
-        .session_config()
-        .get_distributed_worker_resolver()
-    {
-        Ok(r) => r,
-        Err(err) => return Some(Err(err)),
-    };
+    let worker_resolver = ok_or_some_err!(
+        ev.task_ctx
+            .session_config()
+            .get_distributed_worker_resolver()
+    );
 
-    let available_urls = match worker_resolver.get_urls() {
-        Ok(urls) if !urls.is_empty() => urls,
-        Ok(_) => return Some(exec_err!("0 URLs available during routing")),
-        Err(err) => return Some(Err(err)),
-    };
+    let available_urls = ok_or_some_err!(worker_resolver.get_urls());
+
+    if available_urls.is_empty() {
+        return Some(exec_err!("0 URLs available during routing"));
+    }
 
     let start_idx = rand::rng().random_range(0..available_urls.len());
     let urls = (0..ev.task_count)

--- a/src/test_utils/routing.rs
+++ b/src/test_utils/routing.rs
@@ -28,7 +28,7 @@ use tonic::async_trait;
 use crate::{
     DesiredTaskCountEvent, DesiredTaskCountEventResponse, DistributedLeafExec,
     DistributedTaskContext, LocalWorkerContext, RouteTasksEvent, RouteTasksEventResponse,
-    ScaleUpLeafNodeEvent, ScaleUpLeafNodeEventResponse, WorkerResolver,
+    ScaleUpLeafNodeEvent, ScaleUpLeafNodeEventResponse, WorkerResolver, ok_or_some_err,
 };
 
 use crate::distributed_ext::DistributedGetterExt;
@@ -285,12 +285,11 @@ pub fn url_emitter_scale_up_leaf_node(
         })
         .collect();
 
-    Some(Ok(ScaleUpLeafNodeEventResponse::new(
-        match DistributedLeafExec::try_new(template as _, per_task) {
-            Ok(exec) => Arc::new(exec),
-            Err(err) => return Some(Err(err)),
-        },
-    )))
+    let distributed_leaf = ok_or_some_err!(DistributedLeafExec::try_new(template as _, per_task));
+
+    Some(Ok(ScaleUpLeafNodeEventResponse::new(Arc::new(
+        distributed_leaf,
+    ))))
 }
 
 pub fn url_emitter_route_tasks(ev: RouteTasksEvent) -> Option<Result<RouteTasksEventResponse>> {


### PR DESCRIPTION
Adds a new `ok_or_some_err!` macro to be used in event handlers that return
`Option<Result<T>>`.

Passing from something like this:

```rust
let value = match result {
    Ok(value) => value,
    Err(err) => return Some(Err(err))
};
```

To this

```rust
let value = ok_or_some_err!(result);
```

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>