### PR TITLE
Add dialer-based RouteTaskHandler

### DIFF
--- a/docs/source/advanced/06-worker-routing.md
+++ b/docs/source/advanced/06-worker-routing.md
@@ -1,35 +1,68 @@
 # Routing tasks to workers
 
-By default, the planner spreads a stage's tasks across the available workers
-round-robin. When a task's data has a *home* — a worker that already holds it in a
-cache or on local disk — you can send the task **there** instead, so it reads
-locally instead of pulling data over the network.
+By default, each distributed task is routed to an available worker. When a
+task's data has a *home* (e.g, a worker that already holds it in a cache or on
+local disk) a custom routing handler can send the task there instead. As routing
+handlers are responsible for establishing connection to remote workers, they are
+`async`.
 
-Routing is handled by a registered `RouteTasksHandler`. It receives a
-`RouteTasksEvent` (the head plan of the stage, the task count, and the active
-`TaskContext`) and returns one worker URL per task, in task order:
+Implement `RouteTaskHandler` and register it on the coordinating session. The
+handler is called once per task with a `RouteTaskEvent`, providing contextual
+information about what task-specialized plan is getting routed, the task
+identifier to which its routed, etc..
+
+Return `None` when the handler does not apply, allowing the next custom or
+built-in handler to run. Otherwise, call `dialer.dial(url).await` and return the
+response for the selected connection. The dialer may be called more than once,
+sequentially or concurrently, to implement retries.
+
+`dialer.dial(url).await` connects to a remote worker under the hood, and returns
+the already established connection. If this call succeeds, it means that the
+worker is in a good state for being part of the query.
 
 ```rust
-fn route_tasks(event: RouteTasksEvent) -> Option<Result<RouteTasksEventResponse>>;
-```
+use async_trait::async_trait;
+use datafusion::common::{Result, exec_err};
+use datafusion::execution::SessionStateBuilder;
+use datafusion_distributed::{
+    DistributedExt, RouteTaskEvent, RouteTaskEventResponse, RouteTaskHandler,
+    ok_or_some_err
+};
 
-- `Some(Ok(RouteTasksEventResponse::new(urls)))` — task `i` is sent to `urls[i]`.
-- `None` — defer to the next handler; the built-in fallback keeps the round-robin behaviour.
+struct RetryRouteTaskHandler;
 
-Register it on the coordinating session builder:
+#[async_trait]
+impl RouteTaskHandler for RetryRouteTaskHandler {
+    async fn handle(&self, event: RouteTaskEvent<'_>) -> Option<Result<RouteTaskEventResponse>> {
+        let urls = match ok_or_some_err!(event.worker_resolver.get_urls());
+        if urls.is_empty() {
+            return Some(exec_err!("no workers available"));
+        }
 
-```rust
+        let start = event.task_key.task_number % urls.len();
+        let mut last_error = None;
+        for offset in 0..urls.len() {
+            let url = urls[(start + offset) % urls.len()].clone();
+            match event.dialer.dial(url).await {
+                Ok(response) => return Some(Ok(response)),
+                Err(error) => last_error = Some(error),
+            }
+        }
+        Some(Err(last_error.expect("at least one worker was attempted")))
+    }
+}
+
 SessionStateBuilder::new()
-    .with_distributed_route_tasks_handler(route_tasks);
+    .with_distributed_route_task_handler(RetryRouteTaskHandler);
 ```
 
 Routing pairs naturally with `ScaleUpLeafNodeHandler`: that decides *what* data
-task `i` reads, and `RouteTasksHandler` decides *where* it runs. If the leaf-scale
-handler returns a `DistributedLeafExec`, its `variants()` are in task order too,
-so you can line up each task's data with the worker that should serve it.
+task `i` reads, and `RouteTaskHandler` decides *where* that specialized task
+runs. The task index can be used to keep a stable slot-to-worker mapping for
+cache affinity.
 
-For a complete, runnable walkthrough — parquet files consistently routed to
-workers by rendezvous hashing of the file path, so each worker can serve them from
-an in-memory cache on repeat queries — see the
+For a complete, runnable walkthrough where parquet files consistently routed to
+workers by hashing the file path, so each worker can serve them from an
+in-memory cache on repeat queries, see the
 [custom_worker_url_routing.rs](https://github.com/datafusion-contrib/datafusion-distributed/blob/main/examples/custom_worker_url_routing.rs)
 example.

--- a/docs/upgrade/5.0.0.md
+++ b/docs/upgrade/5.0.0.md
@@ -1,0 +1,80 @@
+# Upgrading from 4.0.0 to 5.0.0
+
+This guide covers the source and behavioural changes merged after the
+`v4.0.0` tag.
+
+## 1. Task routing is asynchronous and runs once per task
+
+The stage-level `RouteTasksHandler` API has been replaced by the asynchronous,
+per-task `RouteTaskHandler` API:
+
+| 4.0 API                                      | 5.0 API                                     |
+|----------------------------------------------|---------------------------------------------|
+| `RouteTasksHandler`                          | `RouteTaskHandler`                          |
+| `RouteTasksEvent`                            | `RouteTaskEvent`                            |
+| `RouteTasksEventResponse`                    | `RouteTaskEventResponse`                    |
+| `{with,set}_distributed_route_tasks_handler` | `{with,set}_distributed_route_task_handler` |
+
+Previously, a handler ran once per stage and returned one worker URL for each
+task:
+
+```rust
+fn route_tasks(
+    event: RouteTasksEvent<'_>,
+) -> Option<Result<RouteTasksEventResponse>> {
+    let mut urls = event
+        .task_ctx
+        .session_config()
+        .get_distributed_worker_resolver()
+        .ok()?
+        .get_urls()
+        .ok()?;
+    urls.truncate(event.task_count);
+    Some(Ok(RouteTasksEventResponse::new(urls)))
+}
+
+let state = SessionStateBuilder::new()
+    .with_distributed_route_tasks_handler(route_tasks)
+    .build();
+```
+
+In 5.0, implement the async handler and select and dial one worker for the task
+described by the event:
+
+```rust
+use async_trait::async_trait;
+use datafusion::common::Result;
+use datafusion_distributed::{
+    DistributedExt, RouteTaskEvent, RouteTaskEventResponse, RouteTaskHandler,
+};
+
+struct MyRouteTaskHandler;
+
+#[async_trait]
+impl RouteTaskHandler for MyRouteTaskHandler {
+    async fn handle(
+        &self,
+        event: RouteTaskEvent<'_>,
+    ) -> Option<Result<RouteTaskEventResponse>> {
+        let urls = match event.worker_resolver.get_urls() {
+            Ok(urls) => urls,
+            Err(error) => return Some(Err(error)),
+        };
+        if urls.is_empty() {
+            return None;
+        }
+
+        let url = urls[event.task_key.task_number % urls.len()].clone();
+        Some(event.dialer.dial(url).await)
+    }
+}
+
+let state = SessionStateBuilder::new()
+    .with_distributed_route_task_handler(MyRouteTaskHandler)
+    .build();
+```
+
+`event.dialer.dial(url).await` is expected to be used inside the
+`RouteTaskHandler` implementation, therefore a worker is only chosen if a  
+coordinator-to-worker connection is currently established. Implementations can
+choose to retry on other worker if the current one is not available.

--- a/examples/custom_worker_url_routing.md
+++ b/examples/custom_worker_url_routing.md
@@ -2,9 +2,7 @@
 
 Demonstrates **custom task routing** for **cache affinity**: consistently routing each parquet file
 to the *same* worker so that worker can serve it from an in-memory cache on repeat queries. This is
-the
-[`TaskEstimator::route_tasks`](../docs/source/advanced/06-worker-routing.md)
-API.
+the [`RouteTaskHandler`](../docs/source/advanced/06-worker-routing.md) API.
 
 ## Scenario
 
@@ -24,8 +22,8 @@ Routing is a two-step pipeline:
 - `scale_up_leaf_node` flattens all files, hashes each file's path to a slot
   (`hash(path) % task_count`), and builds one `DataSourceExec(CachedFileScanConfig)` variant per
   slot. The same file always hashes to the same slot.
-- `route_tasks` sorts the available worker URLs and maps slot `i` to `sorted_urls[i % n_workers]`.
-  Each slot therefore always reaches the same worker.
+- `CachedFileScanRouteTaskHandler` sorts the available worker URLs and assigns slot `i` to
+  `sorted_urls[i % n_workers]`. Each slot therefore always reaches the same worker.
 
 Together these guarantee that each worker consistently reads the same set of files and its cache
 stays warm across queries.
@@ -40,8 +38,8 @@ cache is warm on the second query even though the plan is serialised and sent fr
 worker's session extension cache first; on a miss it reads via the inner config and populates the
 cache asynchronously through a `RecordBatchReceiverStreamBuilder`.
 
-**`CachedFileScanConfigTaskEstimator`** — the `TaskEstimator`. `scale_up_leaf_node` produces one
-variant per task slot; `route_tasks` pins each slot to a worker by sorted-URL index.
+**`CachedFileScanRouteTaskHandler`** — the assignment handler. The scale-up handler produces one
+variant per task slot; the assignment handler pins each slot to a worker by sorted-URL index.
 
 **`CachedFileScanCodec`** — a `PhysicalExtensionCodec` that round-trips `CachedFileScanConfig` by
 encoding the inner `FileScanConfig` as a plain `DataSourceExec` using DataFusion's default codec,

--- a/examples/custom_worker_url_routing.rs
+++ b/examples/custom_worker_url_routing.rs
@@ -8,7 +8,7 @@
 //! Routing is a two-step pipeline:
 //! - `cached_file_scan_scale_up_leaf_node_handler` assigns each file to a task slot by
 //!   hashing its path (mod task_count), so the same file always lands in the same slot.
-//! - `cached_file_scan_route_tasks_handler` maps slot `i` to `sorted_urls[i % n]`,
+//! - `CachedFileScanRouteTaskHandler` maps slot `i` to `sorted_urls[i % n]`,
 //!   so each slot always reaches the same worker URL.
 //!
 //! Together these guarantee that each worker consistently reads the same set of files and its
@@ -22,6 +22,7 @@
 //!     --show-distributed-plan
 //! ```
 
+use async_trait::async_trait;
 use dashmap::DashMap;
 use datafusion::arrow::array::RecordBatch;
 use datafusion::arrow::util::pretty::pretty_format_batches;
@@ -42,8 +43,8 @@ use datafusion_distributed::test_utils::localhost::{
     LocalHostWorkerResolver, spawn_worker_service,
 };
 use datafusion_distributed::{
-    DesiredTaskCountEvent, DesiredTaskCountEventResponse, DistributedExt, DistributedGetterExt,
-    DistributedLeafExec, RouteTasksEvent, RouteTasksEventResponse, ScaleUpLeafNodeEvent,
+    DesiredTaskCountEvent, DesiredTaskCountEventResponse, DistributedExt, DistributedLeafExec,
+    RouteTaskEvent, RouteTaskEventResponse, RouteTaskHandler, ScaleUpLeafNodeEvent,
     ScaleUpLeafNodeEventResponse, SessionStateBuilderExt, WorkerQueryContext, display_plan_ascii,
 };
 use datafusion_proto::physical_plan::{PhysicalExtensionCodec, PhysicalProtoConverterExtension};
@@ -211,36 +212,38 @@ fn cached_file_scan_scale_up_leaf_node_handler(
     )
 }
 
-fn cached_file_scan_route_tasks_handler(
-    ctx: RouteTasksEvent,
-) -> Option<Result<RouteTasksEventResponse>> {
-    (|| -> Result<Option<RouteTasksEventResponse>> {
-        let available_urls = ctx
-            .task_ctx
-            .session_config()
-            .get_distributed_worker_resolver()?
-            .get_urls()?;
+struct CachedFileScanRouteTaskHandler;
 
-        let mut routed = None;
-        ctx.plan.apply(|node| {
-            if let Some(leaf) = node.downcast_ref::<DistributedLeafExec>()
-                && leaf.original().downcast_ref::<CacheExec>().is_some()
-            {
-                // Sort URLs so the slot→worker mapping is deterministic across planning passes.
-                let mut urls = available_urls.to_vec();
-                urls.sort();
-                routed = Some(
-                    (0..ctx.task_count)
-                        .map(|i| urls[i % urls.len()].clone())
-                        .collect(),
-                );
-                return Ok(TreeNodeRecursion::Stop);
-            }
-            Ok(TreeNodeRecursion::Continue)
-        })?;
-        Ok(routed.map(RouteTasksEventResponse::new))
-    })()
-    .transpose()
+#[async_trait]
+impl RouteTaskHandler for CachedFileScanRouteTaskHandler {
+    async fn handle(&self, ev: RouteTaskEvent<'_>) -> Option<Result<RouteTaskEventResponse>> {
+        let mut has_cached_file_scan = false;
+        ev.task_specialized_plan
+            .apply(|node| {
+                if node.downcast_ref::<CacheExec>().is_some() {
+                    has_cached_file_scan = true;
+                    return Ok(TreeNodeRecursion::Stop);
+                }
+                Ok(TreeNodeRecursion::Continue)
+            })
+            .expect("Cannot fail");
+        if !has_cached_file_scan {
+            return None;
+        }
+
+        let mut available_urls = match ev.worker_resolver.get_urls() {
+            Ok(urls) => urls,
+            Err(err) => return Some(Err(err)),
+        };
+        if available_urls.is_empty() {
+            return Some(internal_err!("WorkerResolver returned 0 URLs"));
+        }
+
+        // Sort URLs so the task-to-worker mapping is deterministic across planning passes.
+        available_urls.sort();
+        let url = available_urls[ev.task_key.task_number % available_urls.len()].clone();
+        Some(ev.dialer.dial(url).await)
+    }
 }
 
 /// Codec for [`CacheExec`]. The child (`DataSourceExec(FileScanConfig)`) is encoded by the
@@ -359,7 +362,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .with_distributed_user_codec(CachedFileScanCodec)
         .with_distributed_desired_task_count_handler(cached_file_scan_desired_task_count_handler)
         .with_distributed_scale_up_leaf_node_handler(cached_file_scan_scale_up_leaf_node_handler)
-        .with_distributed_route_tasks_handler(cached_file_scan_route_tasks_handler)
+        .with_distributed_route_task_handler(CachedFileScanRouteTaskHandler)
         .build();
     state
         .config_mut()

--- a/src/common/recursion.rs
+++ b/src/common/recursion.rs
@@ -31,7 +31,6 @@ pub(crate) trait TreeNodeExt {
     /// Note that every child subtree is polled concurrently with no fan-out limit, so an `f`
     /// that performs I/O will issue up to one request per node of the widest tree level at a
     /// time.
-    #[allow(dead_code)]
     async fn transform_up_async<F, Fut>(self, f: F) -> Result<Transformed<Self>>
     where
         Self: Sized,

--- a/src/coordinator/distributed.rs
+++ b/src/coordinator/distributed.rs
@@ -220,12 +220,12 @@ impl ExecutionPlan for DistributedExec {
         let prepared_plan = Arc::clone(&self.prepared_plan);
         let collect_dynamic_filters = self.completed_dynamic_filter_store.is_some();
 
-        let query_coordinator = QueryCoordinator::new(
+        let query_coordinator = Arc::new(QueryCoordinator::new(
             Arc::clone(&context),
             &self.metrics,
             self.metrics_store.clone(),
             self.completed_dynamic_filter_store.clone(),
-        );
+        ));
 
         let mut builder = RecordBatchReceiverStreamBuilder::new(self.schema(), 1);
         let tx = builder.tx();
@@ -246,7 +246,7 @@ impl ExecutionPlan for DistributedExec {
             let d_cfg = DistributedConfig::from_config_options(context.session_config().options())?;
             let mut prepared = match d_cfg.dynamic_task_count {
                 true => prepare_dynamic_plan(&query_coordinator, &base_plan).await?,
-                false => prepare_static_plan(&query_coordinator, &base_plan)?,
+                false => prepare_static_plan(&query_coordinator, &base_plan).await?,
             };
 
             prepared.plan_for_viz = match collect_dynamic_filters {

--- a/src/coordinator/prepare_dynamic_plan.rs
+++ b/src/coordinator/prepare_dynamic_plan.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 pub(super) async fn prepare_dynamic_plan(
-    query_coordinator: &QueryCoordinator,
+    query_coordinator: &Arc<QueryCoordinator>,
     base_plan: &Arc<dyn ExecutionPlan>,
 ) -> Result<PreparedPlan> {
     let plans_for_viz = Arc::new(PlanReconstructor::default());
@@ -80,27 +80,30 @@ pub(super) async fn prepare_dynamic_plan(
             // is injected to gather runtime statistics.
             input_stage.plan = ProducerHead::insert_sampler(input_stage.plan)?;
 
-            let mut stage_coordinator = query_coordinator.stage_coordinator(&input_stage);
-
-            let mut workers = Vec::with_capacity(input_stage.tasks);
             let mut load_info_rxs = Vec::with_capacity(input_stage.tasks);
 
-            let routed_urls = stage_coordinator.routed_urls()?;
-
-            for (i, routed_url) in routed_urls.into_iter().enumerate() {
-                workers.push(routed_url.clone());
-                // Spawns the task that feeds this subplan to this worker. There will be as
-                // many as this spawned tasks as workers.
-                let (worker_tx, worker_rx) = stage_coordinator.send_plan_task(i, routed_url)?;
-                load_info_rxs.push({
-                    let rx = stage_coordinator.worker_to_coordinator_task(i, worker_rx);
-                    UnboundedReceiverStream::new(rx)
-                });
-                stage_coordinator.coordinator_to_worker_task(i, worker_tx)?;
-            }
-
+            let query_coordinator = Arc::clone(query_coordinator);
             let plans_for_viz = Arc::clone(&plans_for_viz);
+
             Ok(async move {
+                let mut stage_coordinator = query_coordinator.stage_coordinator(&input_stage);
+
+                let mut futures = Vec::with_capacity(input_stage.tasks);
+                for task_i in 0..input_stage.tasks {
+                    futures.push(stage_coordinator.send_plan_task(task_i));
+                }
+                let results = futures::future::try_join_all(futures).await?;
+
+                let mut workers = Vec::with_capacity(input_stage.tasks);
+                for (task_i, (url, worker_tx, worker_rx)) in results.into_iter().enumerate() {
+                    workers.push(url);
+                    load_info_rxs.push({
+                        let rx = stage_coordinator.worker_to_coordinator_task(task_i, worker_rx);
+                        UnboundedReceiverStream::new(rx)
+                    });
+                    stage_coordinator.coordinator_to_worker_task(task_i, worker_tx)?;
+                }
+
                 let (stats, consumer_tc) = if nb_type == TypeId::of::<NetworkCoalesceExec>() {
                     (None, Maximum(1))
                 } else {

--- a/src/coordinator/prepare_dynamic_plan.rs
+++ b/src/coordinator/prepare_dynamic_plan.rs
@@ -90,7 +90,7 @@ pub(super) async fn prepare_dynamic_plan(
 
                 let mut futures = Vec::with_capacity(input_stage.tasks);
                 for task_i in 0..input_stage.tasks {
-                    futures.push(stage_coordinator.send_plan_task(task_i));
+                    futures.push(stage_coordinator.init_bidirectional_stream(task_i));
                 }
                 let results = futures::future::try_join_all(futures).await?;
 

--- a/src/coordinator/prepare_static_plan.rs
+++ b/src/coordinator/prepare_static_plan.rs
@@ -35,7 +35,7 @@ pub(super) async fn prepare_static_plan(
         let mut stage_coordinator = query_coordinator.stage_coordinator(stage);
         let mut futures = Vec::with_capacity(stage.tasks);
         for task_i in 0..stage.tasks {
-            futures.push(stage_coordinator.send_plan_task(task_i));
+            futures.push(stage_coordinator.init_bidirectional_stream(task_i));
         }
         let results = futures::future::try_join_all(futures).await?;
 

--- a/src/coordinator/prepare_static_plan.rs
+++ b/src/coordinator/prepare_static_plan.rs
@@ -1,15 +1,16 @@
+use crate::common::TreeNodeExt;
 use crate::coordinator::distributed::PreparedPlan;
 use crate::coordinator::query_coordinator::QueryCoordinator;
 use crate::stage::RemoteStage;
 use crate::{NetworkBoundaryExt, Stage};
-use datafusion::common::tree_node::{Transformed, TreeNode};
+use datafusion::common::tree_node::Transformed;
 use datafusion::common::{Result, exec_err};
 use datafusion::physical_plan::ExecutionPlan;
 use std::sync::Arc;
 
 /// Prepares the distributed plan for execution, which implies:
 /// 1. Perform some worker URL assignation, choosing either:
-///    - The URLs set by the user with [crate::RouteTasksHandler].
+///    - The workers selected by the user's [crate::RouteTaskHandler].
 ///    - Randomly otherwise
 /// 2. Sending the sliced subplans to the assigned URLs. For each URL assigned to a task, a
 ///    network call feeding the subplan is necessary.
@@ -17,11 +18,11 @@ use std::sync::Arc;
 ///    become nodes without children and traversing them will not go further down in.
 /// 4. Spawn a background task per worker that waits for the worker to finish and collects
 ///    its metrics into [DistributedExec::task_metrics] via the coordinator channel.
-pub(super) fn prepare_static_plan(
+pub(super) async fn prepare_static_plan(
     query_coordinator: &QueryCoordinator,
     base_plan: &Arc<dyn ExecutionPlan>,
 ) -> Result<PreparedPlan> {
-    let prepared = Arc::clone(base_plan).transform_up(|plan| {
+    let prepared = Arc::clone(base_plan).transform_up_async(async |plan| {
         // The following logic is just applied on network boundaries.
         let Some(plan) = plan.as_network_boundary() else {
             return Ok(Transformed::no(plan));
@@ -32,17 +33,17 @@ pub(super) fn prepare_static_plan(
         };
 
         let mut stage_coordinator = query_coordinator.stage_coordinator(stage);
-
-        let routed_urls = stage_coordinator.routed_urls()?;
+        let mut futures = Vec::with_capacity(stage.tasks);
+        for task_i in 0..stage.tasks {
+            futures.push(stage_coordinator.send_plan_task(task_i));
+        }
+        let results = futures::future::try_join_all(futures).await?;
 
         let mut workers = Vec::with_capacity(stage.tasks);
-        for (i, routed_url) in routed_urls.into_iter().enumerate() {
-            workers.push(routed_url.clone());
-            // Spawn a task that sends the subplan to the chosen URL.
-            // There will be as many spawned tasks as workers.
-            let (worker_tx, worker_rx) = stage_coordinator.send_plan_task(i, routed_url)?;
-            stage_coordinator.worker_to_coordinator_task(i, worker_rx);
-            stage_coordinator.coordinator_to_worker_task(i, worker_tx)?;
+        for (task_i, (url, worker_tx, worker_rx)) in results.into_iter().enumerate() {
+            workers.push(url);
+            stage_coordinator.worker_to_coordinator_task(task_i, worker_rx);
+            stage_coordinator.coordinator_to_worker_task(task_i, worker_tx)?;
         }
 
         Ok(Transformed::yes(plan.with_input_stage(Stage::Remote(
@@ -53,9 +54,9 @@ pub(super) fn prepare_static_plan(
                 runtime_stats: None,
             },
         ))?))
-    })?;
+    });
     Ok(PreparedPlan {
-        head_stage: prepared.data,
+        head_stage: prepared.await?.data,
         // If the plan was statically planned, the base plan is the same one that will be used for
         // visualization.
         plan_for_viz: Arc::clone(base_plan),

--- a/src/coordinator/query_coordinator.rs
+++ b/src/coordinator/query_coordinator.rs
@@ -4,23 +4,25 @@ use crate::config_extension_ext::get_config_extension_propagation_headers;
 use crate::coordinator::Store;
 use crate::coordinator::latency_metric::LatencyMetric;
 use crate::dynamic_filtering::maybe_roundtrip_plan_to_sever_in_memory_dynamic_filter_relationships;
-use crate::events::{RouteTasksEvent, RouteTasksHandlers};
+use crate::events::{
+    RouteTaskEvent, RouteTaskEventResponse, RouteTaskHandlers, new_coordinator_to_worker_dialer,
+};
 use crate::execution_plans::{ChildrenIsolatorUnionExec, DistributedLeafExec};
 use crate::passthrough_headers::get_passthrough_headers;
 use crate::stage::LocalStage;
 use crate::work_unit_feed::WorkUnitFeedRegistry;
 use crate::work_unit_feed::{build_work_unit_batch_msg, set_work_unit_send_time};
 use crate::{
-    CoordinatorToWorkerMsg, DISTRIBUTED_DATAFUSION_TASK_ID_LABEL, DistributedTaskContext,
-    DistributedWorkUnitFeedContext, LoadInfo, LocalWorkerContext, MaybeEncoded, SetPlanRequest,
-    TaskCompletedDynamicFilters, TaskKey, TaskMetrics, WorkUnitFeedDeclaration,
-    WorkerToCoordinatorMsg, get_distributed_channel_resolver,
+    CoordinatorToWorkerMsg, DISTRIBUTED_DATAFUSION_TASK_ID_LABEL, DistributedGetterExt,
+    DistributedTaskContext, DistributedWorkUnitFeedContext, LoadInfo, LocalWorkerContext,
+    MaybeEncoded, SetPlanRequest, TaskCompletedDynamicFilters, TaskKey, TaskMetrics,
+    WorkUnitFeedDeclaration, WorkerToCoordinatorMsg, get_distributed_channel_resolver,
 };
-use datafusion::common::DataFusionError;
+use datafusion::common::Result;
 use datafusion::common::instant::Instant;
 use datafusion::common::runtime::JoinSet;
 use datafusion::common::tree_node::{Transformed, TreeNodeRecursion};
-use datafusion::common::{Result, exec_err};
+use datafusion::common::{DataFusionError, internal_err};
 use datafusion::execution::TaskContext;
 use datafusion::physical_expr_common::metrics::{ExecutionPlanMetricsSet, Label, MetricBuilder};
 use datafusion::physical_plan::ExecutionPlan;
@@ -105,7 +107,7 @@ impl QueryCoordinator {
 
     /// Blocks until all background tasks have finished (e.g., sending WorkUnit feeds, or collecting
     /// metrics)
-    pub(super) async fn drain_pending_tasks(self) -> Result<()> {
+    pub(super) async fn drain_pending_tasks(self: Arc<Self>) -> Result<()> {
         let join_set = std::mem::take(self.join_set.lock().unwrap().deref_mut());
         for res in join_set.join_all().await {
             res?;
@@ -140,11 +142,11 @@ impl<'a> StageCoordinator<'a> {
     /// Sends a serialized plan to a specific worker and sets up the bidirectional gRPC stream.
     /// Returns the sender for outbound coordinator-to-worker messages and the receiver for
     /// inbound worker-to-coordinator messages.
-    pub(super) fn send_plan_task(
-        &mut self,
+    pub(super) async fn send_plan_task(
+        &self,
         task_i: usize,
-        url: Url,
     ) -> Result<(
+        Url,
         UnboundedSender<CoordinatorToWorkerMsg>,
         UnboundedReceiver<WorkerToCoordinatorMsg>,
     )> {
@@ -157,66 +159,105 @@ impl<'a> StageCoordinator<'a> {
             stage_id: self.stage_id,
             task_number: task_i,
         };
-        let set_plan_request = SetPlanRequest {
-            task_key,
-            task_count: self.task_count,
-            plan: MaybeEncoded::Decoded(specialized),
-            work_unit_feed_declarations,
-            target_worker_url: url.clone(),
-            query_start_time_ns: self.metrics.instantiation_time,
-        };
-
-        let (coordinator_to_worker_tx, coordinator_to_worker_rx) =
-            tokio::sync::mpsc::unbounded_channel();
-        let (worker_to_coordinator_tx, worker_to_coordinator_rx) =
-            tokio::sync::mpsc::unbounded_channel();
 
         let mut headers = get_config_extension_propagation_headers(session_config)?;
         headers.extend(get_passthrough_headers(session_config));
 
-        let coordinator_to_worker_stream = UnboundedReceiverStream::new(coordinator_to_worker_rx)
-            .map(set_work_unit_send_time)
-            // Keep the request side of the channel open until the query ends: this tail emits
-            // no messages and only completes, once the `Notify` fires. Workers interpret this
-            // EOS of this stream as a query finished/aborted signal. The flow looks like this:
-            // 1. The query ends normally, as all Arrow RecordBatches are already streamed.
-            // 2. The end stream notifier guard is dropped in `DistributedExec::execute()`.
-            // 3. Here, `end_stream_notifier` fires and the coordinator->worker channel is
-            //    gracefully ended.
-            // 4. The coordinator->worker channel EOS is received in `impl_coordinator_channel.rs`.
-            // 5. The metrics and final dynamic filters are sent back in the
-            //    worker->coordinator channel, and then that channel is closed.
-            .chain(keep_stream_alive(Arc::clone(self.end_stream_notifier)))
-            .boxed();
-
         let metrics = self.metrics.clone();
         let metrics_set = self.metrics_set.clone();
-        let task_ctx = Arc::clone(self.task_ctx);
+        // Stores the last coordinator_to_worker_tx that was attempted for establishing a
+        // connection with the remote worker. If dialing a remote worker fails, and it's retried,
+        // this will hold the channel belonging to the last retry
+        let coordinator_to_worker_tx_slot = Mutex::new(None);
 
+        let dialer = new_coordinator_to_worker_dialer(|url| {
+            let (coordinator_to_worker_tx, coordinator_to_worker_rx) =
+                tokio::sync::mpsc::unbounded_channel();
+            coordinator_to_worker_tx_slot
+                .lock()
+                .unwrap()
+                .replace(coordinator_to_worker_tx);
+
+            let coordinator_to_worker_stream =
+                UnboundedReceiverStream::new(coordinator_to_worker_rx)
+                    .map(set_work_unit_send_time)
+                    // Keep the request side of the channel open until the query ends: this tail emits
+                    // no messages and only completes, once the `Notify` fires. Workers interpret this
+                    // EOS of this stream as a query finished/aborted signal. The flow looks like this:
+                    // 1. The query ends normally, as all Arrow RecordBatches are already streamed.
+                    // 2. The end stream notifier guard is dropped in `DistributedExec::execute()`.
+                    // 3. Here, `end_stream_notifier` fires and the coordinator->worker channel is
+                    //    gracefully ended.
+                    // 4. The coordinator->worker channel EOS is received in `impl_coordinator_channel.rs`.
+                    // 5. The metrics and final dynamic filters are sent back in the
+                    //    worker->coordinator channel, and then that channel is closed.
+                    .chain(keep_stream_alive(Arc::clone(self.end_stream_notifier)))
+                    .boxed();
+
+            let set_plan_request = SetPlanRequest {
+                task_key,
+                task_count: self.task_count,
+                plan: MaybeEncoded::Decoded(Arc::clone(&specialized)),
+                work_unit_feed_declarations: work_unit_feed_declarations.clone(),
+                target_worker_url: url.clone(),
+                query_start_time_ns: self.metrics.instantiation_time,
+            };
+            let task_ctx = Arc::clone(self.task_ctx);
+            let headers = headers.clone();
+            let metrics = metrics.clone();
+            let metrics_set = metrics_set.clone();
+
+            async move {
+                let mut client = match LocalWorkerContext::from_ctx(&task_ctx) {
+                    Some(lw) if lw.self_url == url => {
+                        metrics.local_coordinator_channels.add(1);
+                        Ok(lw.to_worker_channel())
+                    }
+                    _ => {
+                        metrics.remote_coordinator_channels.add(1);
+                        let ch_resolver = get_distributed_channel_resolver(task_ctx.as_ref());
+                        ch_resolver.get_worker_client_for_url(&url).await
+                    }
+                }?;
+                let worker_to_coordinator_stream = client
+                    .coordinator_channel(
+                        headers,
+                        set_plan_request,
+                        coordinator_to_worker_stream,
+                        metrics_set,
+                        &task_ctx,
+                    )
+                    .await?;
+
+                Ok::<_, DataFusionError>(RouteTaskEventResponse {
+                    url,
+                    worker_to_coordinator_stream,
+                })
+            }
+        });
+
+        let worker_resolver = session_config.get_distributed_worker_resolver()?;
+
+        let ev = RouteTaskEvent {
+            task_ctx: self.task_ctx,
+            worker_resolver: worker_resolver.as_ref(),
+            task_specialized_plan: &specialized,
+            task_key,
+            task_count: self.task_count,
+            dialer: &dialer,
+        };
+
+        let start = Instant::now();
+        let Some(response) = RouteTaskHandlers::handle(ev).await.transpose()? else {
+            return internal_err!("No RouteTaskHandler returned a response");
+        };
+        metrics.plan_send_latency.record(&start);
+
+        let (worker_to_coordinator_tx, worker_to_coordinator_rx) =
+            tokio::sync::mpsc::unbounded_channel();
+
+        let mut worker_to_coordinator_stream = response.worker_to_coordinator_stream;
         self.join_set.lock().unwrap().spawn(async move {
-            let start = Instant::now();
-
-            let mut client = match LocalWorkerContext::from_ctx(&task_ctx) {
-                Some(lw) if lw.self_url == url => {
-                    metrics.local_coordinator_channels.add(1);
-                    Ok(lw.to_worker_channel())
-                }
-                _ => {
-                    metrics.remote_coordinator_channels.add(1);
-                    let ch_resolver = get_distributed_channel_resolver(task_ctx.as_ref());
-                    ch_resolver.get_worker_client_for_url(&url).await
-                }
-            }?;
-            let mut worker_to_coordinator_stream = client
-                .coordinator_channel(
-                    headers,
-                    set_plan_request,
-                    coordinator_to_worker_stream,
-                    metrics_set,
-                    &task_ctx,
-                )
-                .await?;
-            metrics.plan_send_latency.record(&start);
             while let Some(msg) = worker_to_coordinator_stream.try_next().await? {
                 if worker_to_coordinator_tx.send(msg).is_err() {
                     break; // receiver dropped
@@ -225,7 +266,16 @@ impl<'a> StageCoordinator<'a> {
             Ok::<_, DataFusionError>(())
         });
 
-        Ok((coordinator_to_worker_tx, worker_to_coordinator_rx))
+        let Some(coordinator_to_worker_tx) = coordinator_to_worker_tx_slot.lock().unwrap().take()
+        else {
+            return internal_err!("Missing coordinator_to_worker_tx");
+        };
+
+        Ok((
+            response.url,
+            coordinator_to_worker_tx,
+            worker_to_coordinator_rx,
+        ))
     }
 
     /// Spawns a background task in charge of collecting messages sent by a worker. Some things that
@@ -403,31 +453,6 @@ impl<'a> StageCoordinator<'a> {
             self.task_ctx,
         )?;
         Ok((plan, work_unit_feed_declarations))
-    }
-
-    /// Returns as many URLs as the task count for the stage this [StageCoordinator]
-    /// is managing. These URLs can be:
-    /// - assigned randomly, if the user did not provide any custom routing.
-    /// - chosen by the user, if they provided an implementation for the
-    ///   [RouteTasksHandler::route_tasks] method.
-    pub(super) fn routed_urls(&self) -> Result<Vec<Url>> {
-        let ev = RouteTasksEvent {
-            task_ctx: Arc::clone(self.task_ctx),
-            plan: self.plan,
-            task_count: self.task_count,
-        };
-        let Some(routed) = RouteTasksHandlers::handle(ev).transpose()? else {
-            return exec_err!("No task routing handler was able to resolve URLs for stage");
-        };
-
-        if routed.urls.len() != self.task_count {
-            return exec_err!(
-                "number of tasks ({}) was not equal to number of urls ({}) at execution time",
-                self.task_count,
-                routed.urls.len()
-            );
-        }
-        Ok(routed.urls)
     }
 }
 

--- a/src/coordinator/query_coordinator.rs
+++ b/src/coordinator/query_coordinator.rs
@@ -139,10 +139,13 @@ pub(super) struct StageCoordinator<'a> {
 }
 
 impl<'a> StageCoordinator<'a> {
-    /// Sends a serialized plan to a specific worker and sets up the bidirectional gRPC stream.
-    /// Returns the sender for outbound coordinator-to-worker messages and the receiver for
-    /// inbound worker-to-coordinator messages.
-    pub(super) async fn send_plan_task(
+    /// Sends a plan to a specific worker and sets up the bidirectional stream.
+    ///
+    /// Its returns are:
+    /// - The worker URL in which the task got allocated
+    /// - The coordinator-to-worker stream for producing messages that reach the worker.
+    /// - The worker-to-coordinator stream for receiving messages from the worker.
+    pub(super) async fn init_bidirectional_stream(
         &self,
         task_i: usize,
     ) -> Result<(

--- a/src/distributed_ext.rs
+++ b/src/distributed_ext.rs
@@ -675,7 +675,7 @@ pub trait DistributedExt: Sized {
     /// # use async_trait::async_trait;
     /// # use datafusion::error::Result;
     /// # use datafusion::execution::SessionStateBuilder;
-    /// # use datafusion_distributed::{DistributedExt, RouteTaskEvent, RouteTaskEventResponse, RouteTaskHandler};
+    /// # use datafusion_distributed::{ok_or_some_err, DistributedExt, RouteTaskEvent, RouteTaskEventResponse, RouteTaskHandler};
     /// # use url::Url;
     ///
     /// struct AssignToWorker;
@@ -686,7 +686,8 @@ pub trait DistributedExt: Sized {
     ///         &self,
     ///         event: RouteTaskEvent<'_>,
     ///     ) -> Option<Result<RouteTaskEventResponse>> {
-    ///         let url = Url::parse("http://worker1:50051").unwrap();
+    ///         let urls = ok_or_some_err!(event.worker_resolver.get_urls());
+    ///         let url = urls.choose(&mut rand::rng());
     ///         Some(event.dialer.dial(url).await)
     ///     }
     /// }

--- a/src/distributed_ext.rs
+++ b/src/distributed_ext.rs
@@ -3,7 +3,7 @@ use crate::config_extension_ext::{
     set_distributed_option_extension, set_distributed_option_extension_from_headers,
 };
 use crate::events::{
-    DesiredTaskCountHandler, DesiredTaskCountHandlers, RouteTasksHandler, RouteTasksHandlers,
+    DesiredTaskCountHandler, DesiredTaskCountHandlers, RouteTaskHandler, RouteTaskHandlers,
     ScaleUpLeafNodeHandler, ScaleUpLeafNodeHandlers, WorkerPlanRewriteHandler,
     WorkerPlanRewriteHandlers,
 };
@@ -199,25 +199,20 @@ pub trait DistributedExt: Sized {
     ///
     /// Example:
     ///
-    /// ```
-    /// # use async_trait::async_trait;
+    /// ```rust
     /// # use datafusion::common::DataFusionError;
-    /// # use datafusion::execution::{SessionState, SessionStateBuilder};
-    /// # use datafusion::prelude::SessionConfig;
+    /// # use datafusion::execution::SessionStateBuilder;
     /// # use url::Url;
-    /// # use std::sync::Arc;
-    /// # use datafusion_distributed::{WorkerResolver, DistributedExt, SessionStateBuilderExt, WorkerQueryContext};
+    /// # use datafusion_distributed::{WorkerResolver, DistributedExt, SessionStateBuilderExt};
     ///
     /// struct CustomWorkerResolver;
     ///
-    /// #[async_trait]
     /// impl WorkerResolver for CustomWorkerResolver {
     ///     fn get_urls(&self) -> Result<Vec<Url>, DataFusionError> {
     ///         todo!()
     ///     }
     /// }
     ///
-    /// // This tweaks the SessionState so that it can plan for distributed queries and execute them.
     /// let state = SessionStateBuilder::new()
     ///     .with_distributed_worker_resolver(CustomWorkerResolver)
     ///     .with_distributed_planner()
@@ -225,7 +220,7 @@ pub trait DistributedExt: Sized {
     /// ```
     fn with_distributed_worker_resolver<T: WorkerResolver + 'static>(self, resolver: T) -> Self;
 
-    /// Same as [DistributedExt::with_distributed_channel_resolver] but with an in-place mutation.
+    /// Same as [DistributedExt::with_distributed_worker_resolver] but with an in-place mutation.
     fn set_distributed_worker_resolver<T: WorkerResolver + 'static>(&mut self, resolver: T);
 
     /// This is what tells Distributed DataFusion how to build a Worker gRPC client out of a worker URL.
@@ -673,40 +668,37 @@ pub trait DistributedExt: Sized {
     /// in-place mutation.
     fn set_distributed_scale_up_leaf_node_handler<T: ScaleUpLeafNodeHandler>(&mut self, handler: T);
 
-    /// Registers a handler that maps a stage's task slots to worker URLs before execution.
-    /// A response must contain one URL per task, in task-index order.
-    ///
-    /// A function with the following signature can be provided as argument:
+    /// Registers an asynchronous handler that assigns each distributed task to a worker.
+    /// The handler may call the event's dialer multiple times to implement retries or failover.
     ///
     /// ```rust
+    /// # use async_trait::async_trait;
     /// # use datafusion::error::Result;
     /// # use datafusion::execution::SessionStateBuilder;
-    /// # use datafusion_distributed::{DistributedExt, DistributedGetterExt, RouteTasksEvent, RouteTasksEventResponse};
+    /// # use datafusion_distributed::{DistributedExt, RouteTaskEvent, RouteTaskEventResponse, RouteTaskHandler};
+    /// # use url::Url;
     ///
-    /// fn handle_custom_route_tasks(event: RouteTasksEvent) -> Option<Result<RouteTasksEventResponse>> {
-    ///     let routing = event.task_ctx.session_config()
-    ///         .get_distributed_worker_resolver()
-    ///         .and_then(|resolver| resolver.get_urls())
-    ///         .map(|workers| RouteTasksEventResponse::new(
-    ///             workers.into_iter().cycle().take(event.task_count).collect()
-    ///         ));
-    ///     Some(routing)
+    /// struct AssignToWorker;
+    ///
+    /// #[async_trait]
+    /// impl RouteTaskHandler for AssignToWorker {
+    ///     async fn handle(
+    ///         &self,
+    ///         event: RouteTaskEvent<'_>,
+    ///     ) -> Option<Result<RouteTaskEventResponse>> {
+    ///         let url = Url::parse("http://worker1:50051").unwrap();
+    ///         Some(event.dialer.dial(url).await)
+    ///     }
     /// }
     ///
     /// SessionStateBuilder::new()
-    ///     .with_distributed_route_tasks_handler(handle_custom_route_tasks);
+    ///     .with_distributed_route_task_handler(AssignToWorker);
     /// ```
-    ///
-    /// ```text
-    /// task 0  ──► http://worker1
-    /// task 1  ──► http://worker2     RouteTasksHandler
-    /// task 2  ──► http://worker3
-    /// ```
-    fn with_distributed_route_tasks_handler<T: RouteTasksHandler>(self, handler: T) -> Self;
+    fn with_distributed_route_task_handler<T: RouteTaskHandler>(self, handler: T) -> Self;
 
-    /// Same as [DistributedExt::with_distributed_route_tasks_handler] but with an in-place
+    /// Same as [DistributedExt::with_distributed_route_task_handler] but with an in-place
     /// mutation.
-    fn set_distributed_route_tasks_handler<T: RouteTasksHandler>(&mut self, handler: T);
+    fn set_distributed_route_task_handler<T: RouteTaskHandler>(&mut self, handler: T);
 
     /// Registers a handler that rewrites a decoded worker stage plan before it is executed.
     ///
@@ -934,8 +926,8 @@ impl DistributedExt for SessionConfig {
         ScaleUpLeafNodeHandlers::push_custom(self, Arc::new(h));
     }
 
-    fn set_distributed_route_tasks_handler<H: RouteTasksHandler>(&mut self, h: H) {
-        RouteTasksHandlers::push_custom(self, Arc::new(h));
+    fn set_distributed_route_task_handler<H: RouteTaskHandler>(&mut self, h: H) {
+        RouteTaskHandlers::push_custom(self, Arc::new(h));
     }
 
     fn set_distributed_worker_plan_rewrite_handler<H: WorkerPlanRewriteHandler>(&mut self, h: H) {
@@ -1046,9 +1038,9 @@ impl DistributedExt for SessionConfig {
             #[expr($;self)]
             fn with_distributed_scale_up_leaf_node_handler<H: ScaleUpLeafNodeHandler>(mut self, h: H) -> Self;
 
-            #[call(set_distributed_route_tasks_handler)]
+            #[call(set_distributed_route_task_handler)]
             #[expr($;self)]
-            fn with_distributed_route_tasks_handler<H: RouteTasksHandler>(mut self, h: H) -> Self;
+            fn with_distributed_route_task_handler<H: RouteTaskHandler>(mut self, h: H) -> Self;
 
             #[call(set_distributed_worker_plan_rewrite_handler)]
             #[expr($;self)]
@@ -1197,10 +1189,10 @@ impl DistributedExt for SessionStateBuilder {
             #[expr($;self)]
             fn with_distributed_scale_up_leaf_node_handler<H: ScaleUpLeafNodeHandler>(mut self, h: H) -> Self;
 
-            fn set_distributed_route_tasks_handler<H: RouteTasksHandler>(&mut self, h: H);
-            #[call(set_distributed_route_tasks_handler)]
+            fn set_distributed_route_task_handler<H: RouteTaskHandler>(&mut self, h: H);
+            #[call(set_distributed_route_task_handler)]
             #[expr($;self)]
-            fn with_distributed_route_tasks_handler<H: RouteTasksHandler>(mut self, h: H) -> Self;
+            fn with_distributed_route_task_handler<H: RouteTaskHandler>(mut self, h: H) -> Self;
 
             fn set_distributed_worker_plan_rewrite_handler<H: WorkerPlanRewriteHandler>(&mut self, h: H);
             #[call(set_distributed_worker_plan_rewrite_handler)]
@@ -1352,10 +1344,10 @@ impl DistributedExt for SessionState {
             #[expr($;self)]
             fn with_distributed_scale_up_leaf_node_handler<H: ScaleUpLeafNodeHandler>(mut self, h: H) -> Self;
 
-            fn set_distributed_route_tasks_handler<H: RouteTasksHandler>(&mut self, h: H);
-            #[call(set_distributed_route_tasks_handler)]
+            fn set_distributed_route_task_handler<H: RouteTaskHandler>(&mut self, h: H);
+            #[call(set_distributed_route_task_handler)]
             #[expr($;self)]
-            fn with_distributed_route_tasks_handler<H: RouteTasksHandler>(mut self, h: H) -> Self;
+            fn with_distributed_route_task_handler<H: RouteTaskHandler>(mut self, h: H) -> Self;
 
             fn set_distributed_worker_plan_rewrite_handler<H: WorkerPlanRewriteHandler>(&mut self, h: H);
             #[call(set_distributed_worker_plan_rewrite_handler)]
@@ -1500,10 +1492,10 @@ impl DistributedExt for SessionContext {
             #[expr($;self)]
             fn with_distributed_scale_up_leaf_node_handler<H: ScaleUpLeafNodeHandler>(self, h: H) -> Self;
 
-            fn set_distributed_route_tasks_handler<H: RouteTasksHandler>(&mut self, h: H);
-            #[call(set_distributed_route_tasks_handler)]
+            fn set_distributed_route_task_handler<H: RouteTaskHandler>(&mut self, h: H);
+            #[call(set_distributed_route_task_handler)]
             #[expr($;self)]
-            fn with_distributed_route_tasks_handler<H: RouteTasksHandler>(self, h: H) -> Self;
+            fn with_distributed_route_task_handler<H: RouteTaskHandler>(self, h: H) -> Self;
 
             fn set_distributed_worker_plan_rewrite_handler<H: WorkerPlanRewriteHandler>(&mut self, h: H);
             #[call(set_distributed_worker_plan_rewrite_handler)]

--- a/src/distributed_ext.rs
+++ b/src/distributed_ext.rs
@@ -676,7 +676,7 @@ pub trait DistributedExt: Sized {
     /// # use datafusion::error::Result;
     /// # use datafusion::execution::SessionStateBuilder;
     /// # use datafusion_distributed::{ok_or_some_err, DistributedExt, RouteTaskEvent, RouteTaskEventResponse, RouteTaskHandler};
-    /// # use url::Url;
+    /// # use rand::prelude::IndexedRandom;
     ///
     /// struct AssignToWorker;
     ///
@@ -687,8 +687,8 @@ pub trait DistributedExt: Sized {
     ///         event: RouteTaskEvent<'_>,
     ///     ) -> Option<Result<RouteTaskEventResponse>> {
     ///         let urls = ok_or_some_err!(event.worker_resolver.get_urls());
-    ///         let url = urls.choose(&mut rand::rng());
-    ///         Some(event.dialer.dial(url).await)
+    ///         let url = urls.choose(&mut rand::rng()).expect("No URLs available");
+    ///         Some(event.dialer.dial(url.clone()).await)
     ///     }
     /// }
     ///

--- a/src/distributed_planner/session_state_builder_ext.rs
+++ b/src/distributed_planner/session_state_builder_ext.rs
@@ -1,9 +1,9 @@
 use crate::distributed_planner::DistributedConfig;
 use crate::distributed_planner::distributed_query_planner::DistributedQueryPlanner;
 use crate::events::{
-    DesiredTaskCountHandlers, RouteTasksHandlers, ScaleUpLeafNodeHandlers,
-    file_scan_config_desired_task_count, file_scan_config_scale_up_leaf_node, random_routing,
-    single_task_child_url_routing, single_task_coordinator_routing,
+    DesiredTaskCountHandlers, RandomRouteTaskHandler, RouteTaskHandlers, ScaleUpLeafNodeHandlers,
+    SingleTaskChildUrlRouteTaskHandler, SingleTaskCoordinatorRouteTaskHandler,
+    file_scan_config_desired_task_count, file_scan_config_scale_up_leaf_node,
 };
 use datafusion::execution::SessionStateBuilder;
 use std::sync::Arc;
@@ -33,17 +33,17 @@ impl SessionStateBuilderExt for SessionStateBuilder {
         ScaleUpLeafNodeHandlers::push_builtin(cfg, Arc::new(file_scan_config_scale_up_leaf_node));
 
         // Add default routing event handlers:
-        RouteTasksHandlers::extend_builtin(
+        RouteTaskHandlers::extend_builtin(
             cfg,
             vec![
                 // 1. If there's a single task to route, place it in the coordinator if it can also act as
                 //    a worker.
-                Arc::new(single_task_coordinator_routing),
+                Arc::new(SingleTaskCoordinatorRouteTaskHandler),
                 // 2. If there's a single task to route, and it cannot be placed in the coordinator,
                 //    co-locate it in one of the workers from the stage below to avoid network transfers.
-                Arc::new(single_task_child_url_routing),
+                Arc::new(SingleTaskChildUrlRouteTaskHandler),
                 // 3. If everything above fails, just place randomly.
-                Arc::new(random_routing),
+                Arc::new(RandomRouteTaskHandler),
             ],
         );
 

--- a/src/events/defaults/mod.rs
+++ b/src/events/defaults/mod.rs
@@ -5,5 +5,6 @@ pub(crate) use file_scan_config::{
     file_scan_config_desired_task_count, file_scan_config_scale_up_leaf_node,
 };
 pub(crate) use routing::{
-    random_routing, single_task_child_url_routing, single_task_coordinator_routing,
+    RandomRouteTaskHandler, SingleTaskChildUrlRouteTaskHandler,
+    SingleTaskCoordinatorRouteTaskHandler,
 };

--- a/src/events/defaults/routing.rs
+++ b/src/events/defaults/routing.rs
@@ -1,71 +1,91 @@
 use crate::{
-    DistributedGetterExt, LocalWorkerContext, NetworkBoundaryExt, RouteTasksEvent,
-    RouteTasksEventResponse, Stage, WorkerResolver, ok_or_some_err,
+    LocalWorkerContext, NetworkBoundaryExt, RouteTaskEvent, RouteTaskEventResponse,
+    RouteTaskHandler, Stage, TaskKey, ok_or_some_err,
 };
+use async_trait::async_trait;
+use datafusion::common::Result;
 use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
-use datafusion::common::{Result, exec_err};
-use rand::Rng;
+use rand::prelude::StdRng;
+use rand::{Rng, SeedableRng};
 
-/// Randomly chooses `ev.task_count` urls from the registered URLs.
-pub(crate) fn random_routing(ev: RouteTasksEvent) -> Option<Result<RouteTasksEventResponse>> {
-    let worker_resolver = ok_or_some_err!(
-        ev.task_ctx
-            .session_config()
-            .get_distributed_worker_resolver()
-    );
+/// Assigns a task to a random URL from the registered [WorkerResolver].
+pub(crate) struct RandomRouteTaskHandler;
 
-    let available_urls = ok_or_some_err!(worker_resolver.get_urls());
+#[async_trait]
+impl RouteTaskHandler for RandomRouteTaskHandler {
+    async fn handle(&self, ev: RouteTaskEvent<'_>) -> Option<Result<RouteTaskEventResponse>> {
+        let urls = ok_or_some_err!(ev.worker_resolver.get_urls());
+        let url = stage_contiguous_rand_choice(&ev.task_key, &urls)?;
 
-    if available_urls.is_empty() {
-        return Some(exec_err!("0 URLs available during routing"));
+        Some(ev.dialer.dial(url.clone()).await)
+    }
+}
+
+/// Chooses an item using a random starting offset shared by every task in this stage.
+/// Successive task numbers rotate through the list from that offset.
+fn stage_contiguous_rand_choice<T>(key: &TaskKey, list: impl IntoIterator<Item = T>) -> Option<T> {
+    let list = list.into_iter().collect::<Vec<_>>();
+    if list.is_empty() {
+        return None;
     }
 
-    let start_idx = rand::rng().random_range(0..available_urls.len());
-    let urls = (0..ev.task_count)
-        .map(|i| available_urls[(start_idx + i) % available_urls.len()].clone())
-        .collect::<Vec<_>>();
-
-    Some(Ok(RouteTasksEventResponse::new(urls)))
+    let mut seed = [0; 32];
+    seed[..16].copy_from_slice(key.query_id.as_bytes());
+    seed[16..24].copy_from_slice(&(key.stage_id as u64).to_le_bytes());
+    let mut rng = StdRng::from_seed(seed);
+    let start = rng.random_range(0..list.len());
+    let index = (start + key.task_number % list.len()) % list.len();
+    list.into_iter().nth(index)
 }
 
 /// If there's a single task, it co-locates it in the coordinator if it can also act as a worker.
-pub(crate) fn single_task_coordinator_routing(
-    ev: RouteTasksEvent,
-) -> Option<Result<RouteTasksEventResponse>> {
-    if ev.task_count != 1 {
-        return None;
+pub(crate) struct SingleTaskCoordinatorRouteTaskHandler;
+
+#[async_trait]
+impl RouteTaskHandler for SingleTaskCoordinatorRouteTaskHandler {
+    async fn handle(&self, ev: RouteTaskEvent<'_>) -> Option<Result<RouteTaskEventResponse>> {
+        if ev.task_count != 1 {
+            return None;
+        }
+
+        let local_worker_context = ev
+            .task_ctx
+            .session_config()
+            .get_extension::<LocalWorkerContext>()?;
+
+        Some(ev.dialer.dial(local_worker_context.self_url.clone()).await)
     }
-    ev.task_ctx
-        .session_config()
-        .get_extension::<LocalWorkerContext>()
-        .map(|v| Ok(RouteTasksEventResponse::new(vec![v.self_url.clone()])))
 }
 
 /// If there's a single task, it co-locates it one of the remote workers that is already handling
 /// a child task, avoiding network transfers.
-pub(crate) fn single_task_child_url_routing(
-    ev: RouteTasksEvent,
-) -> Option<Result<RouteTasksEventResponse>> {
-    if ev.task_count != 1 {
-        return None;
+pub(crate) struct SingleTaskChildUrlRouteTaskHandler;
+
+#[async_trait]
+impl RouteTaskHandler for SingleTaskChildUrlRouteTaskHandler {
+    async fn handle(&self, ev: RouteTaskEvent<'_>) -> Option<Result<RouteTaskEventResponse>> {
+        if ev.task_count != 1 {
+            return None;
+        }
+        let mut single_stage_url = None;
+        ev.task_specialized_plan
+            .apply(|plan| {
+                let Some(nb) = plan.as_network_boundary() else {
+                    return Ok(TreeNodeRecursion::Continue);
+                };
+
+                if let Stage::Remote(remote) = nb.input_stage()
+                    && remote.workers.len() == 1
+                {
+                    single_stage_url = Some(remote.workers[0].clone());
+                    return Ok(TreeNodeRecursion::Stop);
+                }
+
+                Ok(TreeNodeRecursion::Jump)
+            })
+            .expect("Cannot fail");
+        let single_stage_url = single_stage_url?;
+
+        Some(ev.dialer.dial(single_stage_url).await)
     }
-    let mut single_stage_url = None;
-    ev.plan
-        .apply(|plan| {
-            let Some(nb) = plan.as_network_boundary() else {
-                return Ok(TreeNodeRecursion::Continue);
-            };
-
-            if let Stage::Remote(remote) = nb.input_stage()
-                && remote.workers.len() == 1
-            {
-                single_stage_url = Some(remote.workers[0].clone());
-                return Ok(TreeNodeRecursion::Stop);
-            }
-
-            Ok(TreeNodeRecursion::Jump)
-        })
-        .expect("Cannot fail");
-
-    single_stage_url.map(|url| Ok(RouteTasksEventResponse::new(vec![url])))
 }

--- a/src/events/defaults/routing.rs
+++ b/src/events/defaults/routing.rs
@@ -15,7 +15,7 @@ pub(crate) struct RandomRouteTaskHandler;
 impl RouteTaskHandler for RandomRouteTaskHandler {
     async fn handle(&self, ev: RouteTaskEvent<'_>) -> Option<Result<RouteTaskEventResponse>> {
         let urls = ok_or_some_err!(ev.worker_resolver.get_urls());
-        let url = stage_contiguous_rand_choice(&ev.task_key, &urls)?;
+        let url = stage_contiguous_rand_offset(&ev.task_key, &urls)?;
 
         Some(ev.dialer.dial(url.clone()).await)
     }
@@ -23,7 +23,7 @@ impl RouteTaskHandler for RandomRouteTaskHandler {
 
 /// Chooses an item using a random starting offset shared by every task in this stage.
 /// Successive task numbers rotate through the list from that offset.
-fn stage_contiguous_rand_choice<T>(key: &TaskKey, list: impl IntoIterator<Item = T>) -> Option<T> {
+fn stage_contiguous_rand_offset<T>(key: &TaskKey, list: impl IntoIterator<Item = T>) -> Option<T> {
     let list = list.into_iter().collect::<Vec<_>>();
     if list.is_empty() {
         return None;

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -6,16 +6,19 @@ mod scale_up_leaf_node;
 mod worker_plan_rewrite;
 
 pub(crate) use defaults::{
-    file_scan_config_desired_task_count, file_scan_config_scale_up_leaf_node, random_routing,
-    single_task_child_url_routing, single_task_coordinator_routing,
+    RandomRouteTaskHandler, SingleTaskChildUrlRouteTaskHandler,
+    SingleTaskCoordinatorRouteTaskHandler, file_scan_config_desired_task_count,
+    file_scan_config_scale_up_leaf_node,
 };
 pub(crate) use desired_task_count::DesiredTaskCountHandlers;
 pub use desired_task_count::{
     DesiredTaskCountEvent, DesiredTaskCountEventResponse, DesiredTaskCountHandler,
     TaskCountAnnotation,
 };
-pub(crate) use route_tasks::RouteTasksHandlers;
-pub use route_tasks::{RouteTasksEvent, RouteTasksEventResponse, RouteTasksHandler};
+pub use route_tasks::{
+    CoordinatorToWorkerDialer, RouteTaskEvent, RouteTaskEventResponse, RouteTaskHandler,
+};
+pub(crate) use route_tasks::{RouteTaskHandlers, new_coordinator_to_worker_dialer};
 pub(crate) use scale_up_leaf_node::ScaleUpLeafNodeHandlers;
 pub use scale_up_leaf_node::{
     ScaleUpLeafNodeEvent, ScaleUpLeafNodeEventResponse, ScaleUpLeafNodeHandler,

--- a/src/events/route_tasks.rs
+++ b/src/events/route_tasks.rs
@@ -1,79 +1,107 @@
-use super::common::EventHandlerChain;
-use datafusion::error::Result;
+use crate::events::common::EventHandlerChain;
+use crate::{TaskKey, WorkerResolver, WorkerToCoordinatorMsg};
+use async_trait::async_trait;
+use datafusion::common::Result;
 use datafusion::execution::TaskContext;
 use datafusion::physical_plan::ExecutionPlan;
+use futures::stream::BoxStream;
 use std::sync::Arc;
 use url::Url;
 
-/// Information supplied when the coordinator assigns a stage's tasks to workers.
-///
-/// A routing response contains one worker URL per task, in task-index order. The coordinator
-/// validates that a response has exactly [`Self::handle`] URLs before it starts the stage.
-#[derive(Clone)]
-pub struct RouteTasksEvent<'a> {
+/// Information supplied when the coordinator assigns one distributed task to a worker.
+#[derive(Clone, Copy)]
+pub struct RouteTaskEvent<'a> {
     /// The task context active for the query being coordinated.
-    pub task_ctx: Arc<TaskContext>,
-    /// The head execution plan of the stage whose tasks are being routed.
-    /// WARNING: this is never going to be a custom leaf node, this is the head node of the fragment
-    ///  of the plan that contains the custom leaf node.
-    pub plan: &'a Arc<dyn ExecutionPlan>,
-    /// The number of task slots that need a worker assignment.
+    pub task_ctx: &'a Arc<TaskContext>,
+    /// [WorkerResolver] in scope.
+    pub worker_resolver: &'a dyn WorkerResolver,
+    /// Identifier of the task that is getting assigned.
+    pub task_key: TaskKey,
+    /// Number of tasks of the stage to which the assigned task belongs.
     pub task_count: usize,
-}
-
-/// Worker assignments returned by a [`RouteTasksHandler`].
-pub struct RouteTasksEventResponse {
-    /// One worker URL per task, ordered by task index.
-    pub urls: Vec<Url>,
-}
-
-impl RouteTasksEventResponse {
-    /// Returns a response assigning tasks to `urls` in order.
+    /// The exact plan variant that will be sent for this task.
+    pub task_specialized_plan: &'a Arc<dyn ExecutionPlan>,
+    /// Establishes a coordinator-to-worker connection for a candidate URL. Users are expected
+    /// to call `dialer.dial()` inside their [RouteTaskHandler] implementations for establishing
+    /// a connection with the remote worker.
     ///
-    /// The coordinator rejects the response unless `urls.len()` equals
-    /// [`RouteTasksEvent::handle`].
-    pub fn new(urls: Vec<Url>) -> Self {
-        Self { urls }
-    }
+    /// `dialer.dial()` can be called multiple times over different URLs until one successfully
+    /// connects.
+    pub dialer: &'a dyn CoordinatorToWorkerDialer,
 }
 
-/// Optionally assigns a stage's task slots to worker URLs.
+/// A worker connection selected by a [`RouteTaskHandler`].
+pub struct RouteTaskEventResponse {
+    /// The URL of the selected worker.
+    pub url: Url,
+    /// Messages streamed from the selected worker to the coordinator.
+    pub worker_to_coordinator_stream: BoxStream<'static, Result<WorkerToCoordinatorMsg>>,
+}
+
+/// Assigns a distributed task to a worker and establishes its connection.
 ///
-/// Handlers are evaluated in reverse registration order. Return `Some(Ok(_))` to select a
-/// complete routing response and stop dispatch, or `None` to defer to earlier handlers. If every
-/// handler returns `None`, the coordinator assigns the tasks round-robin, from a randomized worker
-/// offset. Returning `Some(Err(_))` aborts execution before tasks are submitted.
-pub trait RouteTasksHandler: Send + Sync + 'static {
-    /// Optionally assigns the tasks described by `ev` to specific worker URLs.
-    ///
-    /// Return `None` when this handler does not apply. A successful response must provide exactly
-    /// one URL for every task, in task-index order.
-    fn handle(&self, ev: RouteTasksEvent) -> Option<Result<RouteTasksEventResponse>>;
+/// Handlers are evaluated in registration order, with custom handlers before built-ins. Return
+/// `None` to defer to the next handler. To implement retries or failover, call
+/// [`RouteTaskEvent::dialer`] multiple times and return the successful response.
+#[async_trait]
+pub trait RouteTaskHandler: Send + Sync + 'static {
+    /// Attempts to assign the task described by the event to a worker.
+    async fn handle(&self, ev: RouteTaskEvent<'_>) -> Option<Result<RouteTaskEventResponse>>;
 }
 
-impl<F> RouteTasksHandler for F
-where
-    F: Send + Sync + 'static,
-    F: for<'a> Fn(RouteTasksEvent<'a>) -> Option<Result<RouteTasksEventResponse>>,
-{
-    fn handle(&self, ev: RouteTasksEvent) -> Option<Result<RouteTasksEventResponse>> {
-        self(ev)
+#[async_trait]
+impl RouteTaskHandler for Arc<dyn RouteTaskHandler> {
+    async fn handle(&self, ev: RouteTaskEvent<'_>) -> Option<Result<RouteTaskEventResponse>> {
+        self.as_ref().handle(ev).await
     }
 }
 
-impl RouteTasksHandler for Arc<dyn RouteTasksHandler> {
-    fn handle(&self, ev: RouteTasksEvent) -> Option<Result<RouteTasksEventResponse>> {
-        self.as_ref().handle(ev)
-    }
-}
+pub(crate) type RouteTaskHandlers = EventHandlerChain<dyn RouteTaskHandler>;
 
-pub(crate) type RouteTasksHandlers = EventHandlerChain<dyn RouteTasksHandler>;
-
-impl RouteTasksHandlers {
-    pub(crate) fn handle(ev: RouteTasksEvent) -> Option<Result<RouteTasksEventResponse>> {
-        ev.task_ctx
+impl RouteTaskHandlers {
+    pub(crate) async fn handle(ev: RouteTaskEvent<'_>) -> Option<Result<RouteTaskEventResponse>> {
+        let handlers = ev
+            .task_ctx
             .session_config()
-            .get_extension::<RouteTasksHandlers>()?
-            .find_map(|handler| handler.handle(ev.clone()))
+            .get_extension::<RouteTaskHandlers>()?;
+        for handler in handlers.iter() {
+            if let Some(response) = handler.handle(ev).await {
+                return Some(response);
+            }
+        }
+        None
     }
+}
+
+// === CoordinatorToWorkerDialer ===
+
+/// Establishes coordinator-to-worker connections for assignment candidates.
+///
+/// Each call represents an independent connection attempt. A handler may call `dial` multiple
+/// times, sequentially or concurrently, when implementing retries or failover.
+#[async_trait]
+pub trait CoordinatorToWorkerDialer: Send + Sync {
+    /// Attempts to connect the task to `url`.
+    async fn dial(&self, url: Url) -> Result<RouteTaskEventResponse>;
+}
+
+pub(crate) fn new_coordinator_to_worker_dialer<F, Fut>(f: F) -> impl CoordinatorToWorkerDialer
+where
+    F: Fn(Url) -> Fut + Send + Sync,
+    Fut: Future<Output = Result<RouteTaskEventResponse>> + Send,
+{
+    struct S<F>(F);
+
+    #[async_trait]
+    impl<F, Fut> CoordinatorToWorkerDialer for S<F>
+    where
+        F: Fn(Url) -> Fut + Send + Sync,
+        Fut: Future<Output = Result<RouteTaskEventResponse>> + Send,
+    {
+        async fn dial(&self, url: Url) -> Result<RouteTaskEventResponse> {
+            self.0(url).await
+        }
+    }
+
+    S(f)
 }

--- a/src/events/route_tasks.rs
+++ b/src/events/route_tasks.rs
@@ -32,9 +32,13 @@ pub struct RouteTaskEvent<'a> {
 
 /// A worker connection selected by a [`RouteTaskHandler`].
 pub struct RouteTaskEventResponse {
-    /// The URL of the selected worker.
+    /// The URL of the selected worker. Once this URL is returned, the worker officially starts
+    /// being part of the query, and it must commit to drive it to completion. Once a worker URL is
+    /// returned, a failure in the worker means the failure of the query.
     pub url: Url,
-    /// Messages streamed from the selected worker to the coordinator.
+    /// Messages streamed from the selected worker to the coordinator. This must be the result of
+    /// calling `ev.dialer.dial(url).await`, where `dialer` is provided by the [RouteTaskEvent]
+    /// definition.
     pub worker_to_coordinator_stream: BoxStream<'static, Result<WorkerToCoordinatorMsg>>,
 }
 

--- a/src/execution_plans/distributed_leaf.rs
+++ b/src/execution_plans/distributed_leaf.rs
@@ -128,8 +128,8 @@ impl DistributedLeafExec {
     }
 
     /// The per-task variants, in task order: `variants()[i]` is the plan sent to task `i`. Useful
-    /// for inspecting per-task information (e.g. data locality) when routing tasks to workers via
-    /// [crate::TaskEstimator::route_tasks].
+    /// for inspecting per-task information (e.g. data locality) when assigning tasks to workers
+    /// via [crate::RouteTaskHandler].
     pub fn variants(&self) -> &[Arc<dyn ExecutionPlan>] {
         &self.variants
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,10 +26,11 @@ pub use distributed_planner::{
 };
 pub use dynamic_filtering::rewrite_distributed_plan_with_dynamic_filters;
 pub use events::{
-    DesiredTaskCountEvent, DesiredTaskCountEventResponse, DesiredTaskCountHandler, RouteTasksEvent,
-    RouteTasksEventResponse, RouteTasksHandler, ScaleUpLeafNodeEvent, ScaleUpLeafNodeEventResponse,
-    ScaleUpLeafNodeHandler, TaskCountAnnotation, WorkerPlanRewriteEvent,
-    WorkerPlanRewriteEventResponse, WorkerPlanRewriteHandler,
+    CoordinatorToWorkerDialer, DesiredTaskCountEvent, DesiredTaskCountEventResponse,
+    DesiredTaskCountHandler, RouteTaskEvent, RouteTaskEventResponse, RouteTaskHandler,
+    ScaleUpLeafNodeEvent, ScaleUpLeafNodeEventResponse, ScaleUpLeafNodeHandler,
+    TaskCountAnnotation, WorkerPlanRewriteEvent, WorkerPlanRewriteEventResponse,
+    WorkerPlanRewriteHandler,
 };
 pub use execution_plans::{
     BroadcastExec, DistributedLeafExec, NetworkBroadcastExec, NetworkCoalesceExec,

--- a/src/protocol/worker_channel.rs
+++ b/src/protocol/worker_channel.rs
@@ -65,6 +65,7 @@ pub struct TaskKey {
     pub task_number: usize,
 }
 
+#[derive(Clone)]
 pub struct WorkUnitFeedDeclaration {
     /// Unique identifier of the node to which work unit feeds are expected to be streamed.
     pub id: Uuid,

--- a/src/protocol/worker_channel.rs
+++ b/src/protocol/worker_channel.rs
@@ -65,7 +65,7 @@ pub struct TaskKey {
     pub task_number: usize,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct WorkUnitFeedDeclaration {
     /// Unique identifier of the node to which work unit feeds are expected to be streamed.
     pub id: Uuid,

--- a/src/test_utils/routing.rs
+++ b/src/test_utils/routing.rs
@@ -27,11 +27,10 @@ use tonic::async_trait;
 
 use crate::{
     DesiredTaskCountEvent, DesiredTaskCountEventResponse, DistributedLeafExec,
-    DistributedTaskContext, LocalWorkerContext, RouteTasksEvent, RouteTasksEventResponse,
-    ScaleUpLeafNodeEvent, ScaleUpLeafNodeEventResponse, WorkerResolver, ok_or_some_err,
+    DistributedTaskContext, LocalWorkerContext, RouteTaskEvent, RouteTaskEventResponse,
+    RouteTaskHandler, ScaleUpLeafNodeEvent, ScaleUpLeafNodeEventResponse, ok_or_some_err,
 };
 
-use crate::distributed_ext::DistributedGetterExt;
 // Table function that creates a `URLEmitterExec` for testing task routing.
 #[derive(Debug)]
 pub struct URLEmitterFunction;
@@ -292,19 +291,18 @@ pub fn url_emitter_scale_up_leaf_node(
     ))))
 }
 
-pub fn url_emitter_route_tasks(ev: RouteTasksEvent) -> Option<Result<RouteTasksEventResponse>> {
-    Some((|| {
-        let mut routed_urls = ev
-            .task_ctx
-            .session_config()
-            .get_distributed_worker_resolver()?
-            .get_urls()?;
+pub struct UrlEmitterRouteTaskHandler;
+
+#[async_trait]
+impl RouteTaskHandler for UrlEmitterRouteTaskHandler {
+    async fn handle(&self, ev: RouteTaskEvent<'_>) -> Option<Result<RouteTaskEventResponse>> {
+        let mut urls = ok_or_some_err!(ev.worker_resolver.get_urls());
 
         // Trivial routing policy: Assign tasks to URLs in reverse order.
-        routed_urls.reverse();
-        routed_urls.truncate(ev.task_count);
-        Ok(RouteTasksEventResponse::new(routed_urls))
-    })())
+        urls.reverse();
+        let url = urls.into_iter().nth(ev.task_key.task_number)?;
+        Some(ev.dialer.dial(url).await)
+    }
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/worker_resolver.rs
+++ b/src/worker_resolver.rs
@@ -28,8 +28,8 @@ pub(crate) fn set_distributed_worker_resolver(
     cfg.set_extension(Arc::new(WorkerResolverExtension(Arc::new(worker_resolver))));
 }
 
-/// Gets the [WorkerResolver] from the [SessionConfig]'s extensions. Typically called inside
-/// [RouteTasksHandler::route_tasks] to resolve the worker URLs available for distributed tasks.
+/// Gets the [WorkerResolver] from the [SessionConfig]'s extensions. This can be called by a
+/// [crate::RouteTaskHandler] to discover the workers available for distributed tasks.
 pub fn get_distributed_worker_resolver(
     cfg: &SessionConfig,
 ) -> Result<Arc<dyn WorkerResolver>, DataFusionError> {

--- a/tests/dynamic_filtering/common.rs
+++ b/tests/dynamic_filtering/common.rs
@@ -9,7 +9,7 @@ use datafusion::physical_plan::collect;
 use datafusion::prelude::{SessionContext, col};
 use datafusion_distributed::test_utils::localhost::start_localhost_context;
 use datafusion_distributed::test_utils::parquet::register_parquet_tables;
-use datafusion_distributed::test_utils::routing::url_emitter_route_tasks;
+use datafusion_distributed::test_utils::routing::UrlEmitterRouteTaskHandler;
 use datafusion_distributed::{
     DefaultSessionBuilder, DistributedExt, display_plan_ascii,
     rewrite_distributed_plan_with_dynamic_filters,
@@ -94,7 +94,7 @@ pub(crate) async fn execute_range_partitioned_query(
     let ctx = ctx
         .with_distributed_broadcast_joins(false)?
         .with_distributed_desired_task_count_handler(2usize)
-        .with_distributed_route_tasks_handler(url_emitter_route_tasks);
+        .with_distributed_route_task_handler(UrlEmitterRouteTaskHandler);
     {
         let state = ctx.state_ref();
         let mut state = state.write();

--- a/tests/task_estimator_test.rs
+++ b/tests/task_estimator_test.rs
@@ -9,8 +9,8 @@ mod tests {
         test_utils::{
             in_memory_channel_resolver::start_in_memory_context,
             routing::{
-                URLEmitterExtensionCodec, URLEmitterFunction, url_emitter_desired_task_count,
-                url_emitter_route_tasks, url_emitter_scale_up_leaf_node,
+                URLEmitterExtensionCodec, URLEmitterFunction, UrlEmitterRouteTaskHandler,
+                url_emitter_desired_task_count, url_emitter_scale_up_leaf_node,
             },
         },
     };
@@ -387,7 +387,7 @@ mod tests {
         let mut ctx = start_in_memory_context(NUM_WORKERS, build_state).await;
         ctx.set_distributed_desired_task_count_handler(url_emitter_desired_task_count);
         ctx.set_distributed_scale_up_leaf_node_handler(url_emitter_scale_up_leaf_node);
-        ctx.set_distributed_route_tasks_handler(url_emitter_route_tasks);
+        ctx.set_distributed_route_task_handler(UrlEmitterRouteTaskHandler);
         ctx.set_distributed_user_codec(URLEmitterExtensionCodec);
         ctx.register_udtf("url_emitter", Arc::new(URLEmitterFunction));
         ctx.state_ref()


### PR DESCRIPTION
Rewrite of the task routing API that unlocks the door for implementing retries and smarter routing.

# Key changes to the task-routing API:

## Fire on a per-task basis instead of per-stage

Previously, this API was fired once for each stage, and the expected returns where a list of URLs (one per task in the stage):

```
Original ExecutionPlan + 3 tasks -> [URL1, URL2, URL3]
```

Now, this is called once per task, and the passed plan is the task specialized one, not the original one.

```
Task-specialized ExecutionPlan + task index -> URL1 + Stablished connection
```

## Returns a successfully established connection

There was a problem with the previous task routing API:

It prompted users and/or default implementations to return a URL, without knowing if something is listening at the other side of the URL.

There is a chance that the routed machine is unavailable, in which case, the new API gives the option to implementations to retry on a different machine.

## The event handler is now `async`

Connections must be established in this event handler, which means that it must make network calls, therefore it's now made `async`.

## Introduction of `CoordinatorToWorkerDialer`

The `CoordinatorToWorkerDialer` is a trait that users are **not** supposed to implement, instead, they are supposed to call its `.dial()` method for attempting to establish a connection from coordinator to remote worker, so implementations of the `RouteTaskHandler` would look like this:

```rust
#[async_trait]
impl RouteTaskHandler for RandomRouteTaskHandler {
    async fn handle(&self, ev: RouteTaskEvent<'_>) -> Option<Result<RouteTaskEventResponse>> {
        // get a URL somehow
        
        Some(ev.dialer.dial(url.clone()).await)
    }
}
```

If there's an error while dialing the worker, the user can choose to retry on another URL.

The `CoordinatorToWorkerDialer` under the hood will handle all the API churn for making API calls to workers, leaving a clean and narrow API to the routing task event handler implementor, just requiring the URL to which it needs to connect to.

# What's not included yet

Any kind of retry mechanism on a different node in case of a connection failure.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>