### PR TITLE
feat: make WorkerPlanRewriteHandler async

### DIFF
--- a/docs/source/advanced/03-plan-hooks.md
+++ b/docs/source/advanced/03-plan-hooks.md
@@ -3,8 +3,8 @@
 `DistributedExt::with_distributed_worker_plan_rewrite_handler` registers handlers that run after
 the worker session has been built and the physical plan has been decoded, but before the task plan
 is registered for execution. It is intended for **worker-local** rewrites of the fragment a worker
-is about to run. Handlers are `async`, so they can perform I/O—such as registering tables the plan
-references—before the plan is handed off for execution.
+is about to run. Handlers are `async`, so they can perform I/O before the plan is handed off for
+execution.
 
 Register handlers in the `SessionStateBuilder` used by each worker's `WorkerSessionBuilder`.
 Registering one on the coordinator's session has no effect: handlers are not sent to workers with

--- a/docs/source/advanced/03-plan-hooks.md
+++ b/docs/source/advanced/03-plan-hooks.md
@@ -3,7 +3,8 @@
 `DistributedExt::with_distributed_worker_plan_rewrite_handler` registers handlers that run after
 the worker session has been built and the physical plan has been decoded, but before the task plan
 is registered for execution. It is intended for **worker-local** rewrites of the fragment a worker
-is about to run.
+is about to run. Handlers are `async`, so they can perform I/O—such as registering tables the plan
+references—before the plan is handed off for execution.
 
 Register handlers in the `SessionStateBuilder` used by each worker's `WorkerSessionBuilder`.
 Registering one on the coordinator's session has no effect: handlers are not sent to workers with
@@ -12,15 +13,27 @@ stage plans.
 Each handler receives a `WorkerPlanRewriteEvent` and returns the possibly rewritten plan:
 
 ```rust
+# use async_trait::async_trait;
 # use datafusion::common::Result;
 # use datafusion::execution::SessionState;
-# use datafusion_distributed::{DistributedExt, Worker, WorkerPlanRewriteEvent, WorkerPlanRewriteEventResponse, WorkerQueryContext};
+# use datafusion_distributed::{DistributedExt, Worker, WorkerPlanRewriteEvent, WorkerPlanRewriteEventResponse, WorkerPlanRewriteHandler, WorkerQueryContext};
+
+struct Passthrough;
+
+#[async_trait]
+impl WorkerPlanRewriteHandler for Passthrough {
+    async fn rewrite_worker_plan(
+        &self,
+        event: WorkerPlanRewriteEvent<'_>,
+    ) -> Result<WorkerPlanRewriteEventResponse> {
+        Ok(WorkerPlanRewriteEventResponse::new(event.plan))
+    }
+}
+
 async fn build_worker_session(ctx: WorkerQueryContext) -> Result<SessionState> {
     Ok(ctx
         .builder
-        .with_distributed_worker_plan_rewrite_handler(|event: WorkerPlanRewriteEvent<'_>| {
-            Ok(WorkerPlanRewriteEventResponse::new(event.plan))
-        })
+        .with_distributed_worker_plan_rewrite_handler(Passthrough)
         .build())
 }
 

--- a/docs/upgrade/5.0.0.md
+++ b/docs/upgrade/5.0.0.md
@@ -79,7 +79,7 @@ let state = SessionStateBuilder::new()
 coordinator-to-worker connection is currently established. Implementations can
 choose to retry on other worker if the current one is not available.
 
-## 2. `WorkerPlanRewriteHandler` is asynchronous
+## 2. `WorkerPlanRewriteHandler::rewrite_worker_plan` renamed to `handle` and is now async
 
 `WorkerPlanRewriteHandler::rewrite_worker_plan` has been renamed to `handle` to
 match other handlers and is now `async`, so implementations can perform setup work

--- a/docs/upgrade/5.0.0.md
+++ b/docs/upgrade/5.0.0.md
@@ -81,51 +81,9 @@ choose to retry on other worker if the current one is not available.
 
 ## 2. `WorkerPlanRewriteHandler` is asynchronous
 
-`WorkerPlanRewriteHandler::rewrite_worker_plan` is now `async`, so
-implementations can perform setup work that needs to make network or I/O
-calls—such as registering tables the worker-local plan references—before the
-plan is handed off for execution. The trait name, method name, and
-`{with,set}_distributed_worker_plan_rewrite_handler` registration methods are
-unchanged.
-
-Because `WorkerPlanRewriteHandler` is now `async_trait`-based, plain closures
-can no longer implement it directly; implement it on a named type instead.
-
-Previously, a plain closure could be registered:
-
-```rust
-fn passthrough(event: WorkerPlanRewriteEvent<'_>) -> Result<WorkerPlanRewriteEventResponse> {
-    Ok(WorkerPlanRewriteEventResponse::new(event.plan))
-}
-
-let state = SessionStateBuilder::new()
-    .with_distributed_worker_plan_rewrite_handler(passthrough)
-    .build();
-```
-
-In 5.0, implement the async handler on a named type:
-
-```rust
-use async_trait::async_trait;
-use datafusion::common::Result;
-use datafusion_distributed::{
-    DistributedExt, WorkerPlanRewriteEvent, WorkerPlanRewriteEventResponse, WorkerPlanRewriteHandler,
-};
-
-struct MyWorkerPlanRewriteHandler;
-
-#[async_trait]
-impl WorkerPlanRewriteHandler for MyWorkerPlanRewriteHandler {
-    async fn rewrite_worker_plan(
-        &self,
-        event: WorkerPlanRewriteEvent<'_>,
-    ) -> Result<WorkerPlanRewriteEventResponse> {
-        // ... perform async setup work here ...
-        Ok(WorkerPlanRewriteEventResponse::new(event.plan))
-    }
-}
-
-let state = SessionStateBuilder::new()
-    .with_distributed_worker_plan_rewrite_handler(MyWorkerPlanRewriteHandler)
-    .build();
-```
+`WorkerPlanRewriteHandler::rewrite_worker_plan` has been renamed to `handle` to
+match other handlers and is now `async`, so implementations can perform setup work
+that needs to make network or I/O calls before the plan is handed off for execution.
+The trait name and `{with,set}_distributed_worker_plan_rewrite_handler` registration
+methods are unchanged, and callback-style sync functions are still supported via an
+auto impl adapter.

--- a/docs/upgrade/5.0.0.md
+++ b/docs/upgrade/5.0.0.md
@@ -78,3 +78,54 @@ let state = SessionStateBuilder::new()
 `RouteTaskHandler` implementation, therefore a worker is only chosen if a  
 coordinator-to-worker connection is currently established. Implementations can
 choose to retry on other worker if the current one is not available.
+
+## 2. `WorkerPlanRewriteHandler` is asynchronous
+
+`WorkerPlanRewriteHandler::rewrite_worker_plan` is now `async`, so
+implementations can perform setup work that needs to make network or I/O
+calls—such as registering tables the worker-local plan references—before the
+plan is handed off for execution. The trait name, method name, and
+`{with,set}_distributed_worker_plan_rewrite_handler` registration methods are
+unchanged.
+
+Because `WorkerPlanRewriteHandler` is now `async_trait`-based, plain closures
+can no longer implement it directly; implement it on a named type instead.
+
+Previously, a plain closure could be registered:
+
+```rust
+fn passthrough(event: WorkerPlanRewriteEvent<'_>) -> Result<WorkerPlanRewriteEventResponse> {
+    Ok(WorkerPlanRewriteEventResponse::new(event.plan))
+}
+
+let state = SessionStateBuilder::new()
+    .with_distributed_worker_plan_rewrite_handler(passthrough)
+    .build();
+```
+
+In 5.0, implement the async handler on a named type:
+
+```rust
+use async_trait::async_trait;
+use datafusion::common::Result;
+use datafusion_distributed::{
+    DistributedExt, WorkerPlanRewriteEvent, WorkerPlanRewriteEventResponse, WorkerPlanRewriteHandler,
+};
+
+struct MyWorkerPlanRewriteHandler;
+
+#[async_trait]
+impl WorkerPlanRewriteHandler for MyWorkerPlanRewriteHandler {
+    async fn rewrite_worker_plan(
+        &self,
+        event: WorkerPlanRewriteEvent<'_>,
+    ) -> Result<WorkerPlanRewriteEventResponse> {
+        // ... perform async setup work here ...
+        Ok(WorkerPlanRewriteEventResponse::new(event.plan))
+    }
+}
+
+let state = SessionStateBuilder::new()
+    .with_distributed_worker_plan_rewrite_handler(MyWorkerPlanRewriteHandler)
+    .build();
+```

--- a/src/distributed_ext.rs
+++ b/src/distributed_ext.rs
@@ -727,7 +727,7 @@ pub trait DistributedExt: Sized {
     ///
     /// #[async_trait]
     /// impl WorkerPlanRewriteHandler for Passthrough {
-    ///     async fn rewrite_worker_plan(
+    ///     async fn handle(
     ///         &self,
     ///         event: WorkerPlanRewriteEvent<'_>,
     ///     ) -> Result<WorkerPlanRewriteEventResponse> {

--- a/src/distributed_ext.rs
+++ b/src/distributed_ext.rs
@@ -718,18 +718,27 @@ pub trait DistributedExt: Sized {
     /// the coordinator session context is not used by workers
     ///
     /// ```rust
+    /// # use async_trait::async_trait;
     /// # use datafusion::common::Result;
     /// # use datafusion::execution::SessionState;
-    /// # use datafusion_distributed::{DistributedExt, Worker, WorkerPlanRewriteEvent, WorkerPlanRewriteEventResponse, WorkerQueryContext};
+    /// # use datafusion_distributed::{DistributedExt, Worker, WorkerPlanRewriteEvent, WorkerPlanRewriteEventResponse, WorkerPlanRewriteHandler, WorkerQueryContext};
+    ///
+    /// struct Passthrough;
+    ///
+    /// #[async_trait]
+    /// impl WorkerPlanRewriteHandler for Passthrough {
+    ///     async fn rewrite_worker_plan(
+    ///         &self,
+    ///         event: WorkerPlanRewriteEvent<'_>,
+    ///     ) -> Result<WorkerPlanRewriteEventResponse> {
+    ///         Ok(WorkerPlanRewriteEventResponse::new(event.plan))
+    ///     }
+    /// }
     ///
     /// async fn build_worker_session(ctx: WorkerQueryContext) -> Result<SessionState> {
     ///     Ok(ctx
     ///         .builder
-    ///         .with_distributed_worker_plan_rewrite_handler(
-    ///             |event: WorkerPlanRewriteEvent<'_>| {
-    ///                 Ok(WorkerPlanRewriteEventResponse::new(event.plan))
-    ///             },
-    ///         )
+    ///         .with_distributed_worker_plan_rewrite_handler(Passthrough)
     ///         .build())
     /// }
     ///

--- a/src/events/common.rs
+++ b/src/events/common.rs
@@ -37,17 +37,6 @@ impl<H: ?Sized> EventHandlerChain<H> {
         // If no user handler handled the event, use the built ins.
         self.builtin.iter().find_map(|handler| f(handler.as_ref()))
     }
-
-    pub(super) fn try_fold<T, E>(
-        &self,
-        mut value: T,
-        mut f: impl FnMut(T, &H) -> Result<T, E>,
-    ) -> Result<T, E> {
-        for handler in self.custom.iter().chain(&self.builtin) {
-            value = f(value, handler.as_ref())?;
-        }
-        Ok(value)
-    }
 }
 
 impl<H: ?Sized + Send + Sync + 'static> EventHandlerChain<H> {

--- a/src/events/worker_plan_rewrite.rs
+++ b/src/events/worker_plan_rewrite.rs
@@ -33,23 +33,37 @@ impl WorkerPlanRewriteEventResponse {
 /// previous handler. Returning an error aborts plan registration.
 ///
 /// The handler is `async` so implementations can perform setup work that needs to make network
-/// or I/O calls (e.g. registering tables in the worker session) before the plan executes.
+/// or I/O calls before the plan executes.
 #[async_trait]
 pub trait WorkerPlanRewriteHandler: Send + Sync + 'static {
     /// Returns the plan to pass to the next handler.
-    async fn rewrite_worker_plan(
+    async fn handle(
         &self,
         ev: WorkerPlanRewriteEvent<'_>,
     ) -> Result<WorkerPlanRewriteEventResponse>;
 }
 
 #[async_trait]
-impl WorkerPlanRewriteHandler for Arc<dyn WorkerPlanRewriteHandler> {
-    async fn rewrite_worker_plan(
+impl<F> WorkerPlanRewriteHandler for F
+where
+    F: Send + Sync + 'static,
+    F: for<'a> Fn(WorkerPlanRewriteEvent<'a>) -> Result<WorkerPlanRewriteEventResponse>,
+{
+    async fn handle(
         &self,
         ev: WorkerPlanRewriteEvent<'_>,
     ) -> Result<WorkerPlanRewriteEventResponse> {
-        self.as_ref().rewrite_worker_plan(ev).await
+        self(ev)
+    }
+}
+
+#[async_trait]
+impl WorkerPlanRewriteHandler for Arc<dyn WorkerPlanRewriteHandler> {
+    async fn handle(
+        &self,
+        ev: WorkerPlanRewriteEvent<'_>,
+    ) -> Result<WorkerPlanRewriteEventResponse> {
+        self.as_ref().handle(ev).await
     }
 }
 
@@ -66,7 +80,7 @@ impl WorkerPlanRewriteHandlers {
         if let Some(handlers) = session_config.get_extension::<WorkerPlanRewriteHandlers>() {
             for handler in handlers.iter() {
                 plan = handler
-                    .rewrite_worker_plan(WorkerPlanRewriteEvent {
+                    .handle(WorkerPlanRewriteEvent {
                         plan,
                         session_config,
                     })

--- a/src/events/worker_plan_rewrite.rs
+++ b/src/events/worker_plan_rewrite.rs
@@ -1,4 +1,5 @@
 use super::common::EventHandlerChain;
+use async_trait::async_trait;
 use datafusion::error::Result;
 use datafusion::execution::config::SessionConfig;
 use datafusion::physical_plan::ExecutionPlan;
@@ -30,55 +31,49 @@ impl WorkerPlanRewriteEventResponse {
 ///
 /// Every registered handler runs in registration order and receives the plan returned by the
 /// previous handler. Returning an error aborts plan registration.
+///
+/// The handler is `async` so implementations can perform setup work that needs to make network
+/// or I/O calls (e.g. registering tables in the worker session) before the plan executes.
+#[async_trait]
 pub trait WorkerPlanRewriteHandler: Send + Sync + 'static {
     /// Returns the plan to pass to the next handler.
-    fn rewrite_worker_plan(
+    async fn rewrite_worker_plan(
         &self,
-        ev: WorkerPlanRewriteEvent,
+        ev: WorkerPlanRewriteEvent<'_>,
     ) -> Result<WorkerPlanRewriteEventResponse>;
 }
 
-impl<F> WorkerPlanRewriteHandler for F
-where
-    F: Send + Sync + 'static,
-    F: for<'a> Fn(WorkerPlanRewriteEvent<'a>) -> Result<WorkerPlanRewriteEventResponse>,
-{
-    fn rewrite_worker_plan(
-        &self,
-        ev: WorkerPlanRewriteEvent,
-    ) -> Result<WorkerPlanRewriteEventResponse> {
-        self(ev)
-    }
-}
-
+#[async_trait]
 impl WorkerPlanRewriteHandler for Arc<dyn WorkerPlanRewriteHandler> {
-    fn rewrite_worker_plan(
+    async fn rewrite_worker_plan(
         &self,
-        ev: WorkerPlanRewriteEvent,
+        ev: WorkerPlanRewriteEvent<'_>,
     ) -> Result<WorkerPlanRewriteEventResponse> {
-        self.as_ref().rewrite_worker_plan(ev)
+        self.as_ref().rewrite_worker_plan(ev).await
     }
 }
 
 pub(crate) type WorkerPlanRewriteHandlers = EventHandlerChain<dyn WorkerPlanRewriteHandler>;
 
 impl WorkerPlanRewriteHandlers {
-    pub(crate) fn handle(ev: WorkerPlanRewriteEvent) -> Result<WorkerPlanRewriteEventResponse> {
+    pub(crate) async fn handle(
+        ev: WorkerPlanRewriteEvent<'_>,
+    ) -> Result<WorkerPlanRewriteEventResponse> {
         let WorkerPlanRewriteEvent {
-            plan,
+            mut plan,
             session_config,
         } = ev;
-        let plan = match session_config.get_extension::<WorkerPlanRewriteHandlers>() {
-            Some(handlers) => handlers.try_fold(plan, |plan, handler| {
-                handler
+        if let Some(handlers) = session_config.get_extension::<WorkerPlanRewriteHandlers>() {
+            for handler in handlers.iter() {
+                plan = handler
                     .rewrite_worker_plan(WorkerPlanRewriteEvent {
                         plan,
                         session_config,
                     })
-                    .map(|response| response.plan)
-            })?,
-            None => plan,
-        };
+                    .await?
+                    .plan;
+            }
+        }
         Ok(WorkerPlanRewriteEventResponse::new(plan))
     }
 }

--- a/src/worker/impl_coordinator_channel.rs
+++ b/src/worker/impl_coordinator_channel.rs
@@ -84,7 +84,7 @@ impl Worker {
                 plan,
                 session_config: session_state.config(),
             };
-            let plan = WorkerPlanRewriteHandlers::handle(ev)?.plan;
+            let plan = WorkerPlanRewriteHandlers::handle(ev).await?.plan;
             load_info_rxs =
                 SamplerExec::kick_off_first_sampler(Arc::clone(&plan), Arc::clone(&task_ctx))?;
 

--- a/tests/worker_plan_hook.rs
+++ b/tests/worker_plan_hook.rs
@@ -4,6 +4,7 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
     use arrow::util::pretty::pretty_format_batches;
+    use async_trait::async_trait;
     use datafusion::common::{HashSet, Result, assert_contains, extensions_options, internal_err};
     use datafusion::config::ConfigExtension;
     use datafusion::error::DataFusionError;
@@ -14,7 +15,8 @@ mod tests {
     use datafusion_distributed::test_utils::session_context::register_temp_parquet_table;
     use datafusion_distributed::{
         DistributedExt, MappedWorkerSessionBuilderExt, WorkerPlanRewriteEvent,
-        WorkerPlanRewriteEventResponse, WorkerQueryContext, assert_snapshot,
+        WorkerPlanRewriteEventResponse, WorkerPlanRewriteHandler, WorkerQueryContext,
+        assert_snapshot,
     };
     use std::sync::Arc;
     use std::sync::Mutex;
@@ -80,16 +82,7 @@ mod tests {
     async fn plan_hook_errors_propagate_to_query() -> Result<(), Box<dyn std::error::Error>> {
         let session_builder = build_state.map(|builder| {
             Ok(builder
-                .with_distributed_worker_plan_rewrite_handler(
-                    |event: WorkerPlanRewriteEvent<'_>| {
-                        let options = plan_hook_options(event.session_config)?;
-                        if options.fail_in_hook {
-                            return internal_err!("plan hook failed for {}", options.label);
-                        }
-
-                        Ok(WorkerPlanRewriteEventResponse::new(event.plan))
-                    },
-                )
+                .with_distributed_worker_plan_rewrite_handler(FailingPlanHook)
                 .build())
         });
         let mut ctx = start_configured_in_memory_context(3, session_builder, |worker| worker).await;
@@ -115,39 +108,77 @@ mod tests {
         second: usize,
     }
 
-    fn add_first_hook(builder: &mut SessionStateBuilder, calls: Arc<Mutex<HookCalls>>) {
-        builder.set_distributed_worker_plan_rewrite_handler(
-            move |event: WorkerPlanRewriteEvent<'_>| {
-                let options = plan_hook_options(event.session_config)?;
-                if options.label != HOOK_LABEL {
-                    return internal_err!("unexpected plan hook label {}", options.label);
-                }
+    /// Fails the plan if [`PlanHookOptions::fail_in_hook`] is set.
+    struct FailingPlanHook;
 
-                let mut calls = calls.lock().unwrap();
-                calls.pending_plan_ids.insert(plan_identity(&event.plan));
-                calls.first += 1;
-                Ok(WorkerPlanRewriteEventResponse::new(event.plan))
-            },
-        )
+    #[async_trait]
+    impl WorkerPlanRewriteHandler for FailingPlanHook {
+        async fn rewrite_worker_plan(
+            &self,
+            event: WorkerPlanRewriteEvent<'_>,
+        ) -> Result<WorkerPlanRewriteEventResponse> {
+            let options = plan_hook_options(event.session_config)?;
+            if options.fail_in_hook {
+                return internal_err!("plan hook failed for {}", options.label);
+            }
+
+            Ok(WorkerPlanRewriteEventResponse::new(event.plan))
+        }
+    }
+
+    struct FirstPlanHook {
+        calls: Arc<Mutex<HookCalls>>,
+    }
+
+    #[async_trait]
+    impl WorkerPlanRewriteHandler for FirstPlanHook {
+        async fn rewrite_worker_plan(
+            &self,
+            event: WorkerPlanRewriteEvent<'_>,
+        ) -> Result<WorkerPlanRewriteEventResponse> {
+            let options = plan_hook_options(event.session_config)?;
+            if options.label != HOOK_LABEL {
+                return internal_err!("unexpected plan hook label {}", options.label);
+            }
+
+            let mut calls = self.calls.lock().unwrap();
+            calls.pending_plan_ids.insert(plan_identity(&event.plan));
+            calls.first += 1;
+            Ok(WorkerPlanRewriteEventResponse::new(event.plan))
+        }
+    }
+
+    struct SecondPlanHook {
+        calls: Arc<Mutex<HookCalls>>,
+    }
+
+    #[async_trait]
+    impl WorkerPlanRewriteHandler for SecondPlanHook {
+        async fn rewrite_worker_plan(
+            &self,
+            event: WorkerPlanRewriteEvent<'_>,
+        ) -> Result<WorkerPlanRewriteEventResponse> {
+            let options = plan_hook_options(event.session_config)?;
+            if options.label != HOOK_LABEL {
+                return internal_err!("unexpected plan hook label {}", options.label);
+            }
+
+            let mut calls = self.calls.lock().unwrap();
+            if !calls.pending_plan_ids.remove(&plan_identity(&event.plan)) {
+                return internal_err!("second hook ran before first hook");
+            }
+
+            calls.second += 1;
+            Ok(WorkerPlanRewriteEventResponse::new(event.plan))
+        }
+    }
+
+    fn add_first_hook(builder: &mut SessionStateBuilder, calls: Arc<Mutex<HookCalls>>) {
+        builder.set_distributed_worker_plan_rewrite_handler(FirstPlanHook { calls });
     }
 
     fn add_second_hook(builder: &mut SessionStateBuilder, calls: Arc<Mutex<HookCalls>>) {
-        builder.set_distributed_worker_plan_rewrite_handler(
-            move |event: WorkerPlanRewriteEvent<'_>| {
-                let options = plan_hook_options(event.session_config)?;
-                if options.label != HOOK_LABEL {
-                    return internal_err!("unexpected plan hook label {}", options.label);
-                }
-
-                let mut calls = calls.lock().unwrap();
-                if !calls.pending_plan_ids.remove(&plan_identity(&event.plan)) {
-                    return internal_err!("second hook ran before first hook");
-                }
-
-                calls.second += 1;
-                Ok(WorkerPlanRewriteEventResponse::new(event.plan))
-            },
-        )
+        builder.set_distributed_worker_plan_rewrite_handler(SecondPlanHook { calls });
     }
 
     fn plan_identity(plan: &Arc<dyn ExecutionPlan>) -> usize {

--- a/tests/worker_plan_hook.rs
+++ b/tests/worker_plan_hook.rs
@@ -82,7 +82,16 @@ mod tests {
     async fn plan_hook_errors_propagate_to_query() -> Result<(), Box<dyn std::error::Error>> {
         let session_builder = build_state.map(|builder| {
             Ok(builder
-                .with_distributed_worker_plan_rewrite_handler(FailingPlanHook)
+                .with_distributed_worker_plan_rewrite_handler(
+                    |event: WorkerPlanRewriteEvent<'_>| {
+                        let options = plan_hook_options(event.session_config)?;
+                        if options.fail_in_hook {
+                            return internal_err!("plan hook failed for {}", options.label);
+                        }
+
+                        Ok(WorkerPlanRewriteEventResponse::new(event.plan))
+                    },
+                )
                 .build())
         });
         let mut ctx = start_configured_in_memory_context(3, session_builder, |worker| worker).await;
@@ -108,53 +117,13 @@ mod tests {
         second: usize,
     }
 
-    /// Fails the plan if [`PlanHookOptions::fail_in_hook`] is set.
-    struct FailingPlanHook;
-
-    #[async_trait]
-    impl WorkerPlanRewriteHandler for FailingPlanHook {
-        async fn rewrite_worker_plan(
-            &self,
-            event: WorkerPlanRewriteEvent<'_>,
-        ) -> Result<WorkerPlanRewriteEventResponse> {
-            let options = plan_hook_options(event.session_config)?;
-            if options.fail_in_hook {
-                return internal_err!("plan hook failed for {}", options.label);
-            }
-
-            Ok(WorkerPlanRewriteEventResponse::new(event.plan))
-        }
-    }
-
-    struct FirstPlanHook {
-        calls: Arc<Mutex<HookCalls>>,
-    }
-
-    #[async_trait]
-    impl WorkerPlanRewriteHandler for FirstPlanHook {
-        async fn rewrite_worker_plan(
-            &self,
-            event: WorkerPlanRewriteEvent<'_>,
-        ) -> Result<WorkerPlanRewriteEventResponse> {
-            let options = plan_hook_options(event.session_config)?;
-            if options.label != HOOK_LABEL {
-                return internal_err!("unexpected plan hook label {}", options.label);
-            }
-
-            let mut calls = self.calls.lock().unwrap();
-            calls.pending_plan_ids.insert(plan_identity(&event.plan));
-            calls.first += 1;
-            Ok(WorkerPlanRewriteEventResponse::new(event.plan))
-        }
-    }
-
     struct SecondPlanHook {
         calls: Arc<Mutex<HookCalls>>,
     }
 
     #[async_trait]
     impl WorkerPlanRewriteHandler for SecondPlanHook {
-        async fn rewrite_worker_plan(
+        async fn handle(
             &self,
             event: WorkerPlanRewriteEvent<'_>,
         ) -> Result<WorkerPlanRewriteEventResponse> {
@@ -174,7 +143,19 @@ mod tests {
     }
 
     fn add_first_hook(builder: &mut SessionStateBuilder, calls: Arc<Mutex<HookCalls>>) {
-        builder.set_distributed_worker_plan_rewrite_handler(FirstPlanHook { calls });
+        builder.set_distributed_worker_plan_rewrite_handler(
+            move |event: WorkerPlanRewriteEvent<'_>| {
+                let options = plan_hook_options(event.session_config)?;
+                if options.label != HOOK_LABEL {
+                    return internal_err!("unexpected plan hook label {}", options.label);
+                }
+
+                let mut calls = calls.lock().unwrap();
+                calls.pending_plan_ids.insert(plan_identity(&event.plan));
+                calls.first += 1;
+                Ok(WorkerPlanRewriteEventResponse::new(event.plan))
+            },
+        )
     }
 
     fn add_second_hook(builder: &mut SessionStateBuilder, calls: Arc<Mutex<HookCalls>>) {


### PR DESCRIPTION
Rewrite of the worker plan rewrite handler API so implementations can perform async setup work before a worker-local plan is registered for execution.

Some setups need to make network or I/O calls while reacting to a decoded worker-local plan (e.g. registering tables the plan references) before the plan is handed off for execution. `WorkerSessionBuilder::build_session_state` runs too early for this: it builds the session before the plan is decoded, so it has no access to the plan being executed. `WorkerPlanRewriteHandler` is the only extension point that sees the decoded plan at worker-session setup time, so it is now `async`.

Because `WorkerPlanRewriteEvent` borrows the worker session's `SessionConfig`, a `Fn(WorkerPlanRewriteEvent<'_>) -> impl Future<...>` blanket implementation cannot express the required lifetimes without boxing. Implementations now define a named type and `#[async_trait] impl WorkerPlanRewriteHandler for ...`, matching the pattern already used by `RouteTaskHandler`.

No new capabilities are added for handlers themselves; this is purely an API change unlocking async work inside existing handlers.