### PR TITLE
feat: propagate typed session extensions

### DIFF
--- a/docs/upgrade/5.0.0.md
+++ b/docs/upgrade/5.0.0.md
@@ -79,7 +79,15 @@ let state = SessionStateBuilder::new()
 coordinator-to-worker connection is currently established. Implementations can
 choose to retry on other worker if the current one is not available.
 
-## 2. `WorkerPlanRewriteHandler::rewrite_worker_plan` renamed to `handle` and is now async
+## 2. `SetPlanRequest` includes session extension payloads
+
+Custom [`WorkerChannel`](https://docs.rs/datafusion-distributed/latest/datafusion_distributed/trait.WorkerChannel.html)
+implementations that construct or destructure `SetPlanRequest` must handle its new
+`session_extensions` field. Forward the payloads unchanged so workers can decode
+opt-in session extensions, or initialize the field with `Vec::new()` when none are
+supported.
+
+## 3. `WorkerPlanRewriteHandler::rewrite_worker_plan` renamed to `handle` and is now async
 
 `WorkerPlanRewriteHandler::rewrite_worker_plan` has been renamed to `handle` to
 match other handlers and is now `async`, so implementations can perform setup work

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -1,11 +1,16 @@
 mod distributed_codec;
 mod physical_plan;
+mod session_extension;
 mod user_codec;
 
 pub use distributed_codec::DistributedCodec;
 pub(crate) use physical_plan::{
     decode_execution_plan, decode_partitioning, decode_physical_expr, encode_execution_plan,
     encode_partitioning, encode_physical_expr, roundtrip_pb,
+};
+pub use session_extension::{SessionExtensionCodec, SessionExtensionPayload};
+pub(crate) use session_extension::{
+    SessionExtensionCodecRegistry, encode_session_extensions, set_session_extension_codec,
 };
 pub(crate) use user_codec::{
     get_distributed_user_codecs, set_distributed_user_codec, set_distributed_user_codec_arc,

--- a/src/codec/session_extension.rs
+++ b/src/codec/session_extension.rs
@@ -1,0 +1,263 @@
+use datafusion::common::{DataFusionError, Result, config_datafusion_err};
+use datafusion::prelude::SessionConfig;
+use std::any::TypeId;
+use std::collections::HashSet;
+use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
+
+/// Serializes one typed [`SessionConfig`] extension for distributed execution.
+///
+/// Registering a codec on a coordinating session opts its [`Extension`](Self::Extension) into
+/// propagation to workers. The codec controls the bytes sent over the wire; DataFusion Distributed
+/// does not provide confidentiality for payloads that contain credentials or other sensitive data.
+/// A decoder for the same [`TYPE_URL`](Self::TYPE_URL) must be registered on each worker.
+pub trait SessionExtensionCodec: Send + Sync + 'static {
+    /// The concrete [`SessionConfig`] extension encoded by this codec.
+    type Extension: Send + Sync + 'static;
+
+    /// Stable identifier for this encoding.
+    ///
+    /// Include a format version in this value when incompatible encodings need distinct decoders,
+    /// for example `"example.com/my-session-extension/v1"`.
+    const TYPE_URL: &'static str;
+
+    /// Serializes `extension` into its transport representation.
+    fn encode(&self, extension: &Self::Extension) -> Result<Vec<u8>>;
+
+    /// Deserializes an extension previously produced by [`Self::encode`].
+    fn decode(&self, payload: &[u8]) -> Result<Self::Extension>;
+}
+
+/// An encoded session extension sent from a coordinator to a worker.
+#[derive(Clone)]
+pub struct SessionExtensionPayload {
+    /// Stable identifier of the codec required to decode [`Self::payload`].
+    pub type_url: String,
+    /// Opaque bytes produced by the registered codec.
+    ///
+    /// These bytes may contain sensitive data and are intentionally omitted from [`Debug`].
+    pub payload: Vec<u8>,
+}
+
+impl Debug for SessionExtensionPayload {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SessionExtensionPayload")
+            .field("type_url", &self.type_url)
+            .field("payload_len", &self.payload.len())
+            .finish()
+    }
+}
+
+pub(crate) trait ErasedSessionExtensionCodec: Send + Sync {
+    fn type_url(&self) -> &'static str;
+    fn extension_type_id(&self) -> TypeId;
+    fn encode_from_config(&self, config: &SessionConfig) -> Result<Option<Vec<u8>>>;
+    fn decode_into_config(&self, payload: &[u8], config: &mut SessionConfig) -> Result<()>;
+}
+
+struct SessionExtensionCodecAdapter<C>(C);
+
+impl<C> ErasedSessionExtensionCodec for SessionExtensionCodecAdapter<C>
+where
+    C: SessionExtensionCodec,
+{
+    fn type_url(&self) -> &'static str {
+        C::TYPE_URL
+    }
+
+    fn extension_type_id(&self) -> TypeId {
+        TypeId::of::<C::Extension>()
+    }
+
+    fn encode_from_config(&self, config: &SessionConfig) -> Result<Option<Vec<u8>>> {
+        config
+            .get_extension::<C::Extension>()
+            .map(|extension| self.0.encode(extension.as_ref()))
+            .transpose()
+    }
+
+    fn decode_into_config(&self, payload: &[u8], config: &mut SessionConfig) -> Result<()> {
+        if config.get_extension::<C::Extension>().is_some() {
+            return Err(config_datafusion_err!(
+                "Cannot decode session extension '{}': an extension of that type is already present in the worker session",
+                C::TYPE_URL
+            ));
+        }
+        config.set_extension(Arc::new(self.0.decode(payload)?));
+        Ok(())
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct SessionExtensionCodecRegistry {
+    codecs: Vec<Arc<dyn ErasedSessionExtensionCodec>>,
+}
+
+impl SessionExtensionCodecRegistry {
+    pub(crate) fn push<C: SessionExtensionCodec>(&mut self, codec: C) {
+        self.codecs
+            .push(Arc::new(SessionExtensionCodecAdapter(codec)));
+    }
+
+    fn validate(&self) -> Result<()> {
+        let mut type_urls = HashSet::with_capacity(self.codecs.len());
+        let mut extension_types = HashSet::with_capacity(self.codecs.len());
+        for codec in &self.codecs {
+            if codec.type_url().is_empty() {
+                return Err(config_datafusion_err!(
+                    "Session extension codec TYPE_URL cannot be empty"
+                ));
+            }
+            if !type_urls.insert(codec.type_url()) {
+                return Err(config_datafusion_err!(
+                    "Multiple session extension codecs use TYPE_URL '{}'",
+                    codec.type_url()
+                ));
+            }
+            if !extension_types.insert(codec.extension_type_id()) {
+                return Err(config_datafusion_err!(
+                    "Multiple session extension codecs encode the same Rust extension type"
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn encode(&self, config: &SessionConfig) -> Result<Vec<SessionExtensionPayload>> {
+        self.validate()?;
+        self.codecs
+            .iter()
+            .filter_map(|codec| {
+                codec.encode_from_config(config).transpose().map(|result| {
+                    result.map(|payload| SessionExtensionPayload {
+                        type_url: codec.type_url().to_string(),
+                        payload,
+                    })
+                })
+            })
+            .collect()
+    }
+
+    pub(crate) fn decode(
+        &self,
+        payloads: &[SessionExtensionPayload],
+        config: &mut SessionConfig,
+    ) -> Result<()> {
+        self.validate()?;
+        let mut decoded_type_urls = HashSet::with_capacity(payloads.len());
+        for payload in payloads {
+            if !decoded_type_urls.insert(payload.type_url.as_str()) {
+                return Err(config_datafusion_err!(
+                    "Received multiple session extension payloads for TYPE_URL '{}'",
+                    payload.type_url
+                ));
+            }
+            let codec = self
+                .codecs
+                .iter()
+                .find(|codec| codec.type_url() == payload.type_url)
+                .ok_or_else(|| {
+                    DataFusionError::Configuration(format!(
+                        "No worker session extension codec is registered for TYPE_URL '{}'",
+                        payload.type_url
+                    ))
+                })?;
+            codec.decode_into_config(&payload.payload, config)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Default)]
+struct CoordinatorSessionExtensionCodecs(SessionExtensionCodecRegistry);
+
+pub(crate) fn set_session_extension_codec<C: SessionExtensionCodec>(
+    config: &mut SessionConfig,
+    codec: C,
+) {
+    let mut codecs = config
+        .get_extension::<CoordinatorSessionExtensionCodecs>()
+        .map(|codecs| codecs.as_ref().clone())
+        .unwrap_or_default();
+    codecs.0.push(codec);
+    config.set_extension(Arc::new(codecs));
+}
+
+pub(crate) fn encode_session_extensions(
+    config: &SessionConfig,
+) -> Result<Vec<SessionExtensionPayload>> {
+    match config.get_extension::<CoordinatorSessionExtensionCodecs>() {
+        Some(codecs) => codecs.0.encode(config),
+        None => Ok(Vec::new()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, PartialEq)]
+    struct TestExtension(String);
+
+    struct TestCodec;
+
+    impl SessionExtensionCodec for TestCodec {
+        type Extension = TestExtension;
+        const TYPE_URL: &'static str = "test/extension/v1";
+
+        fn encode(&self, extension: &Self::Extension) -> Result<Vec<u8>> {
+            Ok(extension.0.as_bytes().to_vec())
+        }
+
+        fn decode(&self, payload: &[u8]) -> Result<Self::Extension> {
+            Ok(TestExtension(String::from_utf8(payload.to_vec()).unwrap()))
+        }
+    }
+
+    #[test]
+    fn registered_extension_roundtrips() -> Result<()> {
+        let mut coordinator = SessionConfig::new()
+            .with_extension(Arc::new(TestExtension("request value".to_string())));
+        set_session_extension_codec(&mut coordinator, TestCodec);
+        let payloads = encode_session_extensions(&coordinator)?;
+
+        let mut worker = SessionConfig::new();
+        let mut codecs = SessionExtensionCodecRegistry::default();
+        codecs.push(TestCodec);
+        codecs.decode(&payloads, &mut worker)?;
+
+        assert_eq!(
+            worker.get_extension::<TestExtension>().as_deref(),
+            Some(&TestExtension("request value".to_string()))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn registered_codec_skips_absent_extension() -> Result<()> {
+        let mut config = SessionConfig::new();
+        set_session_extension_codec(&mut config, TestCodec);
+
+        assert!(encode_session_extensions(&config)?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn decoding_does_not_replace_existing_worker_extension() {
+        let payloads = vec![SessionExtensionPayload {
+            type_url: TestCodec::TYPE_URL.to_string(),
+            payload: b"request value".to_vec(),
+        }];
+        let mut worker = SessionConfig::new()
+            .with_extension(Arc::new(TestExtension("worker value".to_string())));
+        let mut codecs = SessionExtensionCodecRegistry::default();
+        codecs.push(TestCodec);
+
+        let err = codecs.decode(&payloads, &mut worker).unwrap_err();
+        assert!(err.to_string().contains("already present"));
+        assert_eq!(
+            worker.get_extension::<TestExtension>().as_deref(),
+            Some(&TestExtension("worker value".to_string()))
+        );
+    }
+}

--- a/src/coordinator/query_coordinator.rs
+++ b/src/coordinator/query_coordinator.rs
@@ -1,4 +1,4 @@
-use crate::codec::roundtrip_pb;
+use crate::codec::{encode_session_extensions, roundtrip_pb};
 use crate::common::{TreeNodeExt, now_ns, task_ctx_with_extension};
 use crate::config_extension_ext::get_config_extension_propagation_headers;
 use crate::coordinator::Store;
@@ -165,6 +165,7 @@ impl<'a> StageCoordinator<'a> {
 
         let mut headers = get_config_extension_propagation_headers(session_config)?;
         headers.extend(get_passthrough_headers(session_config));
+        let session_extensions = encode_session_extensions(session_config)?;
 
         let metrics = self.metrics.clone();
         let metrics_set = self.metrics_set.clone();
@@ -204,6 +205,7 @@ impl<'a> StageCoordinator<'a> {
                 work_unit_feed_declarations: work_unit_feed_declarations.clone(),
                 target_worker_url: url.clone(),
                 query_start_time_ns: self.metrics.instantiation_time,
+                session_extensions: session_extensions.clone(),
             };
             let task_ctx = Arc::clone(self.task_ctx);
             let headers = headers.clone();

--- a/src/distributed_ext.rs
+++ b/src/distributed_ext.rs
@@ -1,4 +1,6 @@
-use crate::codec::{set_distributed_user_codec, set_distributed_user_codec_arc};
+use crate::codec::{
+    set_distributed_user_codec, set_distributed_user_codec_arc, set_session_extension_codec,
+};
 use crate::config_extension_ext::{
     set_distributed_option_extension, set_distributed_option_extension_from_headers,
 };
@@ -12,8 +14,8 @@ use crate::protocol::set_distributed_channel_resolver;
 use crate::work_unit_feed::set_distributed_work_unit_feed;
 use crate::worker_resolver::set_distributed_worker_resolver;
 use crate::{
-    ChannelResolver, DistributedConfig, LocalWorkerContext, WorkUnitFeed, WorkUnitFeedProvider,
-    WorkerResolver, get_distributed_worker_resolver,
+    ChannelResolver, DistributedConfig, LocalWorkerContext, SessionExtensionCodec, WorkUnitFeed,
+    WorkUnitFeedProvider, WorkerResolver, get_distributed_worker_resolver,
 };
 use datafusion::common::DataFusionError;
 use datafusion::config::ConfigExtension;
@@ -136,6 +138,18 @@ pub trait DistributedExt: Sized {
         &mut self,
         headers: &HeaderMap,
     ) -> Result<(), DataFusionError>;
+
+    /// Registers a codec that opts one typed [`SessionConfig::with_extension`] value into
+    /// propagation from this coordinating session to workers.
+    ///
+    /// Register the same codec on each worker with [`crate::Worker::with_session_extension_codec`].
+    /// Only the extension value is sent; the codec remains node-local. Payloads may contain
+    /// sensitive data and must be protected by the transport configured by the application.
+    fn with_distributed_session_extension_codec<C: SessionExtensionCodec>(self, codec: C) -> Self;
+
+    /// Same as [`DistributedExt::with_distributed_session_extension_codec`] but with an in-place
+    /// mutation.
+    fn set_distributed_session_extension_codec<C: SessionExtensionCodec>(&mut self, codec: C);
 
     /// Injects a user-defined [PhysicalExtensionCodec] that is capable of encoding/decoding
     /// custom execution nodes. Multiple user-defined [PhysicalExtensionCodec] can be added
@@ -776,6 +790,10 @@ impl DistributedExt for SessionConfig {
         Ok(())
     }
 
+    fn set_distributed_session_extension_codec<C: SessionExtensionCodec>(&mut self, codec: C) {
+        set_session_extension_codec(self, codec)
+    }
+
     fn set_distributed_user_codec<T: PhysicalExtensionCodec + 'static>(&mut self, codec: T) {
         set_distributed_user_codec(self, codec)
     }
@@ -954,6 +972,10 @@ impl DistributedExt for SessionConfig {
             #[expr($?;Ok(self))]
             fn with_distributed_option_extension_from_headers<T: ConfigExtension + Default>(mut self, headers: &HeaderMap) -> Result<Self, DataFusionError>;
 
+            #[call(set_distributed_session_extension_codec)]
+            #[expr($;self)]
+            fn with_distributed_session_extension_codec<C: SessionExtensionCodec>(mut self, codec: C) -> Self;
+
             #[call(set_distributed_user_codec)]
             #[expr($;self)]
             fn with_distributed_user_codec<T: PhysicalExtensionCodec + 'static>(mut self, codec: T) -> Self;
@@ -1076,6 +1098,11 @@ impl DistributedExt for SessionStateBuilder {
             #[call(set_distributed_option_extension_from_headers)]
             #[expr($?;Ok(self))]
             fn with_distributed_option_extension_from_headers<T: ConfigExtension + Default>(mut self, headers: &HeaderMap) -> Result<Self, DataFusionError>;
+
+            fn set_distributed_session_extension_codec<C: SessionExtensionCodec>(&mut self, codec: C);
+            #[call(set_distributed_session_extension_codec)]
+            #[expr($;self)]
+            fn with_distributed_session_extension_codec<C: SessionExtensionCodec>(mut self, codec: C) -> Self;
 
             fn set_distributed_user_codec<T: PhysicalExtensionCodec + 'static>(&mut self, codec: T);
             #[call(set_distributed_user_codec)]
@@ -1232,6 +1259,11 @@ impl DistributedExt for SessionState {
             #[expr($?;Ok(self))]
             fn with_distributed_option_extension_from_headers<T: ConfigExtension + Default>(mut self, headers: &HeaderMap) -> Result<Self, DataFusionError>;
 
+            fn set_distributed_session_extension_codec<C: SessionExtensionCodec>(&mut self, codec: C);
+            #[call(set_distributed_session_extension_codec)]
+            #[expr($;self)]
+            fn with_distributed_session_extension_codec<C: SessionExtensionCodec>(mut self, codec: C) -> Self;
+
             fn set_distributed_user_codec<T: PhysicalExtensionCodec + 'static>(&mut self, codec: T);
             #[call(set_distributed_user_codec)]
             #[expr($;self)]
@@ -1379,6 +1411,11 @@ impl DistributedExt for SessionContext {
             #[call(set_distributed_option_extension_from_headers)]
             #[expr($?;Ok(self))]
             fn with_distributed_option_extension_from_headers<T: ConfigExtension + Default>(self, headers: &HeaderMap) -> Result<Self, DataFusionError>;
+
+            fn set_distributed_session_extension_codec<C: SessionExtensionCodec>(&mut self, codec: C);
+            #[call(set_distributed_session_extension_codec)]
+            #[expr($;self)]
+            fn with_distributed_session_extension_codec<C: SessionExtensionCodec>(self, codec: C) -> Self;
 
             fn set_distributed_user_codec<T: PhysicalExtensionCodec + 'static>(&mut self, codec: T);
             #[call(set_distributed_user_codec)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub mod test_utils;
 #[cfg(feature = "grpc")]
 pub use protocol::grpc;
 
-pub use codec::DistributedCodec;
+pub use codec::{DistributedCodec, SessionExtensionCodec, SessionExtensionPayload};
 pub use common::MaybeEncoded;
 pub use worker_resolver::{WorkerResolver, get_distributed_worker_resolver};
 

--- a/src/protocol/grpc/generated/worker.rs
+++ b/src/protocol/grpc/generated/worker.rs
@@ -146,6 +146,18 @@ pub struct SetPlanRequest {
     /// relative to when the query was fired in the coordinator.
     #[prost(uint64, tag = "6")]
     pub query_start_time_ns: u64,
+    /// Opt-in, user-encoded session extensions to install in this task's worker session.
+    #[prost(message, repeated, tag = "7")]
+    pub session_extensions: ::prost::alloc::vec::Vec<SessionExtensionPayload>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SessionExtensionPayload {
+    /// Stable identifier of the codec required to decode payload.
+    #[prost(string, tag = "1")]
+    pub type_url: ::prost::alloc::string::String,
+    /// Opaque bytes produced by the registered codec. These bytes may contain sensitive data.
+    #[prost(bytes = "vec", tag = "2")]
+    pub payload: ::prost::alloc::vec::Vec<u8>,
 }
 /// Nested message and enum types in `SetPlanRequest`.
 pub mod set_plan_request {

--- a/src/protocol/grpc/worker.proto
+++ b/src/protocol/grpc/worker.proto
@@ -131,6 +131,15 @@ message SetPlanRequest {
   // Unix nanos when the query started as reported by the coordinator. Used for collecting temporal metrics
   // relative to when the query was fired in the coordinator.
   uint64 query_start_time_ns = 6;
+  // Opt-in, user-encoded session extensions to install in this task's worker session.
+  repeated SessionExtensionPayload session_extensions = 7;
+}
+
+message SessionExtensionPayload {
+  // Stable identifier of the codec required to decode payload.
+  string type_url = 1;
+  // Opaque bytes produced by the registered codec. These bytes may contain sensitive data.
+  bytes payload = 2;
 }
 
 message WorkUnitBatch {

--- a/src/protocol/grpc/worker_client.rs
+++ b/src/protocol/grpc/worker_client.rs
@@ -489,6 +489,14 @@ fn encode_set_plan_request(
             .collect(),
         target_worker_url: request.target_worker_url.to_string(),
         query_start_time_ns: request.query_start_time_ns as u64,
+        session_extensions: request
+            .session_extensions
+            .into_iter()
+            .map(|extension| pb::SessionExtensionPayload {
+                type_url: extension.type_url,
+                payload: extension.payload,
+            })
+            .collect(),
     })
 }
 

--- a/src/protocol/grpc/worker_service.rs
+++ b/src/protocol/grpc/worker_service.rs
@@ -231,6 +231,14 @@ fn decode_set_plan_request(request: pb::SetPlanRequest) -> Result<SetPlanRequest
             .collect::<Result<_, _>>()?,
         target_worker_url: parse_url(&request.target_worker_url, "target_worker_url")?,
         query_start_time_ns: request.query_start_time_ns as usize,
+        session_extensions: request
+            .session_extensions
+            .into_iter()
+            .map(|extension| crate::SessionExtensionPayload {
+                type_url: extension.type_url,
+                payload: extension.payload,
+            })
+            .collect(),
     })
 }
 

--- a/src/protocol/worker_channel.rs
+++ b/src/protocol/worker_channel.rs
@@ -1,4 +1,4 @@
-use crate::{MaybeEncoded, ProducerHead, WorkUnit};
+use crate::{MaybeEncoded, ProducerHead, SessionExtensionPayload, WorkUnit};
 use async_trait::async_trait;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::Result;
@@ -92,6 +92,8 @@ pub struct SetPlanRequest {
     /// Unix nanos when the query started as reported by the coordinator. Used for collecting temporal metrics
     /// relative to when the query was fired in the coordinator.
     pub query_start_time_ns: usize,
+    /// Opt-in, user-encoded session extensions to install in this task's worker session.
+    pub session_extensions: Vec<SessionExtensionPayload>,
 }
 
 pub struct WorkUnitBatch {

--- a/src/test_utils/localhost.rs
+++ b/src/test_utils/localhost.rs
@@ -25,6 +25,21 @@ where
     B: WorkerSessionBuilder + Send + Sync + 'static,
     B: Clone,
 {
+    start_localhost_context_with_worker(num_workers, session_builder, Worker::from_session_builder)
+        .await
+}
+
+/// Same as [`start_localhost_context`], with a hook for configuring each worker.
+pub async fn start_localhost_context_with_worker<B, F>(
+    num_workers: usize,
+    session_builder: B,
+    worker_factory: F,
+) -> (SessionContext, JoinSet<()>, Vec<Worker>)
+where
+    B: WorkerSessionBuilder + Send + Sync + 'static,
+    B: Clone,
+    F: Fn(B) -> Worker,
+{
     let listeners = futures::future::try_join_all(
         (0..num_workers)
             .map(|_| TcpListener::bind("127.0.0.1:0"))
@@ -47,7 +62,7 @@ where
     let mut workers = vec![];
     for listener in listeners {
         let session_builder = session_builder.clone();
-        let worker = Worker::from_session_builder(session_builder);
+        let worker = worker_factory(session_builder);
         workers.push(worker.clone());
 
         let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);

--- a/src/worker/impl_coordinator_channel.rs
+++ b/src/worker/impl_coordinator_channel.rs
@@ -68,6 +68,13 @@ impl Worker {
                 }))
                 .with_distributed_option_extension_from_headers::<DistributedConfig>(&headers)?;
 
+            // Request extensions are decoded into this task-local config before the user-provided
+            // WorkerSessionBuilder runs, so the builder may inspect them or deliberately replace
+            // one with a node-local value. Decoding itself refuses to replace an extension already
+            // installed above; this prevents a remote payload from shadowing worker-owned DFD state.
+            self.session_extension_codecs
+                .decode(&request.session_extensions, &mut cfg)?;
+
             let d_cfg = DistributedConfig::from_config_options(cfg.options())?;
             let shuffle_batch_size = d_cfg.shuffle_batch_size;
             let collect_metrics = d_cfg.collect_metrics;

--- a/src/worker/worker_service.rs
+++ b/src/worker/worker_service.rs
@@ -1,3 +1,4 @@
+use crate::codec::{SessionExtensionCodec, SessionExtensionCodecRegistry};
 use crate::protocol::LocalWorkerContext;
 use crate::worker::{SingleWriteMultiRead, WorkerSessionBuilder};
 use crate::{DefaultSessionBuilder, TaskData, TaskKey};
@@ -22,6 +23,7 @@ pub struct Worker {
     /// while allowing concurrent access to task results across multiple partition requests.
     pub(crate) task_data_entries: Arc<TaskDataEntries>,
     pub(super) session_builder: Arc<dyn WorkerSessionBuilder + Send + Sync>,
+    pub(crate) session_extension_codecs: SessionExtensionCodecRegistry,
     pub(crate) max_message_size: Option<usize>,
     pub(super) version: Cow<'static, str>,
 }
@@ -33,6 +35,7 @@ impl Default for Worker {
             runtime: Arc::new(RuntimeEnv::default()),
             task_data_entries: Arc::new(cache),
             session_builder: Arc::new(DefaultSessionBuilder),
+            session_extension_codecs: SessionExtensionCodecRegistry::default(),
             max_message_size: Some(usize::MAX),
             version: Cow::Borrowed(""),
         }
@@ -55,6 +58,16 @@ impl Worker {
     /// its lifetime.
     pub fn with_runtime_env(mut self, runtime_env: Arc<RuntimeEnv>) -> Self {
         self.runtime = runtime_env;
+        self
+    }
+
+    /// Registers a decoder for an opt-in session extension sent by coordinators.
+    ///
+    /// The codec is worker-wide, but each decoded value is installed only in the fresh
+    /// [`SessionConfig`](datafusion::prelude::SessionConfig) created for one distributed task.
+    /// Registering a decoder authorizes coordinators to provide that extension type to this worker.
+    pub fn with_session_extension_codec<C: SessionExtensionCodec>(mut self, codec: C) -> Self {
+        self.session_extension_codecs.push(codec);
         self
     }
 

--- a/tests/session_extension_codec.rs
+++ b/tests/session_extension_codec.rs
@@ -1,0 +1,75 @@
+#[cfg(all(feature = "integration", test))]
+mod tests {
+    use datafusion::common::{DataFusionError, Result, internal_err};
+    use datafusion::execution::SessionState;
+    use datafusion_distributed::test_utils::localhost::start_localhost_context_with_worker;
+    use datafusion_distributed::test_utils::parquet::register_parquet_tables;
+    use datafusion_distributed::{
+        DistributedExt, SessionExtensionCodec, Worker, WorkerPlanRewriteEvent,
+        WorkerPlanRewriteEventResponse, WorkerQueryContext,
+    };
+    use std::sync::Arc;
+
+    #[derive(Debug, PartialEq)]
+    struct RequestIdentity(u64);
+
+    #[derive(Clone)]
+    struct RequestIdentityCodec;
+
+    impl SessionExtensionCodec for RequestIdentityCodec {
+        type Extension = RequestIdentity;
+        const TYPE_URL: &'static str = "datafusion-distributed.test/request-identity/v1";
+
+        fn encode(&self, extension: &Self::Extension) -> Result<Vec<u8>> {
+            Ok(extension.0.to_le_bytes().to_vec())
+        }
+
+        fn decode(&self, payload: &[u8]) -> Result<Self::Extension> {
+            let bytes = payload.try_into().map_err(|_| {
+                DataFusionError::Configuration("invalid request identity payload".to_string())
+            })?;
+            Ok(RequestIdentity(u64::from_le_bytes(bytes)))
+        }
+    }
+
+    #[tokio::test]
+    async fn session_extension_reaches_worker_sessions() -> Result<()> {
+        let (mut ctx, _guard, _) =
+            start_localhost_context_with_worker(3, build_worker_session, |builder| {
+                Worker::from_session_builder(builder)
+                    .with_session_extension_codec(RequestIdentityCodec)
+            })
+            .await;
+        ctx.state_ref()
+            .write()
+            .config_mut()
+            .set_extension(Arc::new(RequestIdentity(42)));
+        ctx.set_distributed_session_extension_codec(RequestIdentityCodec);
+
+        register_parquet_tables(&ctx).await?;
+        ctx.sql(r#"SELECT "MinTemp" FROM weather WHERE "MinTemp" > 20.0"#)
+            .await?
+            .collect()
+            .await?;
+        Ok(())
+    }
+
+    async fn build_worker_session(ctx: WorkerQueryContext) -> Result<SessionState> {
+        Ok(ctx
+            .builder
+            .with_distributed_worker_plan_rewrite_handler(require_request_identity)
+            .build())
+    }
+
+    fn require_request_identity(
+        event: WorkerPlanRewriteEvent<'_>,
+    ) -> Result<WorkerPlanRewriteEventResponse> {
+        let Some(identity) = event.session_config.get_extension::<RequestIdentity>() else {
+            return internal_err!("request identity is missing from worker session");
+        };
+        if identity.as_ref() != &RequestIdentity(42) {
+            return internal_err!("worker received the wrong request identity");
+        }
+        Ok(WorkerPlanRewriteEventResponse::new(event.plan))
+    }
+}


### PR DESCRIPTION
## Summary
A custom ExecutionPlan may already call task_ctx.session_config().get_extension::<T>(). After that plan is serialized for distributed execution, the worker must be able to recreate T without changing the execution-plan implementation.

- add an opt-in typed `SessionExtensionCodec` API for arbitrary `SessionConfig` extensions
- send named opaque extension payloads with task setup and decode them into task-local worker sessions
- keep codecs worker-local and reject request payloads that would replace existing worker extensions

## Testing

- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- Integration tests were added but not run locally because the build volume ran out of space.

## AI Disclosure

Used an AI coding assistant for implementation and tests; the resulting changes were reviewed manually.
