### PR TITLE
refactor: make Iceberg codec fixture options explicit

### DIFF
--- a/iceberg/src/codec.rs
+++ b/iceberg/src/codec.rs
@@ -144,7 +144,11 @@ mod tests {
 
     #[tokio::test]
     async fn roundtrips_data_source_plan() -> Result<()> {
-        let harness = IcebergTestHarness::new().await?;
+        let harness = IcebergTestHarness::builder()
+            .with_table_option("fixture.storage", "roundtrip's value")
+            .with_table_option("fixture.region", "test-region")
+            .build()
+            .await?;
         let plan = harness.physical_plan("SELECT * FROM taxi LIMIT 10").await?;
         let decoded_plan = harness.roundtrip_plan(Arc::clone(&plan))?;
         let source_plan = iceberg_plan(&plan)?;
@@ -162,6 +166,15 @@ mod tests {
         assert_eq!(
             source.iceberg_file_io.config().props(),
             decoded.iceberg_file_io.config().props()
+        );
+        let properties = decoded.iceberg_file_io.config().props();
+        assert_eq!(
+            properties.get("fixture.storage").map(String::as_str),
+            Some("roundtrip's value")
+        );
+        assert_eq!(
+            properties.get("fixture.region").map(String::as_str),
+            Some("test-region")
         );
         assert_eq!(
             decoded.partition_statistics(None)?.as_ref(),


### PR DESCRIPTION
Reapplies the reviewed and merged changes from #703 to the intended base, `iceberg-0.10`.

#703 was still targeting `codex/iceberg-runtime-metadata` when it merged, after #700 had already merged into `iceberg-0.10`. Consequently, its codec-test improvements landed only on the old topic branch.

This PR cherry-picks #703's merge commit (`eafc234`) onto `iceberg-0.10`, without additional code changes. It retains the original 15-line diff in `iceberg/src/codec.rs`: explicit storage properties, including a quote-containing value, and assertions that those properties survive the codec round trip.

Validation:
- `cargo test -p datafusion-distributed-iceberg --locked --lib roundtrips_data_source_plan` — passed.
- `cargo fmt --all -- --check` and `git diff --check` passed.

Targets `iceberg-0.10` directly; it does not depend on the separate reapplication of #704.
