### PR TITLE
refactor: make Iceberg codec fixture options explicit

### DIFF
--- a/iceberg/src/codec.rs
+++ b/iceberg/src/codec.rs
@@ -144,7 +144,11 @@ mod tests {
 
     #[tokio::test]
     async fn roundtrips_data_source_plan() -> Result<()> {
-        let harness = IcebergTestHarness::new().await?;
+        let harness = IcebergTestHarness::builder()
+            .with_table_option("fixture.storage", "roundtrip's value")
+            .with_table_option("fixture.region", "test-region")
+            .build()
+            .await?;
         let plan = harness.physical_plan("SELECT * FROM taxi LIMIT 10").await?;
         let decoded_plan = harness.roundtrip_plan(Arc::clone(&plan))?;
         let source_plan = iceberg_plan(&plan)?;
@@ -162,6 +166,15 @@ mod tests {
         assert_eq!(
             source.iceberg_file_io.config().props(),
             decoded.iceberg_file_io.config().props()
+        );
+        let properties = decoded.iceberg_file_io.config().props();
+        assert_eq!(
+            properties.get("fixture.storage").map(String::as_str),
+            Some("roundtrip's value")
+        );
+        assert_eq!(
+            properties.get("fixture.region").map(String::as_str),
+            Some("test-region")
         );
         assert_eq!(
             decoded.partition_statistics(None)?.as_ref(),


### PR DESCRIPTION
Extends `roundtrips_data_source_plan`, the existing codec test from #684, with two explicit storage properties supplied through #700's harness builder. Checks their decoded values, including a quote-containing value that exercises SQL literal escaping, while retaining the existing schema, partitioning, fetch, feed, property-map, and statistics assertions.

The diff against #700 remains 15 changed lines in `iceberg/src/codec.rs`, with no new harness methods or test functions.

Stacked on #700, now rebased onto `iceberg-0.10` at `6507bf8` after #687 merged. Only #700 is a prerequisite.

Validation:
- `cargo test -p datafusion-distributed-iceberg --locked` — 90 tests passed, including the codec roundtrip test and doctest
- `cargo clippy -p datafusion-distributed-iceberg --tests --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
