### PR TITLE
feat: estimate Iceberg distributed task counts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
         with:
           lfs: true
       - uses: ./.github/actions/setup
-      - run: cargo test -p datafusion-distributed-iceberg
+      - run: cargo test -p datafusion-distributed-iceberg --features integration
 
   format-check:
     runs-on: ubuntu-latest

--- a/iceberg/Cargo.toml
+++ b/iceberg/Cargo.toml
@@ -7,6 +7,10 @@ description = "Read-only Apache Iceberg table providers for DataFusion Distribut
 license = "Apache-2.0"
 repository = "https://github.com/datafusion-contrib/datafusion-distributed"
 
+[features]
+# Distributed worker support for the test harness.
+integration = ["datafusion-distributed/integration"]
+
 [dependencies]
 async-trait = "0.1"
 bytes = "1"

--- a/iceberg/src/distributed_desired_task_count_handler.rs
+++ b/iceberg/src/distributed_desired_task_count_handler.rs
@@ -1,21 +1,86 @@
-use datafusion::common::Result;
-use datafusion::datasource::source::DataSourceExec;
-use datafusion_distributed::{DesiredTaskCountEvent, DesiredTaskCountEventResponse};
+use std::num::NonZeroUsize;
+
+use datafusion::common::{Result, config_datafusion_err};
+use datafusion::datasource::source::{DataSource, DataSourceExec};
+use datafusion_distributed::{
+    DesiredTaskCountEvent, DesiredTaskCountEventResponse, DistributedConfig,
+};
 
 use crate::IcebergDataSource;
 
-// TODO: read the inner iceberg::table::Table and based on the contents attempt
-//  to estimate a good desired task count.
+/// Estimates scan parallelism from the selected Iceberg snapshot's total file size.
 pub fn iceberg_desired_task_count(
     ev: DesiredTaskCountEvent,
 ) -> Option<Result<DesiredTaskCountEventResponse>> {
-    let _iceberg_data_source = ev
+    let node = ev
         .plan
         .downcast_ref::<DataSourceExec>()?
         .data_source()
         .downcast_ref::<IcebergDataSource>()?;
+    let statistics = match node.partition_statistics(None) {
+        Ok(statistics) => statistics,
+        Err(error) => return Some(Err(error)),
+    };
+    let total_bytes = *statistics.total_byte_size.get_value()?;
+    let config = DistributedConfig::from_session_config(ev.session_config).ok()?;
 
-    // TODO: not implemented.
+    Some(
+        calculate_task_count(
+            total_bytes,
+            config.file_scan_config_bytes_per_partition,
+            ev.session_config.target_partitions(),
+        )
+        .map(DesiredTaskCountEventResponse::desired),
+    )
+}
 
-    None
+fn calculate_task_count(
+    total_bytes: usize,
+    bytes_per_partition: usize,
+    target_partitions: usize,
+) -> Result<usize> {
+    let bytes_per_partition = non_zero_divisor(bytes_per_partition, "bytes per partition")?;
+    let target_partitions = non_zero_divisor(target_partitions, "target partitions")?;
+
+    Ok(total_bytes
+        .div_ceil(bytes_per_partition.get())
+        .div_ceil(target_partitions.get()))
+}
+
+fn non_zero_divisor(value: usize, name: &str) -> Result<NonZeroUsize> {
+    NonZeroUsize::new(value)
+        .ok_or_else(|| config_datafusion_err!("Iceberg {name} must be greater than zero"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn calculates_exact_rounded_and_boundary_task_counts() {
+        assert_eq!(task_count(24, 4, 3), 2);
+        assert_eq!(task_count(25, 4, 3), 3);
+        assert_eq!(task_count(usize::MAX, usize::MAX, 2), 1);
+        assert_eq!(task_count(usize::MAX, 1, 1), usize::MAX);
+    }
+
+    #[test]
+    fn zero_bytes_require_zero_tasks() {
+        assert_eq!(task_count(0, 1, 1), 0);
+    }
+
+    #[test]
+    fn rejects_zero_divisors() {
+        assert!(calculate_task_count(1, 0, 1).is_err());
+        assert!(calculate_task_count(1, 1, 0).is_err());
+    }
+
+    fn task_count(
+        total_bytes: usize,
+        bytes_per_partition: usize,
+        target_partitions: usize,
+    ) -> usize {
+        calculate_task_count(total_bytes, bytes_per_partition, target_partitions)
+            .expect("test task count should be valid")
+    }
 }

--- a/iceberg/src/iceberg_ext.rs
+++ b/iceberg/src/iceberg_ext.rs
@@ -13,6 +13,7 @@ use crate::distributed_desired_task_count_handler::iceberg_desired_task_count;
 use crate::{IcebergConfig, IcebergDataSource, IcebergTableProviderFactory};
 
 /// Configuration required to register the Iceberg SQL integration.
+#[derive(Clone)]
 pub struct IcebergIntegrationOptions {
     /// Builds storage implementations for table metadata and data files.
     pub storage_factory: Arc<dyn StorageFactory>,

--- a/iceberg/src/test_utils/harness.rs
+++ b/iceberg/src/test_utils/harness.rs
@@ -6,12 +6,18 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bytes::Bytes;
 use datafusion::arrow::util::pretty::pretty_format_batches;
-use datafusion::dataframe::DataFrame;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::SessionStateBuilder;
-use datafusion::physical_plan::{ExecutionPlan, displayable};
+use datafusion::physical_plan::{ExecutionPlan, collect};
 use datafusion::prelude::{SessionConfig, SessionContext};
-use datafusion_distributed::DistributedCodec;
+use datafusion_distributed::{
+    DesiredTaskCountEvent, DistributedCodec, DistributedConfig, DistributedExt, display_plan_ascii,
+};
+#[cfg(feature = "integration")]
+use datafusion_distributed::{
+    SessionStateBuilderExt, WorkerQueryContext,
+    test_utils::in_memory_channel_resolver::{InMemoryChannelResolver, InMemoryWorkerResolver},
+};
 use datafusion_proto::physical_plan::AsExecutionPlan;
 use futures::StreamExt;
 use futures::stream::BoxStream;
@@ -24,14 +30,14 @@ use iceberg::{Error, ErrorKind, Result as IcebergResult};
 use serde::{Deserialize, Serialize};
 
 use super::taxi_metadata;
-use crate::{IcebergExt, IcebergIntegrationOptions};
+use crate::{IcebergExt, IcebergIntegrationOptions, iceberg_desired_task_count};
 
 pub const FIXTURE_URI: &str = "s3://iceberg-test/warehouse/taxi";
 const WAREHOUSE_URI: &str = "s3://iceberg-test/warehouse/";
 const FIXTURE_METADATA_URI: &str = "s3://iceberg-test/warehouse/taxi/metadata/v1.metadata.json";
 
 pub struct IcebergTestHarness {
-    pub ctx: SessionContext,
+    ctx: SessionContext,
 }
 
 impl IcebergTestHarness {
@@ -44,18 +50,34 @@ impl IcebergTestHarness {
     }
 
     pub async fn query(&self, sql: &str) -> Result<(String, String)> {
-        let dataframe: DataFrame = self.ctx.sql(sql).await?;
-        let plan = dataframe.create_physical_plan().await?;
-        let batches = dataframe.collect().await?;
+        let plan = self.physical_plan(sql).await?;
+        let display = display_plan_ascii(plan.as_ref(), false);
+        let batches = collect(plan, self.ctx.task_ctx()).await?;
 
-        Ok((
-            displayable(plan.as_ref()).indent(true).to_string(),
-            pretty_format_batches(&batches)?.to_string(),
-        ))
+        Ok((display, pretty_format_batches(&batches)?.to_string()))
     }
 
     pub async fn physical_plan(&self, sql: &str) -> Result<Arc<dyn ExecutionPlan>> {
         self.ctx.sql(sql).await?.create_physical_plan().await
+    }
+
+    /// Returns the fixture scan without SQL optimization, including for an empty table.
+    pub async fn scan(&self) -> Result<Arc<dyn ExecutionPlan>> {
+        self.ctx
+            .table_provider("taxi")
+            .await?
+            .scan(&self.ctx.state(), None, &[], None)
+            .await
+    }
+
+    /// Estimates Iceberg scan tasks using this harness's session configuration.
+    pub fn estimate_task_count(&self, plan: &Arc<dyn ExecutionPlan>) -> Result<Option<usize>> {
+        iceberg_desired_task_count(DesiredTaskCountEvent {
+            plan,
+            session_config: self.ctx.state().config(),
+        })
+        .transpose()
+        .map(|response| response.map(|response| response.task_count.as_usize()))
     }
 
     pub fn roundtrip_plan(&self, plan: Arc<dyn ExecutionPlan>) -> Result<Arc<dyn ExecutionPlan>> {
@@ -68,22 +90,41 @@ impl IcebergTestHarness {
 }
 
 pub struct IcebergTestHarnessBuilder {
+    session_builder: SessionStateBuilder,
     metadata: TableMetadata,
     table_options: BTreeMap<String, String>,
     files: HashMap<String, Vec<u8>>,
+    #[cfg(feature = "integration")]
+    workers: Option<usize>,
 }
 
 impl Default for IcebergTestHarnessBuilder {
     fn default() -> Self {
         Self {
+            session_builder: SessionStateBuilder::new()
+                .with_default_features()
+                .with_config(SessionConfig::new().with_target_partitions(4))
+                .with_distributed_option_extension(DistributedConfig::default()),
             metadata: taxi_metadata(),
             table_options: BTreeMap::new(),
             files: HashMap::new(),
+            #[cfg(feature = "integration")]
+            workers: None,
         }
     }
 }
 
 impl IcebergTestHarnessBuilder {
+    /// Customizes the existing session builder, retaining defaults unless explicitly replaced.
+    /// Fixture integration and optional worker wiring are installed during [`Self::build`].
+    pub fn configure_session(
+        mut self,
+        configure: impl FnOnce(SessionStateBuilder) -> Result<SessionStateBuilder>,
+    ) -> Result<Self> {
+        self.session_builder = configure(self.session_builder)?;
+        Ok(self)
+    }
+
     /// Serves the supplied metadata while reading data files from the taxi fixture.
     pub fn with_table_metadata(mut self, metadata: TableMetadata) -> Self {
         self.metadata = metadata;
@@ -103,6 +144,13 @@ impl IcebergTestHarnessBuilder {
         self
     }
 
+    /// Enables distributed planning with logical workers backed by in-memory gRPC.
+    #[cfg(feature = "integration")]
+    pub fn with_workers(mut self, workers: usize) -> Self {
+        self.workers = Some(workers);
+        self
+    }
+
     pub async fn build(mut self) -> Result<IcebergTestHarness> {
         let metadata = serde_json::to_vec(&self.metadata)
             .map_err(|error| DataFusionError::External(Box::new(error)))?;
@@ -113,15 +161,31 @@ impl IcebergTestHarnessBuilder {
             files: self.files,
             ..FixtureStorageFactory::default()
         };
-        let state = SessionStateBuilder::new()
-            .with_default_features()
-            .with_config(SessionConfig::new().with_target_partitions(4))
-            .with_iceberg_integration(IcebergIntegrationOptions {
-                storage_factory: Arc::new(storage_factory),
-                iceberg_runtime: iceberg::Runtime::current(),
-            })
-            .build();
-        let ctx = SessionContext::new_with_state(state);
+        let options = IcebergIntegrationOptions {
+            storage_factory: Arc::new(storage_factory),
+            iceberg_runtime: iceberg::Runtime::current(),
+        };
+        let state = self
+            .session_builder
+            .with_iceberg_integration(options.clone());
+        #[cfg(feature = "integration")]
+        let state = if let Some(workers) = self.workers {
+            let resolver =
+                InMemoryChannelResolver::from_session_builder(move |ctx: WorkerQueryContext| {
+                    let state = ctx
+                        .builder
+                        .with_iceberg_integration(options.clone())
+                        .build();
+                    async move { Ok(state) }
+                });
+            state
+                .with_distributed_planner()
+                .with_distributed_worker_resolver(InMemoryWorkerResolver::new(workers))
+                .with_distributed_channel_resolver(resolver)
+        } else {
+            state
+        };
+        let ctx = SessionContext::new_with_state(state.build());
         let mut statement = format!(
             "CREATE EXTERNAL TABLE taxi STORED AS ICEBERG \
              LOCATION '{FIXTURE_METADATA_URI}'"

--- a/iceberg/tests/desired_task_count.rs
+++ b/iceberg/tests/desired_task_count.rs
@@ -1,0 +1,176 @@
+#[cfg(test)]
+mod tests {
+    use datafusion::common::Result;
+    use datafusion_distributed::DistributedExt;
+    use datafusion_distributed_iceberg::test_utils::{
+        IcebergTestHarness, empty_taxi_metadata_builder, taxi_metadata,
+    };
+    use iceberg::spec::{Snapshot, TableMetadata};
+
+    #[cfg(feature = "integration")]
+    #[tokio::test]
+    async fn executes_with_estimated_scan_tasks() -> Result<()> {
+        // 4,480,382 bytes / 1 MB / 2 partitions rounds up to 3 tasks, not all 4 workers.
+        let harness = IcebergTestHarness::builder()
+            .with_workers(4)
+            .configure_session(|mut state| {
+                let config = state.config().get_or_insert_default();
+                config.options_mut().execution.target_partitions = 2;
+                state.with_distributed_file_scan_config_bytes_per_partition(1_000_000)
+            })?
+            .build()
+            .await?;
+        // Grouping prevents COUNT(*) from being answered from snapshot metadata alone.
+        let (plan, results) = harness
+            .query(
+                "SELECT pickup_date, COUNT(*) AS trips FROM taxi \
+             GROUP BY pickup_date ORDER BY pickup_date",
+            )
+            .await?;
+        insta::assert_snapshot!(plan + &results, @"
+        ┌───── DistributedExec
+        │ SortPreservingMergeExec: [pickup_date@0 ASC NULLS LAST]
+        │   [Stage 2] => NetworkCoalesceExec: output_partitions=4, input_tasks=2
+        └──────────────────────────────────────────────────
+          ┌───── Stage 2 ── tasks=2, partitions=2
+          │ SortExec: expr=[pickup_date@0 ASC NULLS LAST], preserve_partitioning=[true]
+          │   ProjectionExec: expr=[pickup_date@0 as pickup_date, count(Int64(1))@1 as trips]
+          │     AggregateExec: mode=FinalPartitioned, gby=[pickup_date@0 as pickup_date], aggr=[count(Int64(1))]
+          │       [Stage 1] => NetworkShuffleExec: output_partitions=2, input_tasks=3
+          └──────────────────────────────────────────────────
+            ┌───── Stage 1 ── tasks=3, partitions=4
+            │ RepartitionExec: partitioning=Hash([pickup_date@0], 4), input_partitions=2
+            │   AggregateExec: mode=Partial, gby=[pickup_date@0 as pickup_date], aggr=[count(Int64(1))]
+            │     DataSourceExec: format=iceberg, projection=[pickup_date]
+            └──────────────────────────────────────────────────
+        +-------------+-------+
+        | pickup_date | trips |
+        +-------------+-------+
+        | 2024-01-08  | 25000 |
+        | 2024-01-09  | 25000 |
+        | 2024-01-10  | 25000 |
+        | 2024-01-11  | 25000 |
+        | 2024-01-12  | 25000 |
+        | 2024-01-13  | 25000 |
+        | 2024-01-14  | 25000 |
+        +-------------+-------+
+        ");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn estimates_current_snapshot() -> Result<()> {
+        assert_task_count(metadata_with_file_size(Some("24000000")), None, Some(12)).await
+    }
+
+    #[tokio::test]
+    async fn estimates_selected_snapshot() -> Result<()> {
+        assert_task_count(
+            metadata_with_file_size(Some("24000000")),
+            taxi_metadata().current_snapshot_id(),
+            Some(3),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn empty_table_needs_no_tasks() -> Result<()> {
+        assert_task_count(empty_metadata(), None, Some(0)).await
+    }
+
+    #[tokio::test]
+    async fn missing_size_does_not_estimate() -> Result<()> {
+        assert_task_count(metadata_with_file_size(None), None, None).await
+    }
+
+    #[tokio::test]
+    async fn malformed_size_does_not_estimate() -> Result<()> {
+        assert_task_count(metadata_with_file_size(Some("invalid")), None, None).await
+    }
+
+    #[tokio::test]
+    async fn negative_size_does_not_estimate() -> Result<()> {
+        assert_task_count(metadata_with_file_size(Some("-1")), None, None).await
+    }
+
+    #[tokio::test]
+    async fn overflowing_size_does_not_estimate() -> Result<()> {
+        assert_task_count(
+            metadata_with_file_size(Some("18446744073709551616")),
+            None,
+            None,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn remote_feed_does_not_estimate_again() -> Result<()> {
+        let harness = IcebergTestHarness::new().await?;
+        let plan = harness.roundtrip_plan(harness.scan().await?)?;
+        assert_eq!(harness.estimate_task_count(&plan)?, None);
+        Ok(())
+    }
+
+    async fn assert_task_count(
+        metadata: TableMetadata,
+        snapshot_id: Option<i64>,
+        expected: Option<usize>,
+    ) -> Result<()> {
+        let mut builder = IcebergTestHarness::builder()
+            .with_table_metadata(metadata)
+            .configure_session(|mut state| {
+                let config = state.config().get_or_insert_default();
+                config.options_mut().execution.target_partitions = 2;
+                state.with_distributed_file_scan_config_bytes_per_partition(1_000_000)
+            })?;
+        if let Some(id) = snapshot_id {
+            builder = builder.with_table_option("iceberg.snapshot_id", id.to_string());
+        }
+        let harness = builder.build().await?;
+        assert_eq!(
+            harness.estimate_task_count(&harness.scan().await?)?,
+            expected
+        );
+        Ok(())
+    }
+
+    fn empty_metadata() -> TableMetadata {
+        empty_taxi_metadata_builder()
+            .build()
+            .expect("empty taxi metadata is valid")
+            .metadata
+    }
+
+    fn metadata_with_file_size(size: Option<&str>) -> TableMetadata {
+        let metadata = taxi_metadata();
+        let current = metadata.current_snapshot().expect("taxi has a snapshot");
+        let mut summary = current.summary().clone();
+        match size {
+            Some(size) => {
+                summary
+                    .additional_properties
+                    .insert("total-files-size".into(), size.into());
+            }
+            None => {
+                summary.additional_properties.remove("total-files-size");
+            }
+        }
+        // Keep the original snapshot for time travel; only the new snapshot's summary differs.
+        let snapshot = Snapshot::builder()
+            .with_snapshot_id(current.snapshot_id() + 1)
+            .with_parent_snapshot_id(Some(current.snapshot_id()))
+            .with_sequence_number(current.sequence_number() + 1)
+            .with_timestamp_ms(current.timestamp_ms() + 1)
+            .with_manifest_list(current.manifest_list())
+            .schema_id_opt(current.schema_id())
+            .with_summary(summary)
+            .build();
+        metadata
+            .into_builder(None)
+            .set_branch_snapshot(snapshot, "main")
+            .expect("new snapshot is valid")
+            .build()
+            .expect("taxi metadata is valid")
+            .metadata
+    }
+}

--- a/iceberg/tests/statistics.rs
+++ b/iceberg/tests/statistics.rs
@@ -45,8 +45,10 @@ mod tests {
 
     #[tokio::test]
     async fn reports_exact_row_count_and_byte_size_for_full_scan_w_col_stats() -> Result<()> {
-        let mut harness = IcebergTestHarness::new().await?;
-        harness.ctx.set_iceberg_column_stats_enabled(true);
+        let harness = IcebergTestHarness::builder()
+            .configure_session(|state| Ok(state.with_iceberg_column_stats_enabled(true)))?
+            .build()
+            .await?;
         let stats = source_statistics(&harness, "SELECT * FROM taxi").await?;
 
         assert_eq!(stats.num_rows, Precision::Exact(TAXI_ROWS));
@@ -65,8 +67,10 @@ mod tests {
 
     #[tokio::test]
     async fn column_statistics_match_full_schema_w_col_stats() -> Result<()> {
-        let mut harness = IcebergTestHarness::new().await?;
-        harness.ctx.set_iceberg_column_stats_enabled(true);
+        let harness = IcebergTestHarness::builder()
+            .configure_session(|state| Ok(state.with_iceberg_column_stats_enabled(true)))?
+            .build()
+            .await?;
         let stats = source_statistics(&harness, "SELECT * FROM taxi").await?;
 
         assert_eq!(stats.column_statistics.len(), TAXI_COLUMNS);
@@ -89,8 +93,10 @@ mod tests {
     async fn column_statistics_match_projected_schema_w_col_stats() -> Result<()> {
         // Regression: a column_statistics vec shorter than the output schema
         // makes DataFusion panic while propagating statistics upstream.
-        let mut harness = IcebergTestHarness::new().await?;
-        harness.ctx.set_iceberg_column_stats_enabled(true);
+        let harness = IcebergTestHarness::builder()
+            .configure_session(|state| Ok(state.with_iceberg_column_stats_enabled(true)))?
+            .build()
+            .await?;
         let stats = source_statistics(&harness, "SELECT vendor_id, pickup_date FROM taxi").await?;
 
         assert_eq!(stats.column_statistics.len(), 2);
@@ -143,8 +149,10 @@ mod tests {
 
     #[tokio::test]
     async fn verify_column_stats_in_explain() -> Result<()> {
-        let mut harness = IcebergTestHarness::new().await?;
-        harness.ctx.set_iceberg_column_stats_enabled(true);
+        let harness = IcebergTestHarness::builder()
+            .configure_session(|state| Ok(state.with_iceberg_column_stats_enabled(true)))?
+            .build()
+            .await?;
         let plan = harness
             .physical_plan("SELECT vendor_id, pickup_date FROM taxi")
             .await?;
@@ -162,8 +170,10 @@ mod tests {
 
     #[tokio::test]
     async fn explain_shows_statistics_on_the_iceberg_source_w_col_stats() -> Result<()> {
-        let mut harness = IcebergTestHarness::new().await?;
-        harness.ctx.set_iceberg_column_stats_enabled(true);
+        let harness = IcebergTestHarness::builder()
+            .configure_session(|state| Ok(state.with_iceberg_column_stats_enabled(true)))?
+            .build()
+            .await?;
         let plan = harness.physical_plan("SELECT vendor_id FROM taxi").await?;
         let display = displayable(plan.as_ref())
             .set_show_statistics(true)
@@ -202,8 +212,10 @@ mod tests {
     async fn exact_row_count_lets_count_star_skip_the_scan_w_col_stats() -> Result<()> {
         // With Precision::Exact(num_rows) the AggregateStatistics optimizer
         // rule answers COUNT(*) from metadata without reading any data file.
-        let mut harness = IcebergTestHarness::new().await?;
-        harness.ctx.set_iceberg_column_stats_enabled(true);
+        let harness = IcebergTestHarness::builder()
+            .configure_session(|state| Ok(state.with_iceberg_column_stats_enabled(true)))?
+            .build()
+            .await?;
         let (plan, batches) = harness.query("SELECT count(*) FROM taxi").await?;
 
         insta::assert_snapshot!(plan, @"


### PR DESCRIPTION
Reapplies the reviewed and merged changes from #704 to the intended base, `iceberg-0.10`.

#704 was still targeting `codex/iceberg-runtime-metadata` when it merged, after #700 had already merged into `iceberg-0.10`. Consequently, the estimator and harness changes landed only on the old topic branch.

This PR cherry-picks #704's merge commit (`d3ba554`) onto `iceberg-0.10`. There are no additional code changes; the resulting tree is identical to #704's final head (`12e1512`).

Includes the source-statistics-based task estimator, explicit estimation tests, distributed execution coverage, and the private-context harness with `configure_session(...)`.

Validation:
- `cargo test -p datafusion-distributed-iceberg --features integration --locked --test desired_task_count` — all 9 tests passed.
- `cargo fmt --all -- --check` and `git diff --check` passed.
- Verified exact tree equality with #704's final head.

Targets `iceberg-0.10` directly; it does not depend on the separate reapplication of #703.
