### PR TITLE
Deflake non-deterministic early-exit due to `LIMIT`

### DIFF
--- a/src/distributed_planner/insert_broadcast.rs
+++ b/src/distributed_planner/insert_broadcast.rs
@@ -291,7 +291,7 @@ mod tests {
         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(RainToday@1, RainToday@1)], projection=[MinTemp@0, MaxTemp@2]
           CoalescePartitionsExec
             BroadcastExec: input_partitions=1, consumer_tasks=1, output_partitions=1
-              DataSourceExec: file_groups={1 group: [[/testdata/weather/result-000001.parquet]]}, projection=[MinTemp, RainToday], limit=50, file_type=parquet
+              DataSourceExec: file_groups={1 group: [[/testdata/weather/result-<shard>.parquet]]}, projection=[MinTemp, RainToday], limit=50, file_type=parquet
           DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MaxTemp, RainToday], file_type=parquet, predicate=DynamicFilter [ empty ], dynamic_rg_pruning=eligible
         ");
     }

--- a/src/test_utils/insta.rs
+++ b/src/test_utils/insta.rs
@@ -30,5 +30,13 @@ pub fn settings() -> insta::Settings {
         r"(DynamicFilter \[[^\[\]]*IN \(SET\) \(\[)[^\]]*(\]\))",
         "${1}<values>${2}",
     );
+    // When a scan has a limit, DataFusion stops scanning files as soon as the row count limit
+    // is satisfied. Because file metadata is fetched asynchronously (buffer_unordered) from
+    // the directory listing, whichever file finishes reading first is selected as the sole
+    // partition. Redact the file index when limit is pushed down to avoid platform-dependent flakiness.
+    settings.add_filter(
+        r"(testdata/weather/result-)\d+(\.parquet\]\]\}, [^\n]*limit=\d+)",
+        "${1}<shard>${2}",
+    );
     settings
 }


### PR DESCRIPTION
Fix a flake introduced by https://github.com/datafusion-contrib/datafusion-distributed/pull/670